### PR TITLE
Feature/netty epoll

### DIFF
--- a/casual/casual-api/src/main/java/se/laz/casual/config/Configuration.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/config/Configuration.java
@@ -32,7 +32,7 @@ public class Configuration
 
     public Outbound getOutbound()
     {
-        return outbound == null ? Outbound.of(null, null) : outbound;
+        return outbound == null ? Outbound.newBuilder().build() : outbound;
     }
 
     @Override

--- a/casual/casual-api/src/main/java/se/laz/casual/config/ConfigurationService.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/config/ConfigurationService.java
@@ -71,6 +71,7 @@ public class ConfigurationService
                                 .withMode( mode )
                                 .build() )
                         .build() )
+                .withOutbound(Outbound.of())
                 .build();
     }
 

--- a/casual/casual-api/src/main/java/se/laz/casual/config/ConfigurationService.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/config/ConfigurationService.java
@@ -71,7 +71,7 @@ public class ConfigurationService
                                 .withMode( mode )
                                 .build() )
                         .build() )
-                .withOutbound(Outbound.of())
+                .withOutbound(Outbound.newBuilder().build())
                 .build();
     }
 

--- a/casual/casual-api/src/main/java/se/laz/casual/config/Outbound.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/config/Outbound.java
@@ -24,45 +24,22 @@ public final class Outbound
 
     public static final String USE_EPOLL_ENV_VAR_NAME = "CASUAL_OUTBOUND_USE_EPOLL";
 
-    private Outbound(String managedExecutorServiceName, int numberOfThreads, boolean unmanaged, Boolean useEpoll)
+    private Outbound(Builder builder)
     {
-        this.managedExecutorServiceName = managedExecutorServiceName;
-        this.numberOfThreads = numberOfThreads;
-        this.unmanaged = unmanaged;
-        this.useEpoll = useEpoll;
+        managedExecutorServiceName = builder.managedExecutorServiceName;
+        numberOfThreads = builder.numberOfThreads;
+        unmanaged = builder.unmanaged;
+        useEpoll = builder.useEpoll;
+    }
+
+    public static Builder newBuilder()
+    {
+        return new Builder();
     }
 
     private boolean getUseEPollFromEnv()
     {
         return Boolean.valueOf(Optional.ofNullable(System.getenv(USE_EPOLL_ENV_VAR_NAME)).orElse("false"));
-    }
-
-    public static Outbound of()
-    {
-        return new Outbound(DEFAULT_MANAGED_EXECUTOR_SERVICE_NAME, DEFAULT_NUMBER_OF_THREADS, DEFAULT_UNMANAGED, null);
-    }
-
-    public static Outbound of(Boolean unmanaged)
-    {
-        return new Outbound(DEFAULT_MANAGED_EXECUTOR_SERVICE_NAME, DEFAULT_NUMBER_OF_THREADS, null == unmanaged ? DEFAULT_UNMANAGED : unmanaged, null);
-    }
-
-    public static Outbound of(String managedExecutorServiceName, Integer numberOfThreads)
-    {
-        return of(managedExecutorServiceName, numberOfThreads, DEFAULT_UNMANAGED, null);
-    }
-
-    public static Outbound of(String managedExecutorServiceName, Integer numberOfThreads, Boolean unmanaged)
-    {
-        return of(managedExecutorServiceName, numberOfThreads, unmanaged, null);
-    }
-
-    public static Outbound of(String managedExecutorServiceName, Integer numberOfThreads, Boolean unmanaged, Boolean useEpoll)
-    {
-        return new Outbound(null == managedExecutorServiceName ? DEFAULT_MANAGED_EXECUTOR_SERVICE_NAME :  managedExecutorServiceName,
-                            null == numberOfThreads ? DEFAULT_NUMBER_OF_THREADS : numberOfThreads,
-                            null == unmanaged ? DEFAULT_UNMANAGED : unmanaged,
-                            useEpoll);
     }
 
     public String getManagedExecutorServiceName()
@@ -120,4 +97,44 @@ public final class Outbound
                 '}';
     }
 
