### PR TITLE
Feature/casual caller needs to handle connection reestablished better

### DIFF
--- a/casual/casual-api/src/main/java/se/laz/casual/api/CasualDiscoveryApi.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/CasualDiscoveryApi.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2022, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
 package se.laz.casual.api;
 
 import se.laz.casual.api.discovery.DiscoveryReturn;

--- a/casual/casual-api/src/main/java/se/laz/casual/api/CasualDiscoveryApi.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/CasualDiscoveryApi.java
@@ -1,0 +1,11 @@
+package se.laz.casual.api;
+
+import se.laz.casual.api.discovery.DiscoveryReturn;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface CasualDiscoveryApi
+{
+    DiscoveryReturn discover(UUID corrid, List<String> serviceNames, List<String> queueNames);
+}

--- a/casual/casual-api/src/main/java/se/laz/casual/api/discovery/DiscoveryReturn.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/discovery/DiscoveryReturn.java
@@ -1,0 +1,92 @@
+package se.laz.casual.api.discovery;
+
+import se.laz.casual.api.queue.QueueDetails;
+import se.laz.casual.api.service.ServiceDetails;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+public class DiscoveryReturn
+{
+    private final List<ServiceDetails> serviceDetails;
+    private final List<QueueDetails> queueDetails;
+    private DiscoveryReturn(List<ServiceDetails> serviceDetails, List<QueueDetails> queueDetails)
+    {
+        this.serviceDetails = serviceDetails;
+        this.queueDetails = queueDetails;
+    }
+
+    public List<ServiceDetails> getServiceDetails()
+    {
+        return Collections.unmodifiableList(serviceDetails);
+    }
+
+    public List<QueueDetails> getQueueDetails()
+    {
+        return Collections.unmodifiableList(queueDetails);
+    }
+
+    public static Builder createBuilder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private List<QueueDetails> queueDetails = new ArrayList<>();
+        private List<ServiceDetails> serviceDetails = new ArrayList<>();
+
+        private Builder()
+        {}
+
+        public Builder addQueueDetails(QueueDetails queueDetails)
+        {
+            Objects.requireNonNull(queueDetails, "queueDetails can not be null");
+            this.queueDetails.add(queueDetails);
+            return this;
+        }
+
+        public Builder addServiceDetails(ServiceDetails serviceDetails)
+        {
+            Objects.requireNonNull(serviceDetails, "serviceDetails can not be null");
+            this.serviceDetails.add(serviceDetails);
+            return this;
+        }
+
+        public DiscoveryReturn build()
+        {
+            return new DiscoveryReturn(serviceDetails, queueDetails);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+        DiscoveryReturn that = (DiscoveryReturn) o;
+        return getServiceDetails().equals(that.getServiceDetails()) && getQueueDetails().equals(that.getQueueDetails());
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(getServiceDetails(), getQueueDetails());
+    }
+
+    @Override
+    public String toString()
+    {
+        return "DiscoveryReturn{" +
+                "serviceDetails=" + serviceDetails +
+                ", queueDetails=" + queueDetails +
+                '}';
+    }
+}

--- a/casual/casual-api/src/main/java/se/laz/casual/api/discovery/DiscoveryReturn.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/discovery/DiscoveryReturn.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2022, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
 package se.laz.casual.api.discovery;
 
 import se.laz.casual.api.queue.QueueDetails;

--- a/casual/casual-api/src/main/java/se/laz/casual/api/queue/QueueDetails.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/queue/QueueDetails.java
@@ -1,0 +1,31 @@
+package se.laz.casual.api.queue;
+
+import java.util.Objects;
+
+public class QueueDetails
+{
+    private final String name;
+    private final long retries;
+
+    public QueueDetails(String name, long retries)
+    {
+        this.name = name;
+        this.retries = retries;
+    }
+
+    public static QueueDetails of(String name, long retries)
+    {
+        Objects.requireNonNull(name, "name can not be null");
+        return new QueueDetails(name, retries);
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public long getRetries()
+    {
+        return retries;
+    }
+}

--- a/casual/casual-api/src/main/java/se/laz/casual/api/queue/QueueDetails.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/queue/QueueDetails.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2022, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
 package se.laz.casual.api.queue;
 
 import java.util.Objects;

--- a/casual/casual-api/src/main/java/se/laz/casual/api/queue/QueueDetails.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/queue/QueueDetails.java
@@ -28,4 +28,14 @@ public class QueueDetails
     {
         return retries;
     }
+
+    @Override
+    public String toString()
+    {
+        return "QueueDetails{" +
+                "name='" + name + '\'' +
+                ", retries=" + retries +
+                '}';
+    }
+
 }

--- a/casual/casual-api/src/main/java/se/laz/casual/jca/CasualConnection.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/jca/CasualConnection.java
@@ -7,6 +7,7 @@
 package se.laz.casual.jca;
 
 import se.laz.casual.api.CasualConversationAPI;
+import se.laz.casual.api.CasualDiscoveryApi;
 import se.laz.casual.api.CasualQueueApi;
 import se.laz.casual.api.CasualServiceApi;
 
@@ -15,7 +16,7 @@ import se.laz.casual.api.CasualServiceApi;
  *
  * @version $Revision: $
  */
