### PR TITLE
Feature/casual caller better queue handling

### DIFF
--- a/casual/casual-api/src/main/java/se/laz/casual/api/CasualQueueApi.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/CasualQueueApi.java
@@ -6,12 +6,11 @@
 
 package se.laz.casual.api;
 
+import se.laz.casual.api.queue.DequeueReturn;
+import se.laz.casual.api.queue.EnqueueReturn;
 import se.laz.casual.api.queue.MessageSelector;
 import se.laz.casual.api.queue.QueueInfo;
 import se.laz.casual.api.queue.QueueMessage;
-
-import java.util.List;
-import java.util.UUID;
 
 /**
  * Interface to operate on a casual queue
@@ -23,18 +22,18 @@ public interface CasualQueueApi
      * @param qinfo the queue info
      * @param msg the queue message
      * @throws se.laz.casual.network.connection.CasualConnectionException
-     * @return the id of the enqueued message
+     * @return a wrapper containing the uuid of the enqueued message and an ErrorState
      */
-    UUID enqueue(QueueInfo qinfo, QueueMessage msg);
+    EnqueueReturn enqueue(QueueInfo qinfo, QueueMessage msg);
 
     /**
      * Dequeue message(s)
      * @param qinfo the queue info
      * @param selector the queue message
      * @throws se.laz.casual.network.connection.CasualConnectionException
-     * @return a list of matching messages
+     * @return a wrapper containing a list of matching messages and an ErrorState
      */