+
+    public static final class Builder
+    {
+        private String managedExecutorServiceName;
+        private Integer numberOfThreads;
+        private Boolean unmanaged;
+        private Boolean useEpoll;
+
+        public Builder withManagedExecutorServiceName(String managedExecutorServiceName)
+        {
+            this.managedExecutorServiceName = managedExecutorServiceName;
+            return this;
+        }
+
+        public Builder withNumberOfThreads(Integer numberOfThreads)
+        {
+            this.numberOfThreads = numberOfThreads;
+            return this;
+        }
+
+        public Builder withUnmanaged(Boolean unmanaged)
+        {
+            this.unmanaged = unmanaged;
+            return this;
+        }
+
+        public Builder withUseEpoll(Boolean useEpoll)
+        {
+            this.useEpoll = useEpoll;
+            return this;
+        }
+
+        public Outbound build()
+        {
+            managedExecutorServiceName = null == managedExecutorServiceName ? DEFAULT_MANAGED_EXECUTOR_SERVICE_NAME : managedExecutorServiceName;
+            numberOfThreads = null == numberOfThreads ? DEFAULT_NUMBER_OF_THREADS : numberOfThreads;
+            unmanaged = null == unmanaged ? DEFAULT_UNMANAGED : unmanaged;
+            return new Outbound(this);
+        }
+    }
 }