-public interface CasualConnection extends CasualServiceApi, CasualQueueApi, CasualConversationAPI, AutoCloseable
+public interface CasualConnection extends CasualServiceApi, CasualQueueApi, CasualConversationAPI, CasualDiscoveryApi, AutoCloseable
 {
     /**
      * Clean up the connection handle and close.

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/Cache.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/Cache.java
@@ -32,7 +32,7 @@ public class Cache
 
     public List<ConnectionFactoryEntry> get(QueueInfo qinfo)
     {
-        return Optional.ofNullable(queueCache.getAll(qinfo)).orElseGet(() -> (Collections.emptyList()));
+        return Optional.ofNullable(queueCache.getAll(qinfo)).orElseGet(Collections::emptyList);
     }
 
     public Optional<ConnectionFactoryEntry> getSingle(QueueInfo qinfo)
@@ -79,17 +79,17 @@ public class Cache
     }
     public void repopulate(DiscoveryReturn discoveryReturn, ConnectionFactoryEntry connectionFactoryEntry)
     {
-        discoveryReturn.getServiceDetails().stream()
-                       .forEach(serviceDetails -> {
-                           ConnectionFactoriesByPriority connectionFactoriesByPriority = get(serviceDetails.getName());
-                           connectionFactoriesByPriority.store(Arrays.asList(serviceDetails), connectionFactoryEntry);
-                           store(serviceDetails.getName(), connectionFactoriesByPriority);
-                       });
-        discoveryReturn.getQueueDetails().stream()
-                       .forEach(queueDetails ->
-                           store(QueueInfo.createBuilder()
-                                          .withQueueName(queueDetails.getName()).build(), Arrays.asList(connectionFactoryEntry))
-                       );
+        discoveryReturn.getServiceDetails().forEach(
+                serviceDetails -> {
+                    ConnectionFactoriesByPriority connectionFactoriesByPriority = get(serviceDetails.getName());
+                    connectionFactoriesByPriority.store(Arrays.asList(serviceDetails), connectionFactoryEntry);
+                    store(serviceDetails.getName(), connectionFactoriesByPriority);
+                });
+        discoveryReturn.getQueueDetails().forEach(
+                queueDetails ->
+                        store(QueueInfo.createBuilder()
+                                       .withQueueName(queueDetails.getName()).build(), Arrays.asList(connectionFactoryEntry))
+        );
     }
 
     public List<String> getServices()

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/Cache.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/Cache.java
@@ -12,7 +12,7 @@ import se.laz.casual.api.queue.QueueInfo;
 import javax.enterprise.context.ApplicationScoped;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -71,7 +71,7 @@ public class Cache
     }
     public Map<CacheType, List<String>> getAll()
     {
-        Map<CacheType, List<String>> entries = new HashMap<>();
+        Map<CacheType, List<String>> entries = new EnumMap<>(CacheType.class);
         entries.put(CacheType.SERVICE, getServices());
         entries.put(CacheType.QUEUE, getServices());
         return entries;
@@ -85,10 +85,10 @@ public class Cache
                            store(serviceDetails.getName(), connectionFactoriesByPriority);
                        });
         discoveryReturn.getQueueDetails().stream()
-                       .forEach(queueDetails -> {
+                       .forEach(queueDetails ->
                            store(QueueInfo.createBuilder()
-                                          .withQueueName(queueDetails.getName()).build(), Arrays.asList(connectionFactoryEntry));
-                       });
+                                          .withQueueName(queueDetails.getName()).build(), Arrays.asList(connectionFactoryEntry))
+                       );
     }
 
     public List<String> getServices()

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/Cache.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/Cache.java
@@ -6,10 +6,12 @@
 
 package se.laz.casual.connection.caller;
 
+import se.laz.casual.api.discovery.DiscoveryReturn;
 import se.laz.casual.api.queue.QueueInfo;
 
 import javax.enterprise.context.ApplicationScoped;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -73,6 +75,20 @@ public class Cache
         entries.put(CacheType.SERVICE, getServices());
         entries.put(CacheType.QUEUE, getServices());
         return entries;
+    }
+    public void repopulate(DiscoveryReturn discoveryReturn, ConnectionFactoryEntry connectionFactoryEntry)
+    {
+        discoveryReturn.getServiceDetails().stream()
+                       .forEach(serviceDetails -> {
+                           ConnectionFactoriesByPriority connectionFactoriesByPriority = get(serviceDetails.getName());
+                           connectionFactoriesByPriority.store(Arrays.asList(serviceDetails), connectionFactoryEntry);
+                           store(serviceDetails.getName(), connectionFactoriesByPriority);
+                       });
+        discoveryReturn.getQueueDetails().stream()
+                       .forEach(queueDetails -> {
+                           store(QueueInfo.createBuilder()
+                                          .withQueueName(queueDetails.getName()).build(), Arrays.asList(connectionFactoryEntry));
+                       });
     }
 
     public List<String> getServices()

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/Cache.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/Cache.java
@@ -10,7 +10,9 @@ import se.laz.casual.api.queue.QueueInfo;
 
 import javax.enterprise.context.ApplicationScoped;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -58,6 +60,19 @@ public class Cache
     public void purgeQueues()
     {
         queueCache.clear();
+    }
+
+    public void purge(ConnectionFactoryEntry connectionFactoryEntry)
+    {
+        serviceCache.remove(connectionFactoryEntry);
+        queueCache.remove(connectionFactoryEntry);
+    }
+    public Map<CacheType, List<String>> getAll()
+    {
+        Map<CacheType, List<String>> entries = new HashMap<>();
+        entries.put(CacheType.SERVICE, getServices());
+        entries.put(CacheType.QUEUE, getServices());
+        return entries;
     }
 
     public List<String> getServices()

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/Cache.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/Cache.java
@@ -12,6 +12,7 @@ import se.laz.casual.api.queue.QueueInfo;
 import javax.enterprise.context.ApplicationScoped;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -31,7 +32,7 @@ public class Cache
 
     public List<ConnectionFactoryEntry> get(QueueInfo qinfo)
     {
-        return queueCache.getAll(qinfo);
+        return Optional.ofNullable(queueCache.getAll(qinfo)).orElseGet(() -> (Collections.emptyList()));
     }
 
     public Optional<ConnectionFactoryEntry> getSingle(QueueInfo qinfo)

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/CacheType.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/CacheType.java
@@ -1,0 +1,7 @@
+package se.laz.casual.connection.caller;
+
+public enum CacheType
+{
+    SERVICE,
+    QUEUE;
+}

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/CacheType.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/CacheType.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2022, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
 package se.laz.casual.connection.caller;
 
 public enum CacheType

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoriesByPriority.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoriesByPriority.java
@@ -177,11 +177,15 @@ public class ConnectionFactoriesByPriority
 
     public void remove(ConnectionFactoryEntry connectionFactoryEntry)
     {
-        foundConnectionFactories.remove(connectionFactoryEntry);
-        checkedConnectionFactories.remove(connectionFactoryEntry);
+        foundConnectionFactories.remove(connectionFactoryEntry.getJndiName());
+        checkedConnectionFactories.remove(connectionFactoryEntry.getJndiName());
         for(Map.Entry<Long, List<ConnectionFactoryEntry>> entry : mapping.entrySet())
         {
             entry.getValue().removeIf(cachedConnectionFactoryEntry -> cachedConnectionFactoryEntry.getJndiName().equals(connectionFactoryEntry.getJndiName()));
+            if(entry.getValue().isEmpty())
+            {
+                mapping.remove(entry.getKey());
+            }
         }
     }
 }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoriesByPriority.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoriesByPriority.java
@@ -76,7 +76,6 @@ public class ConnectionFactoriesByPriority
                     });
         }
     }
-
     public void store(Long priority, List<ConnectionFactoryEntry> entries)
     {
         // Ensure priority level exists
@@ -174,5 +173,15 @@ public class ConnectionFactoriesByPriority
     public static ConnectionFactoriesByPriority emptyInstance()
     {
         return new ConnectionFactoriesByPriority();
+    }
+
+    public void remove(ConnectionFactoryEntry connectionFactoryEntry)
+    {
+        foundConnectionFactories.remove(connectionFactoryEntry);
+        checkedConnectionFactories.remove(connectionFactoryEntry);
+        for(Map.Entry<Long, List<ConnectionFactoryEntry>> entry : mapping.entrySet())
+        {
+            entry.getValue().removeIf(cachedConnectionFactoryEntry -> cachedConnectionFactoryEntry.getJndiName().equals(connectionFactoryEntry.getJndiName()));
+        }
     }
 }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoryEntryValidationTimer.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoryEntryValidationTimer.java
@@ -31,6 +31,9 @@ public class ConnectionFactoryEntryValidationTimer
     @Inject
     private ConnectionFactoryEntryStore connectionFactoryStore;
 
+    @Inject
+    ConnectionValidator connectionValidator;
+
     @PostConstruct
     private void setup()
     {
@@ -63,10 +66,10 @@ public class ConnectionFactoryEntryValidationTimer
         try
         {
             connectionFactoryStore.get().stream()
-                                  .forEach(connectionFactoryEntry -> {
+                                  .forEach( connectionFactoryEntry -> {
                                              try
                                              {
-                                                 connectionFactoryEntry.validate();
+                                                 connectionValidator.validate(connectionFactoryEntry);
                                              }
                                              catch(Exception e)
                                              {

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionValidator.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionValidator.java
@@ -1,10 +1,14 @@
 package se.laz.casual.connection.caller;
 
 import se.laz.casual.api.discovery.DiscoveryReturn;
+import se.laz.casual.api.queue.QueueInfo;
+import se.laz.casual.api.service.ServiceDetails;
 import se.laz.casual.jca.CasualConnection;
 
 import javax.inject.Inject;
 import javax.resource.ResourceException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -30,13 +34,19 @@ public class ConnectionValidator
     {
         boolean invalidBeforeRevalidation = !connectionFactoryEntry.isValid();
         connectionFactoryEntry.validate();
-        if(invalidBeforeRevalidation && connectionFactoryEntry.isValid())
+        if(connectionReestablished(invalidBeforeRevalidation, connectionFactoryEntry.isValid()))
         {
             Map<CacheType, List<String>> cachedItems = cache.getAll();
             cache.purge(connectionFactoryEntry);
             issueDiscovery(cachedItems, connectionFactoryEntry);
         }
     }
+
+    private boolean connectionReestablished(boolean invalidBeforeRevalidation, boolean valid)
+    {
+        return invalidBeforeRevalidation && valid;
+    }
+
     private void issueDiscovery(Map<CacheType, List<String>> cachedItems, ConnectionFactoryEntry connectionFactoryEntry)
     {
         try(CasualConnection connection = connectionFactoryEntry.getConnectionFactory().getConnection())
@@ -47,6 +57,17 @@ public class ConnectionValidator
                     cachedItems.get(CacheType.SERVICE),
                     cachedItems.get(CacheType.QUEUE));
             LOG.finest(() -> "discovery returned: " + discoveryReturn);
+            discoveryReturn.getServiceDetails().stream()
+                    .forEach(serviceDetails -> {
+                        ConnectionFactoriesByPriority connectionFactoriesByPriority = cache.get(serviceDetails.getName());
+                        connectionFactoriesByPriority.store(Arrays.asList(serviceDetails), connectionFactoryEntry);
+                        cache.store(serviceDetails.getName(), connectionFactoriesByPriority);
+                    });
+            discoveryReturn.getQueueDetails().stream()
+                    .forEach(queueDetails -> {
+                        cache.store(QueueInfo.createBuilder()
+                                             .withQueueName(queueDetails.getName()).build(), Arrays.asList(connectionFactoryEntry));
+                    });
         }
         catch (ResourceException e)
         {

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionValidator.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionValidator.java
@@ -1,0 +1,59 @@
+package se.laz.casual.connection.caller;
+
+import se.laz.casual.api.discovery.DiscoveryReturn;
+import se.laz.casual.jca.CasualConnection;
+
+import javax.inject.Inject;
+import javax.resource.ResourceException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.logging.Logger;
+
+public class ConnectionValidator
+{
+    private static final Logger LOG = Logger.getLogger(ConnectionValidator.class.getName());
+    @Inject
+    Cache cache;
+
+    // WLS - no arg constructor
+    public ConnectionValidator()
+    {}
+
+    @Inject
+    public ConnectionValidator(Cache cache)
+    {
+        this.cache = cache;
+    }
+
+    public void validate(final ConnectionFactoryEntry connectionFactoryEntry)
+    {
+        boolean invalidBeforeRevalidation = !connectionFactoryEntry.isValid();
+        connectionFactoryEntry.validate();
+        if(invalidBeforeRevalidation && connectionFactoryEntry.isValid())
+        {
+            Map<CacheType, List<String>> cachedItems = cache.getAll();
+            cache.purge(connectionFactoryEntry);
+            issueDiscovery(cachedItems, connectionFactoryEntry);
+        }
+    }
+    private void issueDiscovery(Map<CacheType, List<String>> cachedItems, ConnectionFactoryEntry connectionFactoryEntry)
+    {
+        try(CasualConnection connection = connectionFactoryEntry.getConnectionFactory().getConnection())
+        {
+            LOG.finest(() -> "domain discovery for all known services/queues will be issued for " + connectionFactoryEntry );
+            LOG.finest(() -> "all known services/queues being, services: " + cachedItems.get(CacheType.SERVICE) + " queues: " + cachedItems.get(CacheType.QUEUE));
+            DiscoveryReturn discoveryReturn = connection.discover(UUID.randomUUID(),
+                    cachedItems.get(CacheType.SERVICE),
+                    cachedItems.get(CacheType.QUEUE));
+            LOG.finest(() -> "discovery returned: " + discoveryReturn);
+        }
+        catch (ResourceException e)
+        {
+            connectionFactoryEntry.invalidate();
+            LOG.warning(() -> "failed domain discovery for: " + connectionFactoryEntry + " -> " + e);
+            LOG.warning(() -> "services: " + cachedItems.get(CacheType.SERVICE) + " queues: " + cachedItems.get(CacheType.QUEUE));
+        }
+    }
+
+}

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionValidator.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionValidator.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2022, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
 package se.laz.casual.connection.caller;
 
 import se.laz.casual.api.discovery.DiscoveryReturn;
@@ -14,7 +20,6 @@ import java.util.logging.Logger;
 public class ConnectionValidator
 {
     private static final Logger LOG = Logger.getLogger(ConnectionValidator.class.getName());
-    @Inject
     Cache cache;
 
     // WLS - no arg constructor
@@ -29,9 +34,9 @@ public class ConnectionValidator
 
     public void validate(final ConnectionFactoryEntry connectionFactoryEntry)
     {
-        boolean invalidBeforeRevalidation = !connectionFactoryEntry.isValid();
+        boolean invalidBeforeValidation = !connectionFactoryEntry.isValid();
         connectionFactoryEntry.validate();
-        if(connectionReestablished(invalidBeforeRevalidation, connectionFactoryEntry.isValid()))
+        if(connectionReestablished(invalidBeforeValidation, connectionFactoryEntry.isValid()))
         {
             Map<CacheType, List<String>> cachedItems = cache.getAll();
             cache.purge(connectionFactoryEntry);

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/QueueCache.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/QueueCache.java
@@ -91,6 +91,10 @@ public class QueueCache
         {
             List<ConnectionFactoryEntry> l = entry.getValue();
             l.removeIf(cachedEntry -> Objects.equals(cachedEntry.getJndiName(), connectionFactoryEntry.getJndiName()));
+            if(l.isEmpty())
+            {
+                cacheMap.remove(entry.getKey());
+            }
         }
     }
 

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/QueueCache.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/QueueCache.java
@@ -77,6 +77,21 @@ public class QueueCache
         cacheMap.put(queueInfo.getQueueName(), entries);
     }
 
+    public void remove(ConnectionFactoryEntry connectionFactoryEntry)
+    {
+        for(Map.Entry<String, ConnectionFactoryEntry> entry : stickies.entrySet())
+        {
+            if(entry.getValue().getJndiName().equals(connectionFactoryEntry.getJndiName()))
+            {
+                stickies.remove(entry.getKey());
+            }
+        }
+        for(Map.Entry<String, List<ConnectionFactoryEntry>> entry : cacheMap.entrySet())
+        {
+            entry.getValue().removeIf(cachedEntry -> cachedEntry.getJndiName().equals(connectionFactoryEntry.getJndiName()));
+        }
+    }
+
     public void clear()
     {
         cacheMap.clear();

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/QueueCache.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/QueueCache.java
@@ -8,11 +8,14 @@ package se.laz.casual.connection.caller;
 
 import se.laz.casual.api.queue.QueueInfo;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -88,7 +91,8 @@ public class QueueCache
         }
         for(Map.Entry<String, List<ConnectionFactoryEntry>> entry : cacheMap.entrySet())
         {
-            entry.getValue().removeIf(cachedEntry -> cachedEntry.getJndiName().equals(connectionFactoryEntry.getJndiName()));
+            List<ConnectionFactoryEntry> l = entry.getValue();
+            l.removeIf(cachedEntry -> Objects.equals(cachedEntry.getJndiName(), connectionFactoryEntry.getJndiName()));
         }
     }
 

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/QueueCache.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/QueueCache.java
@@ -8,14 +8,12 @@ package se.laz.casual.connection.caller;
 
 import se.laz.casual.api.queue.QueueInfo;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Predicate;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ServiceCache.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ServiceCache.java
@@ -56,6 +56,14 @@ public class ServiceCache
         mapForService.store(priority, entries);
     }
 
+    public void remove(ConnectionFactoryEntry connectionFactoryEntry)
+    {
+        for (Map.Entry<String, ConnectionFactoriesByPriority> cachedEntry : cacheMap.entrySet())
+        {
+            cachedEntry.getValue().remove(connectionFactoryEntry);
+        }
+    }
+
     public void clear()
     {
         cacheMap.clear();

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ServiceCache.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ServiceCache.java
@@ -61,6 +61,10 @@ public class ServiceCache
         for (Map.Entry<String, ConnectionFactoriesByPriority> cachedEntry : cacheMap.entrySet())
         {
             cachedEntry.getValue().remove(connectionFactoryEntry);
+            if(cachedEntry.getValue().isEmpty())
+            {
+                cacheMap.remove(cachedEntry.getKey());
+            }
         }
     }
 

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/CacheTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/CacheTest.groovy
@@ -6,25 +6,31 @@
 
 package se.laz.casual.connection.caller
 
+import se.laz.casual.api.discovery.DiscoveryReturn
+import se.laz.casual.api.queue.QueueDetails
 import se.laz.casual.api.queue.QueueInfo
+import se.laz.casual.api.service.ServiceDetails
 import se.laz.casual.jca.CasualConnectionFactory
+import se.laz.casual.network.messages.domain.TransactionType
 import spock.lang.Shared
 import spock.lang.Specification
 
+import java.util.stream.Collectors
+
 class CacheTest extends Specification
 {
-    @Shared
-    Cache instance
-    @Shared
-    def connectionFactoryOne = Mock(CasualConnectionFactory)
-    @Shared
-    def jndiNameOne = 'eis/CasualConnectionFactory'
-    @Shared
-    def connectionFactoryTwo = Mock(CasualConnectionFactory)
-    @Shared
-    def jndiNameTwo = 'eis/AnotherCasualConnectionFactory'
-    @Shared
-    ConnectionFactoryProducer producerOne = {
+   @Shared
+   Cache instance
+   @Shared
+   def connectionFactoryOne = Mock(CasualConnectionFactory)
+   @Shared
+   def jndiNameOne = 'eis/CasualConnectionFactory'
+   @Shared
+   def connectionFactoryTwo = Mock(CasualConnectionFactory)
+   @Shared
+   def jndiNameTwo = 'eis/AnotherCasualConnectionFactory'
+   @Shared
+   ConnectionFactoryProducer producerOne = {
       def mock = Mock(ConnectionFactoryProducer)
       mock.getConnectionFactory() >> {
          connectionFactoryOne
@@ -33,95 +39,196 @@ class CacheTest extends Specification
          jndiNameOne
       }
       return mock
-    }()
-    @Shared
-    ConnectionFactoryProducer producerTwo = {
-       def mock = Mock(ConnectionFactoryProducer)
-       mock.getConnectionFactory() >> {
-          connectionFactoryTwo
-       }
-       mock.getJndiName() >> {
-          jndiNameTwo
-       }
-       return mock
-    }()
-    @Shared
-    def cacheEntryOne = ConnectionFactoryEntry.of(producerOne)
-    @Shared
-    def cacheEntryTwo = ConnectionFactoryEntry.of(producerTwo)
-    @Shared
-    def serviceName = 'casual.test.echo'
-    @Shared
-    def qInfo = QueueInfo.createBuilder().withQueueName('space1.agrajag').build()
-    @Shared
-    def qInfoList = [QueueInfo.createBuilder().withQueueName('hairy.otter').build(), QueueInfo.createBuilder().withQueueName('drunken.monkey').build()]
-    @Shared
-    def serviceNames = ['casual.rollback', 'casually.casual']
-    @Shared
-    def priority = 17L
-    @Shared
-    def priorityMapping
+   }()
+   @Shared
+   ConnectionFactoryProducer producerTwo = {
+      def mock = Mock(ConnectionFactoryProducer)
+      mock.getConnectionFactory() >> {
+         connectionFactoryTwo
+      }
+      mock.getJndiName() >> {
+         jndiNameTwo
+      }
+      return mock
+   }()
+   @Shared
+   def cacheEntryOne = ConnectionFactoryEntry.of(producerOne)
+   @Shared
+   def cacheEntryTwo = ConnectionFactoryEntry.of(producerTwo)
+   @Shared
+   def serviceName = 'casual.test.echo'
+   @Shared
+   def serviceNameOnlyFromConnectionFactoryOne = 'flash.gordon'
+   @Shared
+   def queueNameOnlyFromConnectionFactoryOne = 'nifty.queue'
+   @Shared
+   def qInfo = QueueInfo.createBuilder().withQueueName('space1.agrajag').build()
+   @Shared
+   def qInfoList = [QueueInfo.createBuilder().withQueueName('hairy.otter').build(), QueueInfo.createBuilder().withQueueName('drunken.monkey').build()]
+   @Shared
+   def serviceNames = ['casual.rollback', 'casually.casual']
+   @Shared
+   def priority = 17L
+   @Shared
+   def lowerPriority = priority - 1
+   @Shared
+   def priorityMapping
 
-    def setup()
-    {
-        instance = new Cache()
-        qInfoList.forEach({q -> instance.store(q, [cacheEntryOne])})
-        serviceNames.forEach({ s -> instance.store(s, ConnectionFactoriesByPriority.of([(priority): [cacheEntryTwo]]))})
-        instance.store(serviceName, ConnectionFactoriesByPriority.of([(priority): [cacheEntryOne, cacheEntryTwo]]))
-    }
+   def setup()
+   {
+      instance = new Cache()
+      qInfoList.forEach({ q -> instance.store(q, [cacheEntryOne, cacheEntryTwo]) })
+      serviceNames.forEach({ s -> instance.store(s, ConnectionFactoriesByPriority.of([(priority): [cacheEntryTwo]])) })
+      instance.store(serviceName, ConnectionFactoriesByPriority.of([(priority): [cacheEntryOne, cacheEntryTwo]]))
+      instance.store(serviceNameOnlyFromConnectionFactoryOne, ConnectionFactoriesByPriority.of([(priority): [cacheEntryOne]]))
+   }
 
-    def 'store null cache entry'()
-    {
-        when:
-        instance.store(serviceName, null)
-        then:
-        thrown(NullPointerException)
-    }
+   def 'store null cache entry'()
+   {
+      when:
+      instance.store(serviceName, null)
+      then:
+      thrown(NullPointerException)
+   }
 
-    def 'set and get get service'()
-    {
-        given:
-        def anotherServiceName = 'anotherServiceName'
-        when:
-        instance.store(anotherServiceName, ConnectionFactoriesByPriority.of([(priority): [cacheEntryOne, cacheEntryTwo]]))
-        def entries = instance.get(anotherServiceName)
-        then:
-        entries.getForPriority(priority).size() == 2
-    }
+   def 'set and get get service'()
+   {
+      given:
+      def anotherServiceName = 'anotherServiceName'
+      when:
+      instance.store(anotherServiceName, ConnectionFactoriesByPriority.of([(priority): [cacheEntryOne, cacheEntryTwo]]))
+      def entries = instance.get(anotherServiceName)
+      then:
+      entries.getForPriority(priority).size() == 2
+   }
 
-    def 'get missing service entry'()
-    {
-        when:
-        def entries = instance.get('does-not-exist')
-        then:
-        entries.isEmpty()
-    }
+   def 'get missing service entry'()
+   {
+      when:
+      def entries = instance.get('does-not-exist')
+      then:
+      entries.isEmpty()
+   }
 
-    def 'store queue null cache entry'()
-    {
-        when:
-        instance.store(qInfo, null)
-        then:
-        thrown(NullPointerException)
-    }
+   def 'store queue null cache entry'()
+   {
+      when:
+      instance.store(qInfo, null)
+      then:
+      thrown(NullPointerException)
+   }
 
-    def 'set and get queue'()
-    {
-        when:
-        instance.store(qInfo, [cacheEntryOne])
-        def entries = instance.getSingle(qInfo)
-        then:
-        entries.isPresent()
-    }
+   def 'set and get queue'()
+   {
+      when:
+      instance.store(qInfo, [cacheEntryOne])
+      def entries = instance.getSingle(qInfo)
+      then:
+      entries.isPresent()
+   }
 
-    def 'get missing queue entry'()
-    {
-        given:
-        def qinfoNotStored = QueueInfo.createBuilder().withQueueName("abc.Ford Prefect").build()
-        when:
-        def entries = instance.getSingle(qinfoNotStored)
-        then:
-        !entries.isPresent()
-    }
+   def 'get missing queue entry'()
+   {
+      given:
+      def qinfoNotStored = QueueInfo.createBuilder().withQueueName("abc.Ford Prefect").build()
+      when:
+      def entries = instance.getSingle(qinfoNotStored)
+      then:
+      !entries.isPresent()
+   }
 
+   def 'get service with only one provider'()
+   {
+      when:
+      def connectionFactoryByPriority = instance.get(serviceNameOnlyFromConnectionFactoryOne)
+      then:
+      connectionFactoryByPriority.getForPriority(priority).size() == 1
+      connectionFactoryByPriority.getForPriority(priority).get(0) == cacheEntryOne
+   }
+
+   def 'cache purge and repopulation via DiscoveryReturn - services'()
+   {
+      given:
+      def discoveryReturn = Mock(DiscoveryReturn){
+         getQueueDetails() >> {
+            []
+         }
+         getServiceDetails() >> {
+            [toServiceDetails(serviceNameOnlyFromConnectionFactoryOne), toServiceDetails(serviceName), serviceNames.stream()
+                    .map({toServiceDetails(it)})
+                    .collect(Collectors.toList())].flatten()
+         }
+      }
+      when:
+      instance.purge(cacheEntryOne)
+      def afterPurge = instance.get(serviceNameOnlyFromConnectionFactoryOne)
+      then:
+      afterPurge.isEmpty()
+      when:
+      instance.repopulate(discoveryReturn, cacheEntryOne)
+      def afterRepopulate = instance.get(serviceNameOnlyFromConnectionFactoryOne)
+      then:
+      afterRepopulate.getForPriority(priority).size() == 1
+      afterRepopulate.getForPriority(priority).get(0) == cacheEntryOne
+      when: //get entry services by 2 connections
+      def moreThanOneConnection = instance.get(serviceName)
+      then:
+      moreThanOneConnection.getForPriority(priority).size() == 2
+   }
+
+   def 'cache purge and repopulation via DiscoveryReturn - queues'()
+   {
+      given:
+      def discoveryReturn = Mock(DiscoveryReturn){
+         getQueueDetails() >> {
+            [qInfoList.stream()
+                     .map({item -> toQueueDetails(item.getQueueName())})
+                     .collect(Collectors.toList()),
+             toQueueDetails(queueNameOnlyFromConnectionFactoryOne)].flatten()
+         }
+         getServiceDetails() >> {
+            []
+         }
+      }
+      println "queue details: ${discoveryReturn.getQueueDetails()}"
+      println "first qname: ${qInfoList.get(0)}"
+      def queueInfoOnlyConnectionOne = QueueInfo.createBuilder().withQueueName(queueNameOnlyFromConnectionFactoryOne).build()
+      instance.store(queueInfoOnlyConnectionOne, [cacheEntryOne])
+      when:
+      def beforePurge = instance.get(queueInfoOnlyConnectionOne)
+      then:
+      beforePurge.size() == 1
+      when: // get queue served from 2 places
+      beforePurge = instance.get(qInfoList.get(0))
+      then:
+      beforePurge.size() == 2
+      when:
+      instance.purge(cacheEntryOne)
+      def afterPurge = instance.get(queueInfoOnlyConnectionOne)
+      then:
+      afterPurge.isEmpty()
+      when:
+      afterPurge = instance.get(qInfoList.get(0))
+      then:
+      afterPurge.size() == 1
+      when:
+      instance.repopulate(discoveryReturn, cacheEntryOne)
+      def afterRepopulate = instance.get(queueInfoOnlyConnectionOne)
+      then:
+      afterRepopulate.size() == 1
+   }
+
+   QueueDetails toQueueDetails(String name)
+   {
+      return QueueDetails.of(name, 0)
+   }
+
+   ServiceDetails toServiceDetails(name)
+   {
+      return ServiceDetails.createBuilder().withName(name)
+              .withHops(priority)
+              .withCategory('foo')
+              .withTransactionType(TransactionType.AUTOMATIC)
+              .build()
+   }
 }

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualConnectionImpl.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualConnectionImpl.java
@@ -9,6 +9,7 @@ package se.laz.casual.jca;
 import se.laz.casual.api.Conversation;
 import se.laz.casual.api.buffer.CasualBuffer;
 import se.laz.casual.api.buffer.ServiceReturn;
+import se.laz.casual.api.discovery.DiscoveryReturn;
 import se.laz.casual.api.flags.AtmiFlags;
 import se.laz.casual.api.flags.Flag;
 import se.laz.casual.api.queue.DequeueReturn;
@@ -18,6 +19,7 @@ import se.laz.casual.api.queue.QueueInfo;
 import se.laz.casual.api.queue.QueueMessage;
 import se.laz.casual.api.service.ServiceDetails;
 import se.laz.casual.jca.conversation.ConversationConnectCaller;
+import se.laz.casual.jca.discovery.CasualDiscoveryCaller;
 import se.laz.casual.jca.queue.CasualQueueCaller;
 import se.laz.casual.jca.service.CasualServiceCaller;
 import se.laz.casual.network.connection.CasualConnectionException;
@@ -25,6 +27,7 @@ import se.laz.casual.network.connection.CasualConnectionException;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -38,6 +41,7 @@ public class CasualConnectionImpl implements CasualConnection
     private CasualServiceCaller serviceCaller;
     private CasualQueueCaller queueCaller;
     private ConversationConnectCaller conversationConnectCaller;
+    private CasualDiscoveryCaller discoveryCaller;
     private CasualManagedConnection managedConnection;
 
     /**
@@ -163,6 +167,12 @@ public class CasualConnectionImpl implements CasualConnection
         return getConversationConnectCaller().tpconnect(serviceName, data, flags);
     }
 
+    @Override
+    public DiscoveryReturn discover(UUID corrid, List<String> serviceNames, List<String> queueNames)
+    {
+        return getCasualDiscoveryCaller().discover(corrid, serviceNames, queueNames);
+    }
+
     private ConversationConnectCaller getConversationConnectCaller()
     {
         if ( conversationConnectCaller == null )
@@ -192,7 +202,14 @@ public class CasualConnectionImpl implements CasualConnection
         this.serviceCaller  = serviceCaller;
     }
 
-
+    private CasualDiscoveryCaller getCasualDiscoveryCaller()
+    {
+        if(null == discoveryCaller)
+        {
+            discoveryCaller = CasualDiscoveryCaller.of(getManagedConnection());
+        }
+        return discoveryCaller;
+    }
 
     @Override
     public String toString()
@@ -201,5 +218,6 @@ public class CasualConnectionImpl implements CasualConnection
                 "managedConnection=" + managedConnection +
                 '}';
     }
+
 
 }

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/discovery/CasualDiscoveryCaller.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/discovery/CasualDiscoveryCaller.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2022, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
 package se.laz.casual.jca.discovery;
 
 import se.laz.casual.api.CasualDiscoveryApi;

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/discovery/CasualDiscoveryCaller.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/discovery/CasualDiscoveryCaller.java
@@ -1,0 +1,90 @@
+package se.laz.casual.jca.discovery;
+
+import se.laz.casual.api.CasualDiscoveryApi;
+import se.laz.casual.api.discovery.DiscoveryReturn;
+import se.laz.casual.api.network.protocol.messages.CasualNWMessage;
+import se.laz.casual.api.queue.QueueDetails;
+import se.laz.casual.api.service.ServiceDetails;
+import se.laz.casual.api.util.PrettyPrinter;
+import se.laz.casual.config.ConfigurationService;
+import se.laz.casual.config.Domain;
+import se.laz.casual.jca.CasualManagedConnection;
+import se.laz.casual.network.protocol.messages.CasualNWMessageImpl;
+import se.laz.casual.network.protocol.messages.domain.CasualDomainDiscoveryReplyMessage;
+import se.laz.casual.network.protocol.messages.domain.CasualDomainDiscoveryRequestMessage;
+import se.laz.casual.network.protocol.messages.domain.Queue;
+import se.laz.casual.network.protocol.messages.domain.Service;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.logging.Logger;
+
+public class CasualDiscoveryCaller implements CasualDiscoveryApi
+{
+
+    private static final Logger LOG = Logger.getLogger(CasualDiscoveryCaller.class.getName());
+    private CasualManagedConnection connection;
+
+    private CasualDiscoveryCaller(CasualManagedConnection connection)
+    {
+        this.connection = connection;
+    }
+
+    public static CasualDiscoveryCaller of(CasualManagedConnection managedConnection)
+    {
+        Objects.requireNonNull(managedConnection, "managedConnection can not be null");
+        return new CasualDiscoveryCaller(managedConnection);
+    }
+
+    @Override
+    public DiscoveryReturn discover(UUID corrid, List<String> serviceNames, List<String> queueNames)
+    {
+        LOG.finest(() -> "issuing domain discovery, corrid: " + PrettyPrinter.casualStringify(corrid) + " service names: " + serviceNames + " queue names: " + queueNames);
+        Domain domain = ConfigurationService.getInstance().getConfiguration().getDomain();
+        CasualDomainDiscoveryRequestMessage requestMsg = CasualDomainDiscoveryRequestMessage.createBuilder()
+                                                                                            .setExecution(UUID.randomUUID())
+                                                                                            .setDomainId(domain.getId())
+                                                                                            .setDomainName(domain.getName())
+                                                                                            .setServiceNames(serviceNames)
+                                                                                            .setQueueNames(queueNames)
+                                                                                            .build();
+        CasualNWMessage<CasualDomainDiscoveryRequestMessage> msg = CasualNWMessageImpl.of(corrid, requestMsg);
+        CompletableFuture<CasualNWMessage<CasualDomainDiscoveryReplyMessage>> replyMsgFuture = connection.getNetworkConnection().request(msg);
+
+        CasualNWMessage<CasualDomainDiscoveryReplyMessage> replyMsg = replyMsgFuture.join();
+        LOG.finest(() -> "domain discovery ok for corrid: " + PrettyPrinter.casualStringify(corrid) + "reply -> service names: " + serviceNames + " queue names: " + queueNames);
+        return toDiscoveryReturn(replyMsg.getMessage());
+    }
+
+    private DiscoveryReturn toDiscoveryReturn(CasualDomainDiscoveryReplyMessage message)
+    {
+        DiscoveryReturn.Builder builder = DiscoveryReturn.createBuilder();
+        message.getQueues()
+               .stream()
+               .map(this::toQueueDetails)
+               .forEach(builder::addQueueDetails);
+        message.getServices()
+               .stream()
+               .map(this::toServiceDetails)
+               .forEach(builder::addServiceDetails);
+        return builder.build();
+    }
+
+    private QueueDetails toQueueDetails(Queue queue)
+    {
+        return QueueDetails.of(queue.getName(), queue.getRetries());
+    }
+
+    private ServiceDetails toServiceDetails(Service service)
+    {
+        return ServiceDetails.createBuilder()
+                             .withName(service.getName())
+                             .withCategory(service.getCategory())
+                             .withTransactionType(service.getTransactionType())
+                             .withTimeout(service.getTimeout())
+                             .withHops(service.getHops())
+                             .build();
+    }
+}

--- a/versions.gradle
+++ b/versions.gradle
@@ -9,7 +9,7 @@
 group = 'se.laz.casual'
 version = '2.0.0'
 
-ext.casual_caller_app_version = '3.0.0'
+ext.casual_caller_app_version = '2.1.0'
 
 ext.libs = [
   netty : 'io.netty:netty-all:4.1.75.Final',

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,8 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '1.0.0'
-
+version = '2.0.0'
 
 ext.casual_caller_app_version = '2.0.0'
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '2.0.0'
+version = '1.1.0'
 
 ext.casual_caller_app_version = '2.1.0'
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -9,7 +9,7 @@
 group = 'se.laz.casual'
 version = '2.0.0'
 
-ext.casual_caller_app_version = '2.0.0'
+ext.casual_caller_app_version = '3.0.0'
 
 ext.libs = [
   netty : 'io.netty:netty-all:4.1.75.Final',


### PR DESCRIPTION
* When a previously known connection goes away and comes back again, rediscovery of all known services/queues ( for all connections) needs to be issued and the caches repopulated with the result of that discovery. 