-    List<QueueMessage> dequeue(QueueInfo qinfo, MessageSelector selector);
+    DequeueReturn dequeue(QueueInfo qinfo, MessageSelector selector);
 
     /**
      * Check if queue exists

--- a/casual/casual-api/src/main/java/se/laz/casual/api/queue/DequeueReturn.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/queue/DequeueReturn.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2022, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
+package se.laz.casual.api.queue;
+
+import se.laz.casual.api.flags.ErrorState;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class DequeueReturn
+{
+    private final QueueMessage queueMessage;
+    private final ErrorState errorState;
+
+    private DequeueReturn(QueueMessage queueMessage, ErrorState errorState)
+    {
+        Objects.requireNonNull(errorState, "errorState can't be null");
+        this.queueMessage = queueMessage;
+        this.errorState = errorState;
+    }
+
+    public Optional<QueueMessage> getQueueMessage()
+    {
+        return Optional.ofNullable(queueMessage);
+    }
+
+    public ErrorState getErrorState()
+    {
+        return errorState;
+    }
+
+    public static Builder createBuilder()
+    {
+        return new Builder();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+        DequeueReturn dequeueReturn = (DequeueReturn) o;
+        return Objects.equals(queueMessage, dequeueReturn.queueMessage) && errorState.equals(dequeueReturn.getErrorState());
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return queueMessage.hashCode() + Integer.hashCode(errorState.getValue());
+    }
+
+    @Override
+    public String toString()
+    {
+        return "DequeueReturn{" + "queueMessage=" + queueMessage +
+                ", errorState=" + errorState.name() + '(' + errorState.getValue() + ')' +
+                "}";
+    }
+
+    public static final class Builder
+    {
+        private QueueMessage queueMessage;
+        private ErrorState errorState;
+
+        public Builder withQueueMessage(QueueMessage queueMessage)
+        {
+            this.queueMessage = queueMessage;
+            return this;
+        }
+
+        public Builder withErrorState(ErrorState errorState)
+        {
+            this.errorState = errorState;
+            return this;
+        }
+
+        public DequeueReturn build()
+        {
+            return new DequeueReturn(queueMessage, errorState);
+        }
+    }
+}

--- a/casual/casual-api/src/main/java/se/laz/casual/api/queue/EnqueueReturn.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/queue/EnqueueReturn.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2022, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
+package se.laz.casual.api.queue;
+
+import se.laz.casual.api.flags.ErrorState;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+public class EnqueueReturn
+{
+    private final UUID id;
+    private final ErrorState errorState;
+
+    private EnqueueReturn(UUID id, ErrorState errorState)
+    {
+        Objects.requireNonNull(errorState, "errorState can't be null");
+        this.id = id;
+        this.errorState = errorState;
+    }
+
+    public Optional<UUID> getId()
+    {
+        return Optional.ofNullable(id);
+    }
+
+    public ErrorState getErrorState()
+    {
+        return errorState;
+    }
+
+    public static Builder createBuilder()
+    {
+        return new Builder();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+        EnqueueReturn enqueueReturn = (EnqueueReturn) o;
+
+        return Objects.equals(id, enqueueReturn.id) && errorState.equals(enqueueReturn.getErrorState());
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return id.hashCode() + Integer.hashCode(errorState.getValue());
+    }
+
+    @Override
+    public String toString()
+    {
+        return "EnqueueReturn{" + "id=" + id +
+                ", errorState=" + errorState.name() + '(' + errorState.getValue() + ')' +
+                "}";
+    }
+
+    public static final class Builder
+    {
+        private UUID id;
+        private ErrorState errorState;
+
+        public Builder withId(UUID id)
+        {
+            this.id = id;
+            return this;
+        }
+
+        public Builder withErrorState(ErrorState errorState)
+        {
+            this.errorState = errorState;
+            return this;
+        }
+
+        public EnqueueReturn build()
+        {
+            return new EnqueueReturn(id, errorState);
+        }
+    }
+}

--- a/casual/casual-api/src/test/groovy/se/laz/casual/api/queue/DequeueReturnTest.groovy
+++ b/casual/casual-api/src/test/groovy/se/laz/casual/api/queue/DequeueReturnTest.groovy
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2022, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
+package se.laz.casual.api.queue
+
+
+import se.laz.casual.api.buffer.type.JsonBuffer
+import se.laz.casual.api.flags.ErrorState
+import spock.lang.Shared
+import spock.lang.Specification
+
+class DequeueReturnTest extends Specification {
+
+    @Shared String message = '{"hello": 1}'
+    @Shared QueueMessage someQueueMessage = QueueMessage.of(JsonBuffer.of(message))
+
+    def "build ok variant"()
+    {
+        when:
+        ErrorState stateOk = ErrorState.OK
+        DequeueReturn dequeueReturn = DequeueReturn.createBuilder().withQueueMessage(someQueueMessage).withErrorState(stateOk).build()
+
+        then:
+        Optional<QueueMessage> returnedMessages = dequeueReturn.getQueueMessage()
+        returnedMessages.isPresent()
+        new String(returnedMessages.get().getPayload().getBytes().get(0)) == message
+        dequeueReturn.getErrorState() == stateOk
+    }
+
+    def "build non-ok variant"()
+    {
+        when:
+        ErrorState stateTpenoent = ErrorState.TPENOENT
+        DequeueReturn dequeueReturn = DequeueReturn.createBuilder().withErrorState(stateTpenoent).build()
+
+        then:
+        !dequeueReturn.getQueueMessage().isPresent()
+        dequeueReturn.getErrorState() == stateTpenoent
+    }
+
+    def "buildable variants"(QueueMessage queueMessage, ErrorState errorState)
+    {
+        when:
+        DequeueReturn dequeueReturn = DequeueReturn.createBuilder().withQueueMessage(queueMessage).withErrorState(errorState).build()
+
+        then:
+        noExceptionThrown()
+        dequeueReturn != null
+
+        where:
+        queueMessage     | errorState
+        someQueueMessage | ErrorState.OK
+        null             | ErrorState.OK
+        someQueueMessage | ErrorState.TPENOENT
+        null             | ErrorState.TPENOENT
+    }
+
+    def "not buildable variants"(QueueMessage queueMessages, ErrorState errorState)
+    {
+
+        when:
+        DequeueReturn dequeueReturn = DequeueReturn.createBuilder().withQueueMessage(queueMessages).withErrorState(errorState).build()
+
+        then:
+        dequeueReturn == null
+        thrown NullPointerException
+
+        where:
+        queueMessages    | errorState
+        someQueueMessage | null
+        null             | null
+    }
+}

--- a/casual/casual-api/src/test/groovy/se/laz/casual/api/queue/EnqueueReturnTest.groovy
+++ b/casual/casual-api/src/test/groovy/se/laz/casual/api/queue/EnqueueReturnTest.groovy
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2022, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
+package se.laz.casual.api.queue
+
+import se.laz.casual.api.flags.ErrorState
+import spock.lang.Shared
+import spock.lang.Specification
+
+class EnqueueReturnTest extends Specification {
+
+    @Shared UUID someUuid = UUID.randomUUID()
+
+    def "build ok variant"()
+    {
+        when:
+
+        ErrorState stateOk = ErrorState.OK
+        EnqueueReturn enqueueReturn = EnqueueReturn.createBuilder().withId(someUuid).withErrorState(stateOk).build()
+
+        then:
+        enqueueReturn.getId().get() == someUuid
+        enqueueReturn.getErrorState() == stateOk
+    }
+
+    def "build non-ok variant"()
+    {
+        when:
+
+        ErrorState stateTpenoent = ErrorState.TPENOENT
+        EnqueueReturn enqueueReturn = EnqueueReturn.createBuilder().withErrorState(stateTpenoent).build()
+
+        then:
+        !enqueueReturn.getId().isPresent()
+        enqueueReturn.getErrorState() == stateTpenoent
+    }
+
+    def "buildable variants"(UUID uuid, ErrorState errorState)
+    {
+        when:
+
+        EnqueueReturn enqueueReturn = EnqueueReturn.createBuilder().withId(uuid).withErrorState(errorState).build()
+
+        then:
+        enqueueReturn != null
+        noExceptionThrown()
+
+        where:
+        uuid              | errorState
+        UUID.randomUUID() | ErrorState.OK
+        null              | ErrorState.TPENOENT
+    }
+
+    def "not buildable variants"(UUID uuid, ErrorState errorState)
+    {
+
+        when:
+
+        EnqueueReturn enqueueReturn = EnqueueReturn.createBuilder().withId(uuid).withErrorState(errorState).build()
+
+        then:
+        enqueueReturn == null
+        thrown NullPointerException
+
+        where:
+        uuid              | errorState
+        UUID.randomUUID() | null
+        null              | null
+    }
+}

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/Cache.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/Cache.java
@@ -10,17 +10,14 @@ import se.laz.casual.api.queue.QueueInfo;
 
 import javax.enterprise.context.ApplicationScoped;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
+import java.util.Optional;
 
 @ApplicationScoped
 public class Cache
 {
-    private final Map<QueueInfo, List<ConnectionFactoryEntry>> queueCache = new ConcurrentHashMap<>();
+    private final QueueCache queueCache = new QueueCache();
     private final ServiceCache serviceCache = new ServiceCache();
 
     public ConnectionFactoriesByPriority get(String serviceName)
@@ -30,7 +27,12 @@ public class Cache
 
     public List<ConnectionFactoryEntry> get(QueueInfo qinfo)
     {
-        return queueCache.getOrDefault(qinfo, Collections.emptyList());
+        return queueCache.getAll(qinfo);
+    }
+
+    public Optional<ConnectionFactoryEntry> getSingle(QueueInfo qinfo)
+    {
+        return queueCache.getOrEmpty(qinfo);
     }
 
     public void store(String serviceName, ConnectionFactoriesByPriority entries)
@@ -45,7 +47,7 @@ public class Cache
     {
         Objects.requireNonNull(qinfo, "qinfo can not be null");
         Objects.requireNonNull(entries, "entry can not be null");
-        queueCache.put(qinfo, entries);
+        queueCache.store(qinfo, entries);
     }
 
     public void purgeServices()
@@ -65,6 +67,6 @@ public class Cache
 
     public List<String> getQueues()
     {
-        return queueCache.keySet().stream().map(QueueInfo::toString).collect(Collectors.toList());
+        return new ArrayList<>(queueCache.getCachedQueueNames());
     }
 }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoryLookup.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoryLookup.java
@@ -9,6 +9,7 @@ package se.laz.casual.connection.caller;
 import se.laz.casual.api.queue.QueueInfo;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Lookup CacheEntries that can serve the QueueInfo/ServiceInfo request
@@ -28,9 +29,9 @@ public interface ConnectionFactoryLookup
     /**
      *
      * @param qinfo
-     * @return a List of 0-n CacheEntries
+     * @return an optional CacheEntry that may be empty if no connection factory handles the requested queue
      */