--- a/casual/casual-api/src/test/groovy/se/laz/casual/config/ConfigurationServiceTest.groovy
+++ b/casual/casual-api/src/test/groovy/se/laz/casual/config/ConfigurationServiceTest.groovy
@@ -68,7 +68,12 @@ class ConfigurationServiceTest extends Specification
     {
         given:
         Configuration expected = Configuration.newBuilder()
-                .withOutbound(Outbound.of(executorName, numberOfThreads, unmanaged, useEpoll))
+                .withOutbound(Outbound.newBuilder()
+                        .withManagedExecutorServiceName(executorName)
+                        .withNumberOfThreads(numberOfThreads)
+                        .withUnmanaged(unmanaged)
+                        .withUseEpoll(useEpoll)
+                        .build())
                 .build()
 
         when:
@@ -95,7 +100,7 @@ class ConfigurationServiceTest extends Specification
     {
         given:
         Configuration expected = Configuration.newBuilder()
-                .withOutbound(Outbound.of('java:comp/DefaultManagedExecutorService', 0))
+                .withOutbound(Outbound.newBuilder().build())
                 .build()
         when:
         Configuration actual = ConfigurationService.getInstance().getConfiguration()
@@ -106,8 +111,14 @@ class ConfigurationServiceTest extends Specification
    def 'no outbound config, useEpoll set via env var'()
    {
       given:
+      // Outbound.of('java:comp/DefaultManagedExecutorService', 0, false, true)
       Configuration expected = Configuration.newBuilder()
-              .withOutbound(Outbound.of('java:comp/DefaultManagedExecutorService', 0, false, true))
+              .withOutbound(Outbound.newBuilder()
+                      .withManagedExecutorServiceName('java:comp/DefaultManagedExecutorService')
+                      .withNumberOfThreads(0)
+                      .withUnmanaged(false)
+                      .withUseEpoll(true)
+                      .build())
               .build()
       when:
       Configuration actual

--- a/casual/casual-api/src/test/resources/casual-config-outbound-epoll.json
+++ b/casual/casual-api/src/test/resources/casual-config-outbound-epoll.json
@@ -1,0 +1,6 @@
+{
+  "outbound":
+  {
+    "useEpoll": true
+  }
+}

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/RandomEntry.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/RandomEntry.java
@@ -37,6 +37,8 @@ public final class RandomEntry
      * @param max
      * @return a pseudorandom number within the range [min, max-1]
      */
+    // note: Pseudorandom is fine in this context
+    @SuppressWarnings("java:S2245")
     private static int getRandomNumber(int min, int max)
     {
         return ThreadLocalRandom.current().nextInt(min, max);

--- a/casual/casual-jca/build.gradle
+++ b/casual/casual-jca/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     resourceAdapter project(':casual:casual-network-protocol')
     resourceAdapter project(':casual:casual-inbound-api')
     resourceAdapterLib libs.netty
-
+    resourceAdapterLib libs.netty_epoll
 
     testImplementation project(':casual:casual-api')
     testImplementation project(':casual:casual-service-discovery-extension')

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualManagedConnection.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualManagedConnection.java
@@ -6,13 +6,12 @@
 
 package se.laz.casual.jca;
 
-import se.laz.casual.config.ConfigurationService;
-import se.laz.casual.config.Domain;
 import se.laz.casual.internal.network.NetworkConnection;
 import se.laz.casual.jca.event.ConnectionEventHandler;
 import se.laz.casual.jca.pool.NetworkPoolHandler;
 import se.laz.casual.network.outbound.NettyConnectionInformation;
 import se.laz.casual.network.outbound.NettyNetworkConnection;
+import se.laz.casual.network.outbound.NettyConnectionInformationCreator;
 import se.laz.casual.network.outbound.NetworkListener;
 
 import javax.resource.NotSupportedException;
@@ -35,7 +34,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.logging.Logger;
 
 /**
@@ -323,12 +321,7 @@ public class CasualManagedConnection implements ManagedConnection, NetworkListen
 
     private NetworkConnection createOneToOneManagedConnection()
     {
-        Domain domain = ConfigurationService.getInstance().getConfiguration().getDomain();
-        NettyConnectionInformation ci = NettyConnectionInformation.createBuilder().withAddress(new InetSocketAddress(mcf.getHostName(), mcf.getPortNumber()))
-                                                                  .withProtocolVersion(mcf.getCasualProtocolVersion())
-                                                                  .withDomainId(domain.getId())
-                                                                  .withDomainName(domain.getName())
-                                                                  .build();
+        NettyConnectionInformation ci = NettyConnectionInformationCreator.create(new InetSocketAddress(mcf.getHostName(), mcf.getPortNumber()), mcf.getCasualProtocolVersion());
         NetworkConnection newNetworkConnection = NettyNetworkConnection.of(ci, this);
         log.finest(() -> "created new nw connection " + this);
         return newNetworkConnection;

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/pool/NetworkConnectionPool.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/pool/NetworkConnectionPool.java
@@ -5,12 +5,10 @@
  */
 package se.laz.casual.jca.pool;
 
-import io.netty.channel.epoll.EpollSocketChannel;
-import se.laz.casual.config.ConfigurationService;
-import se.laz.casual.config.Domain;
 import se.laz.casual.internal.network.NetworkConnection;
 import se.laz.casual.jca.Address;
 import se.laz.casual.jca.CasualResourceAdapterException;
+import se.laz.casual.network.outbound.NettyConnectionInformationCreator;
 import se.laz.casual.network.ProtocolVersion;
 import se.laz.casual.network.connection.CasualConnectionException;
 import se.laz.casual.network.outbound.NettyConnectionInformation;
@@ -126,13 +124,7 @@ public class NetworkConnectionPool implements ReferenceCountedNetworkCloseListen
 
     private static ReferenceCountedNetworkConnection createNetworkConnection(Address address, ProtocolVersion protocolVersion, NetworkListener networkListener, ReferenceCountedNetworkCloseListener referenceCountedNetworkCloseListener, NetworkListener ownListener)
     {
-        Domain domain = ConfigurationService.getInstance().getConfiguration().getDomain();
-        NettyConnectionInformation ci = NettyConnectionInformation.createBuilder().withAddress(new InetSocketAddress(address.getHostName(), address.getPort()))
-                                                                  .withProtocolVersion(protocolVersion)
-                                                                  .withDomainId(domain.getId())
-                                                                  .withDomainName(domain.getName())
-                                                                  .withChannelClass(EpollSocketChannel.class)
-                                                                  .build();
+        NettyConnectionInformation ci = NettyConnectionInformationCreator.create(new InetSocketAddress(address.getHostName(), address.getPort()), protocolVersion);
         NetworkConnection networkConnection = NettyNetworkConnection.of(ci, ownListener);
         if (networkConnection instanceof NettyNetworkConnection)
         {

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/pool/NetworkConnectionPool.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/pool/NetworkConnectionPool.java
@@ -5,6 +5,7 @@
  */
 package se.laz.casual.jca.pool;
 
+import io.netty.channel.epoll.EpollSocketChannel;
 import se.laz.casual.config.ConfigurationService;
 import se.laz.casual.config.Domain;
 import se.laz.casual.internal.network.NetworkConnection;
@@ -130,6 +131,7 @@ public class NetworkConnectionPool implements ReferenceCountedNetworkCloseListen
                                                                   .withProtocolVersion(protocolVersion)
                                                                   .withDomainId(domain.getId())
                                                                   .withDomainName(domain.getName())
+                                                                  .withChannelClass(EpollSocketChannel.class)
                                                                   .build();
         NetworkConnection networkConnection = NettyNetworkConnection.of(ci, ownListener);
         if (networkConnection instanceof NettyNetworkConnection)

--- a/casual/casual-network/src/main/java/se/laz/casual/network/outbound/EventLoopFactory.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/outbound/EventLoopFactory.java
@@ -28,18 +28,6 @@ public final class EventLoopFactory
         return INSTANCE;
     }
 
-    private static EventLoopGroup createEventLoopGroup()
-    {
-        Outbound outbound = ConfigurationService.getInstance().getConfiguration().getOutbound();
-        if(outbound.getUnmanaged())
-        {
-            LOG.info(() -> "outbound not using any ManagedExecutorService, running unmanaged");
-            //return new NioEventLoopGroup(outbound.getNumberOfThreads());
-            return new EpollEventLoopGroup(outbound.getNumberOfThreads());
-        }
-        return new EpollEventLoopGroup(outbound.getNumberOfThreads(), getManagedExecutorService());
-    }
-
     public static ManagedExecutorService getManagedExecutorService()
     {
         Outbound outbound = ConfigurationService.getInstance().getConfiguration().getOutbound();
@@ -58,6 +46,39 @@ public final class EventLoopFactory
         {
             throw new CasualResourceAdapterException("failed lookup for: " + name + "\n outbound will not function!", e);
         }
+    }
+
+    private static EventLoopGroup createEventLoopGroup()
+    {
+        Outbound outbound = ConfigurationService.getInstance().getConfiguration().getOutbound();
+        if(outbound.getUnmanaged())
+        {
+            return getUnmanagedEventLoopGroup(outbound.getUseEpoll(), outbound.getNumberOfThreads());
+        }
+        return getManagedEventLoopGroup(outbound.getUseEpoll(), outbound.getNumberOfThreads());
+    }
+
+    private static EventLoopGroup getUnmanagedEventLoopGroup(boolean useEpoll, int numberOfThreads)
+    {
+        LOG.info(() -> "outbound not using any ManagedExecutorService, running unmanaged");
+        if(useEpoll)
+        {
+            LOG.info(() -> "using EpollEventLoopGroup");
+            return new EpollEventLoopGroup(numberOfThreads);
+        }
+        LOG.info(() -> "using NioEventLoopGroup");
+        return new NioEventLoopGroup(numberOfThreads);
+    }
+
+    private static EventLoopGroup getManagedEventLoopGroup(boolean useEpoll, int numberOfThreads)
+    {
+        if(useEpoll)
+        {
+            LOG.info(() -> "using EpollEventLoopGroup");
+            return new EpollEventLoopGroup(numberOfThreads, getManagedExecutorService());
+        }
+        LOG.info(() -> "using NioEventLoopGroup");
+        return new NioEventLoopGroup(numberOfThreads, getManagedExecutorService());
     }
 
 }

--- a/casual/casual-network/src/main/java/se/laz/casual/network/outbound/EventLoopFactory.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/outbound/EventLoopFactory.java
@@ -6,6 +6,7 @@
 package se.laz.casual.network.outbound;
 
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import se.laz.casual.config.ConfigurationService;
 import se.laz.casual.config.Outbound;
@@ -33,9 +34,10 @@ public final class EventLoopFactory
         if(outbound.getUnmanaged())
         {
             LOG.info(() -> "outbound not using any ManagedExecutorService, running unmanaged");
-            return new NioEventLoopGroup(outbound.getNumberOfThreads());
+            //return new NioEventLoopGroup(outbound.getNumberOfThreads());
+            return new EpollEventLoopGroup(outbound.getNumberOfThreads());
         }
-        return new NioEventLoopGroup(outbound.getNumberOfThreads(), getManagedExecutorService());
+        return new EpollEventLoopGroup(outbound.getNumberOfThreads(), getManagedExecutorService());
     }
 
     public static ManagedExecutorService getManagedExecutorService()

--- a/casual/casual-network/src/main/java/se/laz/casual/network/outbound/NettyConnectionInformationCreator.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/outbound/NettyConnectionInformationCreator.java
@@ -1,0 +1,29 @@
+package se.laz.casual.network.outbound;
+
+import io.netty.channel.epoll.EpollSocketChannel;
+import se.laz.casual.config.ConfigurationService;
+import se.laz.casual.config.Domain;
+import se.laz.casual.network.ProtocolVersion;
+
+import java.net.InetSocketAddress;
+
+public final class NettyConnectionInformationCreator
+{
+    private NettyConnectionInformationCreator()
+    {}
+
+    public static NettyConnectionInformation create(InetSocketAddress address, ProtocolVersion protocolVersion)
+    {
+        Domain domain = ConfigurationService.getInstance().getConfiguration().getDomain();
+        NettyConnectionInformation.Builder builder = NettyConnectionInformation.createBuilder().withAddress(address)
+                                                                  .withProtocolVersion(protocolVersion)
+                                                                  .withDomainId(domain.getId())
+                                                                  .withDomainName(domain.getName());
+        boolean useEPoll = ConfigurationService.getInstance().getConfiguration().getOutbound().getUseEpoll();
+        if(useEPoll)
+        {
+            builder.withChannelClass(EpollSocketChannel.class);
+        }
+        return builder.build();
+    }
+}

--- a/casual/casual-network/src/main/java/se/laz/casual/network/outbound/NettyNetworkConnection.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/outbound/NettyNetworkConnection.java
@@ -12,7 +12,6 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.epoll.EpollChannelOption;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;

--- a/casual/casual-network/src/main/java/se/laz/casual/network/outbound/NettyNetworkConnection.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/outbound/NettyNetworkConnection.java
@@ -12,6 +12,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.EpollChannelOption;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;

--- a/casual/casual-network/src/test/groovy/se/laz/casual/network/outbound/NettyConnectionInformationCreatorTest.groovy
+++ b/casual/casual-network/src/test/groovy/se/laz/casual/network/outbound/NettyConnectionInformationCreatorTest.groovy
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2022, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
 package se.laz.casual.network.outbound
 
 import io.netty.channel.epoll.EpollSocketChannel

--- a/casual/casual-network/src/test/groovy/se/laz/casual/network/outbound/NettyConnectionInformationCreatorTest.groovy
+++ b/casual/casual-network/src/test/groovy/se/laz/casual/network/outbound/NettyConnectionInformationCreatorTest.groovy
@@ -1,0 +1,39 @@
+package se.laz.casual.network.outbound
+
+import io.netty.channel.epoll.EpollSocketChannel
+import se.laz.casual.config.Outbound
+
+import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable
+import io.netty.channel.socket.nio.NioSocketChannel
+import se.laz.casual.network.ProtocolVersion
+import spock.lang.Specification
+
+class NettyConnectionInformationCreatorTest extends Specification
+{
+   def 'default, does not use epoll'()
+   {
+      given:
+      InetSocketAddress address = new InetSocketAddress('foo.bar', 1234)
+      ProtocolVersion protocolVersion = ProtocolVersion.VERSION_1_0
+      when:
+      NettyConnectionInformation ci = NettyConnectionInformationCreator.create(address, protocolVersion)
+      then:
+      ci.getChannelClass() == NioSocketChannel.class
+   }
+
+   def 'use epoll'()
+   {
+      given:
+      InetSocketAddress address = new InetSocketAddress('foo.bar', 1234)
+      ProtocolVersion protocolVersion = ProtocolVersion.VERSION_1_0
+      when:
+      NettyConnectionInformation ci
+      withEnvironmentVariable( Outbound.USE_EPOLL_ENV_VAR_NAME, "true" )
+              .execute( {
+                 ci = NettyConnectionInformationCreator.create(address, protocolVersion)
+                 } )
+
+      then:
+      ci.getChannelClass() == EpollSocketChannel.class
+   }
+}

--- a/configuration.md
+++ b/configuration.md
@@ -11,6 +11,7 @@ Casual supports the following configuration options which can be set using envir
 * `CASUAL_CONFIG_FILE` - Set path for casual configuration file. If not provided, default are used.
 * `CASUAL_INBOUND_STARTUP_MODE` - Set mode for inbound startup. Default `immediate`. Alternatives `trigger`, `discover`.
     See [Inbound Startup Configuration](inbound.md#startup-configuration) for more details.
+* `CASUAL_OUTBOUND_USE_EPOLL` - If set to true, Netty uses epoll instead of NIO.
 
 NB - if a `CASUAL_CONFIG_FILE` is provided, it take precedence over the `CASUAL_INBOUND_STARTUP_MODE` setting.
 However, if some configuration is missing from the configuration file but has a setting via an environment variable then this will be used before any hardcoded default setting.

--- a/outbound.md
+++ b/outbound.md
@@ -21,7 +21,8 @@ Example configurations:
 {
   "outbound":
   {
-    "unmanaged": true
+    "unmanaged": true,
+    "useEpoll": true
   }
 }
 ```
@@ -40,6 +41,7 @@ If you do not provide any configuration for outbound the defaults are:
 
 * *0*
 
+* Netty uses NIO
 
 0 for netty means: 
 ```java
@@ -47,6 +49,7 @@ Math.max(1, SystemPropertyUtil.getInt( "io.netty.eventLoopThreads", NettyRuntime
 ```
 
 If you are running on an older JVM in a containerized world, that might be suboptimal.
+
 
 ## Pool configuration
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -13,7 +13,7 @@ version = '2.2.4-beta'
 ext.casual_caller_app_version = '2.2.4'
 ext.casual_test_app_version = '1.0.2'
 
-def netty_version = '4.1.82.Final'
+def netty_version = '4.1.84.Final'
 
 ext.libs = [
   netty : "io.netty:netty-all:${netty_version}",

--- a/versions.gradle
+++ b/versions.gradle
@@ -8,7 +8,7 @@
 // casual-java group and version
 group = 'se.laz.casual'
 
-version = '2.2.4-beta'
+version = '2.2.4'
 
 ext.casual_caller_app_version = '2.2.4'
 ext.casual_test_app_version = '1.0.2'

--- a/versions.gradle
+++ b/versions.gradle
@@ -8,13 +8,16 @@
 // casual-java group and version
 group = 'se.laz.casual'
 
-version = '2.2.3'
+version = '2.2.4-beta'
 
 ext.casual_caller_app_version = '2.2.4'
 ext.casual_test_app_version = '1.0.2'
 
+def netty_version = '4.1.82.Final'
+
 ext.libs = [
-  netty : 'io.netty:netty-all:4.1.75.Final',
+  netty : "io.netty:netty-all:${netty_version}",
+  netty_epoll: "io.netty:netty-transport-native-epoll:${netty_version}",
   javaee_api: 'javax:javaee-api:7.0',
   gson: 'com.google.code.gson:gson:2.9.0',
   objenesis: 'org.objenesis:objenesis:2.6',


### PR DESCRIPTION
This enables us to choose if Netty should use NIO ( default) or epoll.

According to Netty's [documentation](https://netty.io/wiki/native-transports.html ) it may give us less garbage and better throughput so it makes sense to provide the option to use it.

To enable epoll, you either set CASUAL_OUTBOUND_USE_EPOLL to true or in the outbound section of your configuration file you add - ``` "useEpoll": true```.

Note, this does affect our packaging since now ```netty-transport-native-epoll``` will always be available, even when using NIO.
That in itself is not a problem.

