### PR TITLE
Handling case in casual-caller where exception is thrown, but should be TPENOENT

### DIFF
--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoriesByPriority.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoriesByPriority.java
@@ -49,6 +49,11 @@ public class ConnectionFactoriesByPriority
         checkedConnectionFactories.addAll(resolvedNames);
     }
 
+    public boolean containsCheckedConnectionFactories()
+    {
+        return !checkedConnectionFactories.isEmpty();
+    }
+
     public Set<String> getCheckedFactoriesForService()
     {
         return Collections.unmodifiableSet(checkedConnectionFactories);
@@ -58,6 +63,7 @@ public class ConnectionFactoriesByPriority
     {
         if (!serviceDetails.isEmpty())
         {
+            checkedConnectionFactories.add(entry.getJndiName());
             foundConnectionFactories.add(entry.getJndiName());
             serviceDetails
                     .forEach(discoveryDetails ->

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoryLookupService.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoryLookupService.java
@@ -58,7 +58,7 @@ public class ConnectionFactoryLookupService implements ConnectionFactoryLookup
                 .stream()
                 .filter(entry -> !cache.get(serviceName).isResolved(entry.getJndiName()))
                 .collect(Collectors.toList()));
-        if (!newEntries.isEmpty())
+        if (!newEntries.isEmpty() || newEntries.containsCheckedConnectionFactories())
         {
             cache.store(serviceName, newEntries);
             return cache.get(serviceName).randomizeWithPriority();

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/FailoverAlgorithm.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/FailoverAlgorithm.java
@@ -31,7 +31,7 @@ public class FailoverAlgorithm<T>
         // Service not found
         if (prioritySortedFactories.isEmpty())
         {
-            LOG.warning("No priority or service targets at all");
+            LOG.warning(() -> "No priority or service targets at all for service " + serviceName);
             return doTpenoent.apply();
         }
 
@@ -42,7 +42,8 @@ public class FailoverAlgorithm<T>
         // No valid casual server found (revalidation is on a timer in ConnectionFactoryEntryValidationTimer)
         if (validEntries.isEmpty())
         {
-            throw new CasualResourceException("Received a set of ConnectionFactoryEntries, but not one was valid");
+            LOG.warning(() -> "Received a set of ConnectionFactoryEntries, but not one was valid for service " + serviceName);
+            return doTpenoent.apply();
         }
 
         for (ConnectionFactoryEntry connectionFactoryEntry : validEntries)
@@ -70,7 +71,7 @@ public class FailoverAlgorithm<T>
                 thrownException = e;
             }
         }
-        throw new CasualResourceException("Call failed to all " + validEntries.size() + " available casual connections connections.", thrownException);
+        throw new CasualResourceException("Call failed to all " + validEntries.size() + " available casual connections.", thrownException);
     }
 
     public interface FunctionNoArg<R>

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ServiceCache.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ServiceCache.java
@@ -40,7 +40,12 @@ public class ServiceCache
             storeServiceWithPriority(serviceName, priority, entries.getForPriority(priority));
         }
 
-        cacheMap.get(serviceName).addResolvedFactories(entries.getCheckedFactoriesForService());
+        // Guard against service lookups that only contain checked services list for a service that is unknown
+        // We do not want to store unknown services
+        if (cacheMap.containsKey(serviceName))
+        {
+            cacheMap.get(serviceName).addResolvedFactories(entries.getCheckedFactoriesForService());
+        }
     }
 
     private void storeServiceWithPriority(String serviceName, Long priority, List<ConnectionFactoryEntry> entries)

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/TpCallerFailoverTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/TpCallerFailoverTest.groovy
@@ -130,7 +130,7 @@ class TpCallerFailoverTest extends Specification
         1 * conFacHigh.getConnection() >> {throw new javax.resource.ResourceException(failMessage)}
         1 * conFacLow.getConnection() >> {throw new javax.resource.ResourceException(failMessage)}
         def e = thrown(CasualResourceException)
-        e.message == 'Call failed to all 2 available casual connections connections.'
+        e.message == 'Call failed to all 2 available casual connections.'
         result == null
     }
 
@@ -166,7 +166,7 @@ class TpCallerFailoverTest extends Specification
         then:
         (priorities*entriesPerPriority) * conFacHigh.getConnection() >> {throw new javax.resource.ResourceException(failMessage)}
         def e = thrown(CasualResourceException)
-        e.message == 'Call failed to all 64 available casual connections connections.'
+        e.message == 'Call failed to all 64 available casual connections.'
         result == null
     }
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -10,7 +10,7 @@ group = 'se.laz.casual'
 
 version = '1.2.0'
 
-ext.casual_caller_app_version = '2.1.0'
+ext.casual_caller_app_version = '2.1.1'
 ext.casual_test_app_version = '1.0.0'
 
 ext.libs = [


### PR DESCRIPTION
When a service is known in the cache, but no valid pool handles it an exception is thrown incorrectly. Instead a TPENOENT reply should be returned. This should now mirror the behavior where a that is completely unknown is unreachable

(and some minor fixes discovered while testing this ...)
Making sure services rediscovered on a validation rediscovery are tagged as checked as well as found
Fixing issue where attempted discoveries containing only a list of checked/resolved pools never registered them as checked. This is most likely to happen if not all pools are discovered together