-    List<ConnectionFactoryEntry> get(QueueInfo qinfo);
+    Optional<ConnectionFactoryEntry> get(QueueInfo qinfo);
 
 
     /**

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoryLookupService.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoryLookupService.java
@@ -12,6 +12,7 @@ import javax.inject.Inject;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class ConnectionFactoryLookupService implements ConnectionFactoryLookup
@@ -24,20 +25,20 @@ public class ConnectionFactoryLookupService implements ConnectionFactoryLookup
     private Lookup lookup;
 
     @Override
-    public List<ConnectionFactoryEntry> get(QueueInfo qinfo)
+    public Optional<ConnectionFactoryEntry> get(QueueInfo qinfo)
     {
         Objects.requireNonNull(qinfo, "qinfo can not be null");
-        List<ConnectionFactoryEntry> cachedEntries = cache.get(qinfo);
-        if (!cachedEntries.isEmpty())
+        Optional<ConnectionFactoryEntry> cachedEntry = cache.getSingle(qinfo);
+        if (cachedEntry.isPresent())
         {
-            return cachedEntries;
+            return cachedEntry;
         }
         List<ConnectionFactoryEntry> newEntries = lookup.find(qinfo, connectionFactoryProvider.get());
         if (!newEntries.isEmpty())
         {
             cache.store(qinfo, newEntries);
         }
-        return newEntries;
+        return cache.getSingle(qinfo); // May be something or empty depending on if
     }
 
     @Override

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/Lookup.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/Lookup.java
@@ -48,7 +48,7 @@ public class Lookup
                 }
                 catch (ResourceException e)
                 {
-                    LOG.log(Level.WARNING, e, ()->"Skipping connection factory " + entry.getJndiName() + " for lookup, received error: " + e.getMessage());
+                    LOG.log(Level.WARNING, e, ()->"Skipping connection factory " + entry.getJndiName() + " for service lookup, received error: " + e.getMessage());
                 }
             }
         }
@@ -70,7 +70,7 @@ public class Lookup
             }
             catch (ResourceException e)
             {
-                throw new CasualResourceException(e);
+                LOG.log(Level.WARNING, e, ()->"Skipping connection factory " + entry.getJndiName() + " for queue lookup on, received error: " + e.getMessage());
             }
         }
         return foundEntries;

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/QueueCache.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/QueueCache.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2022, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
+package se.laz.casual.connection.caller;
+
+import se.laz.casual.api.queue.QueueInfo;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+public class QueueCache
+{
+    private static final Logger LOG = Logger.getLogger(QueueCache.class.getName());
+
+    private final Map<String, List<ConnectionFactoryEntry>> cacheMap = new ConcurrentHashMap<>();
+    private final Map<String, ConnectionFactoryEntry> stickies = new ConcurrentHashMap<>();
+
+    public Set<String> getCachedQueueNames()
+    {
+        return cacheMap.keySet();
+    }
+
+    public List<ConnectionFactoryEntry> getAll(QueueInfo queueInfo) {
+        return cacheMap.get(queueInfo.getQueueName());
+    }
+
+    public Optional<ConnectionFactoryEntry> getOrEmpty(QueueInfo queueInfo)
+    {
+        String queueName = queueInfo.getQueueName();
+        if (stickies.containsKey(queueName))
+        {
+            return Optional.of(stickies.get(queueName));
+        }
+        else if (cacheMap.containsKey(queueName))
+        {
+            // Prevent the unlikely case that two different threads manage to find and set different stickies
+            synchronized (stickies) {
+                if (stickies.containsKey(queueName))
+                {
+                    // While waiting another thread may have already set a sticky
+                    return Optional.of(stickies.get(queueName));
+                }
+
+                List<ConnectionFactoryEntry> cachedForQueue = cacheMap.get(queueName)
+                        .stream()
+                        .filter(ConnectionFactoryEntry::isValid)
+                        .collect(Collectors.toList());
+
+                // We never expect more than one source for a queue. Just pick first one and stick to it
+                ConnectionFactoryEntry selectedFactory = cachedForQueue.get(0);
+                stickies.put(queueName, selectedFactory);
+
+                if (cachedForQueue.size() > 1) {
+                    LOG.info(() -> "Found multiple (" + cachedForQueue.size() + ") sources for queue '" + queueName
+                            + "', selecting and setting sticky for CasualConnectionFactory=" + selectedFactory);
+                }
+
+                return Optional.of(selectedFactory);
+            }
+        }
+        else
+        {
+            return Optional.empty();
+        }
+    }
+
+    public void store(QueueInfo queueInfo, List<ConnectionFactoryEntry> entries)
+    {
+        cacheMap.put(queueInfo.getQueueName(), entries);
+    }
+
+    public void clear()
+    {
+        cacheMap.clear();
+        stickies.clear();
+    }
+}

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/jmx/CasualCallerControl.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/jmx/CasualCallerControl.java
@@ -6,21 +6,47 @@
 
 package se.laz.casual.connection.caller.jmx;
 
+import se.laz.casual.api.queue.QueueInfo;
 import se.laz.casual.connection.caller.Cache;
 import se.laz.casual.connection.caller.ConnectionFactoryEntry;
+import se.laz.casual.connection.caller.ConnectionFactoryEntryStore;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class CasualCallerControl implements CasualCallerControlMBean
 {
     private final Cache cache;
+    private final ConnectionFactoryEntryStore connectionFactoryEntryStore;
 
-    public CasualCallerControl(Cache cache)
+    public CasualCallerControl(Cache cache, ConnectionFactoryEntryStore connectionFactoryEntryStore)
     {
         this.cache = cache;
+        this.connectionFactoryEntryStore = connectionFactoryEntryStore;
     }
+
+    @Override
+    public List<String> validPools()
+    {
+        return connectionFactoryEntryStore.get()
+                .stream()
+                .filter(ConnectionFactoryEntry::isValid)
+                .map(ConnectionFactoryEntry::getJndiName)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<String> invalidPools()
+    {
+        return connectionFactoryEntryStore.get()
+                .stream()
+                .filter(ConnectionFactoryEntry::isInvalid)
+                .map(ConnectionFactoryEntry::getJndiName)
+                .collect(Collectors.toList());
+    }
+
 
     @Override
     public void purgeServiceCache()
@@ -47,7 +73,7 @@ public class CasualCallerControl implements CasualCallerControlMBean
     }
 
     @Override
-    public List<String> factoriesChecked(String serviceName)
+    public List<String> poolsCheckedForService(String serviceName)
     {
         List<String> factories = new ArrayList<>(cache.get(serviceName).getCheckedFactoriesForService());
         factories.sort(String::compareTo);
@@ -55,8 +81,32 @@ public class CasualCallerControl implements CasualCallerControlMBean
     }
 
     @Override
-    public List<String> factoriesContaining(String serviceName)
+    public List<String> poolsContainingService(String serviceName)
     {
-        return cache.get(serviceName).randomizeWithPriority().stream().map(ConnectionFactoryEntry::getJndiName).sorted().collect(Collectors.toList());
+        return cache
+                .get(serviceName)
+                .randomizeWithPriority()
+                .stream()
+                .map(ConnectionFactoryEntry::getJndiName)
+                .sorted()
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<String> queueInPools(String queueName)
+    {
+        return cache
+                .get(QueueInfo.createBuilder().withQueueName(queueName).build())
+                .stream()
+                .map(ConnectionFactoryEntry::getJndiName)
+                .sorted()
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public String getQueueStickiedPool(String queueName)
+    {
+        Optional<ConnectionFactoryEntry> queueEntry = cache.getSingle(QueueInfo.createBuilder().withQueueName(queueName).build());
+        return queueEntry.map(ConnectionFactoryEntry::getJndiName).orElse(null);
     }
 }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/jmx/CasualCallerControlMBean.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/jmx/CasualCallerControlMBean.java
@@ -10,12 +10,16 @@ import java.util.List;
 
 public interface CasualCallerControlMBean
 {
+    List<String> validPools();
+    List<String> invalidPools();
+
     void purgeServiceCache();
-    void purgeQueueCache();
-
     List<String> cachedServices();
-    List<String> cachedQueues();
+    List<String> poolsCheckedForService(String serviceName);
+    List<String> poolsContainingService(String serviceName);
 
-    List<String> factoriesChecked(String serviceName);
-    List<String> factoriesContaining(String serviceName);
+    void purgeQueueCache();
+    List<String> cachedQueues();
+    List<String> queueInPools(String queueName);
+    String getQueueStickiedPool(String queueName);
 }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/jmx/JMXStartup.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/jmx/JMXStartup.java
@@ -8,6 +8,7 @@ package se.laz.casual.connection.caller.jmx;
 
 import se.laz.casual.api.CasualRuntimeException;
 import se.laz.casual.connection.caller.Cache;
+import se.laz.casual.connection.caller.ConnectionFactoryEntryStore;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -34,6 +35,9 @@ public class JMXStartup
     @Inject
     Cache cache;
 
+    @Inject
+    ConnectionFactoryEntryStore connectionFactoryEntryStore;
+
     @PostConstruct
     void initJmx()
     {
@@ -41,7 +45,7 @@ public class JMXStartup
 
         try {
             MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
-            CasualCallerControl ccc = new CasualCallerControl(cache);
+            CasualCallerControl ccc = new CasualCallerControl(cache, connectionFactoryEntryStore);
 
             ObjectName objectName = new ObjectName(NAME);
 

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/CacheTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/CacheTest.groovy
@@ -109,9 +109,9 @@ class CacheTest extends Specification
     {
         when:
         instance.store(qInfo, [cacheEntryOne])
-        def entries = instance.get(qInfo)
+        def entries = instance.getSingle(qInfo)
         then:
-        entries.size() == 1
+        entries.isPresent()
     }
 
     def 'get missing queue entry'()
@@ -119,9 +119,9 @@ class CacheTest extends Specification
         given:
         def qinfoNotStored = QueueInfo.createBuilder().withQueueName("abc.Ford Prefect").build()
         when:
-        def entries = instance.get(qinfoNotStored)
+        def entries = instance.getSingle(qinfoNotStored)
         then:
-        entries.isEmpty()
+        !entries.isPresent()
     }
 
 }

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/ConnectionFactoryLookupServiceTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/ConnectionFactoryLookupServiceTest.groovy
@@ -118,10 +118,10 @@ class ConnectionFactoryLookupServiceTest extends Specification
         ConnectionFactoryEntry entry = ConnectionFactoryEntry.of(producerTwo)
         lookup.find(qinfo, _) >> [entry]
         when:
-        def entries = instance.get(qinfo)
+        def actual = instance.get(qinfo)
         then:
-        entries.size() == 1
-        entries[0] == entry
+        actual.isPresent()
+        actual.get() == entry
     }
 
     def 'qinfo get jndi name, no cached entry - not found'()
@@ -129,9 +129,9 @@ class ConnectionFactoryLookupServiceTest extends Specification
         setup:
         lookup.find(qinfo, _) >> []
         when:
-        def entries = instance.get(qinfo)
+        def entry = instance.get(qinfo)
         then:
-        entries.isEmpty()
+        !entry.isPresent()
     }
 
     def 'qinfo get jndi name, cached entry'()
@@ -139,10 +139,10 @@ class ConnectionFactoryLookupServiceTest extends Specification
         setup:
         cache.store(qinfo, [ConnectionFactoryEntry.of(producerTwo)])
         when:
-        def entries = instance.get(qinfo)
+        def entry = instance.get(qinfo)
         then:
-        entries.size() == 1
-        entries[0].jndiName == jndiNameConFactoryTwo
+        entry.isPresent()
+        entry.get().jndiName == jndiNameConFactoryTwo
         0 * lookup.find(qinfo, _)
     }
 

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/RandomEntryTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/RandomEntryTest.groovy
@@ -20,19 +20,19 @@ class RandomEntryTest extends Specification
         !entry.isPresent()
     }
 
-    def 'get queue with 0 entries, should throw'()
+    def 'get queue with 0 entries, should give TPENOENT'()
     {
         given:
         def queueInfo = QueueInfo.createBuilder().withQueueName('Battlestar.Galactica').build()
-        def entries = []
+        def entry = Optional.empty()
         def lookup = Mock(ConnectionFactoryLookup)
         lookup.get(queueInfo) >> {
-            entries
+            entry
         }
         when:
-        def entry = RandomEntry.getEntry(lookup.get(queueInfo))
+        def actual = lookup.get(queueInfo)
         then:
-        !entry.isPresent()
+        !actual.isPresent()
     }
 
     def 'get service with 1 entry, should return that entry'()
@@ -54,15 +54,15 @@ class RandomEntryTest extends Specification
     {
         given:
         def queueInfo = QueueInfo.createBuilder().withQueueName('Battlestar.Galactica').build()
-        def entries = [ConnectionFactoryEntry.of(Mock(ConnectionFactoryProducer))]
+        def entry = Optional.of(ConnectionFactoryEntry.of(Mock(ConnectionFactoryProducer)))
         def lookup = Mock(ConnectionFactoryLookup)
         lookup.get(queueInfo) >> {
-            entries
+            entry
         }
         when:
-        def actual = RandomEntry.getEntry(lookup.get(queueInfo))
+        def actual = lookup.get(queueInfo)
         then:
-        actual.get() == entries[0]
+        actual.get() == entry.get()
     }
 
     def 'getEntry with more than 1 entry should get all entries eventually'()

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualConnectionImpl.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualConnectionImpl.java
@@ -11,6 +11,8 @@ import se.laz.casual.api.buffer.CasualBuffer;
 import se.laz.casual.api.buffer.ServiceReturn;
 import se.laz.casual.api.flags.AtmiFlags;
 import se.laz.casual.api.flags.Flag;
+import se.laz.casual.api.queue.DequeueReturn;
+import se.laz.casual.api.queue.EnqueueReturn;
 import se.laz.casual.api.queue.MessageSelector;
 import se.laz.casual.api.queue.QueueInfo;
 import se.laz.casual.api.queue.QueueMessage;
@@ -23,7 +25,6 @@ import se.laz.casual.network.connection.CasualConnectionException;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -105,14 +106,14 @@ public class CasualConnectionImpl implements CasualConnection
     }
 
     @Override
-    public UUID enqueue(QueueInfo qinfo, QueueMessage msg)
+    public EnqueueReturn enqueue(QueueInfo qinfo, QueueMessage msg)
     {
         throwIfInvalidated();
         return getCasualQueueCaller().enqueue(qinfo, msg);
     }
 
     @Override
-    public List<QueueMessage> dequeue(QueueInfo qinfo, MessageSelector selector)
+    public DequeueReturn dequeue(QueueInfo qinfo, MessageSelector selector)
     {
         throwIfInvalidated();
         return getCasualQueueCaller().dequeue(qinfo, selector);

--- a/casual/casual-jca/src/test/groovy/se/laz/casual/jca/queue/CasualQueueCallerTest.groovy
+++ b/casual/casual-jca/src/test/groovy/se/laz/casual/jca/queue/CasualQueueCallerTest.groovy
@@ -7,6 +7,8 @@
 package se.laz.casual.jca.queue
 
 import se.laz.casual.api.buffer.type.JsonBuffer
+import se.laz.casual.api.queue.DequeueReturn
+import se.laz.casual.api.queue.EnqueueReturn
 import se.laz.casual.api.queue.MessageSelector
 import se.laz.casual.api.queue.QueueInfo
 import se.laz.casual.api.queue.QueueMessage
@@ -158,10 +160,10 @@ class CasualQueueCallerTest extends Specification
     def 'enqueue'()
     {
         when:
-        UUID msgId = instance.enqueue(queueInfo, QueueMessage.of(message))
+        EnqueueReturn msgId = instance.enqueue(queueInfo, QueueMessage.of(message))
         then:
         noExceptionThrown()
-        msgId == enqueueReplyId
+        msgId.getId().get() == enqueueReplyId
         1 * networkConnection.request( _ ) >> {
             CasualNWMessageImpl<CasualEnqueueRequestMessage> input ->
                 actualEnqueueRequest = input
@@ -173,7 +175,7 @@ class CasualQueueCallerTest extends Specification
     def 'enqueue goes big badda boom'()
     {
         when:
-        UUID msgId = instance.enqueue(queueInfo, QueueMessage.of(message))
+        EnqueueReturn msgId = instance.enqueue(queueInfo, QueueMessage.of(message))
         then:
         null == msgId
         thrown(CasualConnectionException)
@@ -186,7 +188,7 @@ class CasualQueueCallerTest extends Specification
     def 'dequeue goes big badda boom'()
     {
         when:
-        List<QueueMessage> messages = instance.dequeue(queueInfo, MessageSelector.of())
+        DequeueReturn messages = instance.dequeue(queueInfo, MessageSelector.of())
         then:
         messages == null
         thrown(CasualConnectionException)

--- a/casual/casual-network/src/test/groovy/se/laz/casual/network/outbound/NettyNetworkConnectionTest.groovy
+++ b/casual/casual-network/src/test/groovy/se/laz/casual/network/outbound/NettyNetworkConnectionTest.groovy
@@ -7,7 +7,6 @@
 package se.laz.casual.network.outbound
 
 import io.netty.channel.Channel
-import io.netty.channel.ChannelFuture
 import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelPromise
 import io.netty.channel.embedded.EmbeddedChannel
@@ -86,6 +85,7 @@ class NettyNetworkConnectionTest extends Specification implements NetworkListene
     def 'send conversation request message, no message is stored'()
     {
        given:
+       conversationMessageStorage.clearAllConversations()
        CasualNWMessage<Request> requestMessage = CasualNWMessageImpl.of(UUID.randomUUID(), Request.createBuilder()
                .setExecution(UUID.randomUUID())
                .setDuplex(Duplex.RECEIVE)

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,10 +7,10 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '1.0.82-beta'
+version = '1.0.0'
 
 
-ext.casual_caller_app_version = '1.2.8'
+ext.casual_caller_app_version = '2.0.0'
 
 ext.libs = [
   netty : 'io.netty:netty-all:4.1.75.Final',


### PR DESCRIPTION
- Updated queue api with breaking changes (both for caller and jci because of shared api). Now using wrapper for enqueue/dequeue to handle metadata like error state (only that for now, but could possibly accomodate for others in the future)
- Can lookup queues even if casual pools are unavailable, will return with errorstate TPENOENT if the queue could not be found (it could not exist in any pool, or the pool could be down
- Connection factories for queues are stickied to a specific connection pool per queue name. Normally there shouldn't be multiple sources for one queue, but if there are then the first encountered pool with the queue will be selected and stickied. The order seems to be pretty stable, but different application servers yield different orders. Never assume that the selected pools for a queue with multiple sources will be stable over different runs of the application server or if the queue cache is cleared