### PR TITLE
Feature/optional inbound delay start of server

### DIFF
--- a/casual/casual-api/src/main/java/se/laz/casual/config/ConfigurationService.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/config/ConfigurationService.java
@@ -64,16 +64,12 @@ public class ConfigurationService
         Mode mode = getEnv( CASUAL_INBOUND_STARTUP_MODE_ENV_NAME )
                 .map( name -> name.isEmpty() ? Mode.IMMEDIATE : Mode.fromName( name ) )
                 .orElse( Mode.IMMEDIATE );
-        long inboundInitialDelay = getEnv(Inbound.CASUAL_INBOUND_INITIAL_DELAY_ENV_NAME)
-                .map( delay -> delay.isEmpty() ? 0L : Long.parseLong(delay))
-                .orElse(0L);
         return Configuration.newBuilder()
                 .withDomain( Domain.getFromEnv() )
                 .withInbound( Inbound.newBuilder()
                         .withStartup( Startup.newBuilder()
                                 .withMode( mode )
                                 .build() )
-                        .withInitialDelay( inboundInitialDelay )
                         .build() )
                 .withOutbound(Outbound.newBuilder().build())
                 .build();

--- a/casual/casual-api/src/main/java/se/laz/casual/config/ConfigurationService.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/config/ConfigurationService.java
@@ -64,12 +64,16 @@ public class ConfigurationService
         Mode mode = getEnv( CASUAL_INBOUND_STARTUP_MODE_ENV_NAME )
                 .map( name -> name.isEmpty() ? Mode.IMMEDIATE : Mode.fromName( name ) )
                 .orElse( Mode.IMMEDIATE );
+        long inboundInitialDelay = getEnv(Inbound.CASUAL_INBOUND_INITIAL_DELAY_ENV_NAME)
+                .map( delay -> delay.isEmpty() ? 0L : Long.parseLong(delay))
+                .orElse(0L);
         return Configuration.newBuilder()
                 .withDomain( Domain.getFromEnv() )
                 .withInbound( Inbound.newBuilder()
                         .withStartup( Startup.newBuilder()
                                 .withMode( mode )
                                 .build() )
+                        .withInitialDelay( inboundInitialDelay )
                         .build() )
                 .withOutbound(Outbound.newBuilder().build())
                 .build();

--- a/casual/casual-api/src/main/java/se/laz/casual/config/Inbound.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/config/Inbound.java
@@ -13,13 +13,17 @@ public class Inbound
 {
     public static final String CASUAL_INBOUND_STARTUP_MODE = "CASUAL_INBOUND_STARTUP_MODE";
     public static final String CASUAL_INBOUND_USE_EPOLL = "CASUAL_INBOUND_USE_EPOLL";
+    public static final String CASUAL_INBOUND_INITIAL_DELAY_ENV_NAME = "CASUAL_INBOUND_INITIAL_DELAY";
+
     private final Startup startup;
     private final boolean useEpoll;
+    private final long initialDelay;
 
     public Inbound( Builder builder )
     {
         this.startup = builder.startup;
         this.useEpoll = builder.useEpoll;
+        this.initialDelay = builder.initialDelay;
     }
 
     public Startup getStartup()
@@ -30,6 +34,11 @@ public class Inbound
     public boolean isUseEpoll()
     {
         return useEpoll;
+    }
+
+    public long getInitialDelay()
+    {
+        return initialDelay;
     }
 
     @Override
@@ -71,6 +80,7 @@ public class Inbound
     {
         private Startup startup;
         private Boolean useEpoll;
+        private Long initialDelay;
 
         private Builder()
         {
@@ -85,6 +95,12 @@ public class Inbound
         public Builder withStartup( Startup startup )
         {
             this.startup = startup;
+            return this;
+        }
+
+        public Builder withInitialDelay(long initialDelay)
+        {
+            this.initialDelay = initialDelay;
             return this;
         }
 
@@ -103,6 +119,12 @@ public class Inbound
             if( useEpoll == null )
             {
                 useEpoll = Boolean.parseBoolean( Optional.ofNullable( System.getenv( CASUAL_INBOUND_USE_EPOLL ) ).orElse( "false" ) );
+            }
+            if( initialDelay == null )
+            {
+                initialDelay = Optional.ofNullable( System.getenv( CASUAL_INBOUND_INITIAL_DELAY_ENV_NAME ) )
+                                       .map( delay -> delay.isEmpty() ? 0L : Long.parseLong( delay ) )
+                                       .orElse(0L );
             }
             return new Inbound( this );
         }

--- a/casual/casual-api/src/main/java/se/laz/casual/config/Inbound.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/config/Inbound.java
@@ -13,7 +13,7 @@ public class Inbound
 {
     public static final String CASUAL_INBOUND_STARTUP_MODE = "CASUAL_INBOUND_STARTUP_MODE";
     public static final String CASUAL_INBOUND_USE_EPOLL = "CASUAL_INBOUND_USE_EPOLL";
-    public static final String CASUAL_INBOUND_INITIAL_DELAY_ENV_NAME = "CASUAL_INBOUND_INITIAL_DELAY";
+    public static final String CASUAL_INBOUND_STARTUP_INITIAL_DELAY_ENV_NAME = "CASUAL_INBOUND_STARTUP_INITIAL_DELAY_IN_SECONDS";
 
     private final Startup startup;
     private final boolean useEpoll;
@@ -53,13 +53,14 @@ public class Inbound
             return false;
         }
         Inbound inbound = (Inbound) o;
-        return isUseEpoll() == inbound.isUseEpoll() && Objects.equals( getStartup(), inbound.getStartup() );
+        return isUseEpoll() == inbound.isUseEpoll() && Objects.equals( getStartup(), inbound.getStartup() ) &&
+                inbound.getInitialDelay() == getInitialDelay();
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash( getStartup(), isUseEpoll() );
+        return Objects.hash( getStartup(), isUseEpoll(), getInitialDelay() );
     }
 
     @Override
@@ -68,6 +69,7 @@ public class Inbound
         return "Inbound{" +
                 "startup=" + startup +
                 ", useEpoll=" + useEpoll +
+                ", initialDelay=" + initialDelay +
                 '}';
     }
 
@@ -122,7 +124,7 @@ public class Inbound
             }
             if( initialDelay == null )
             {
-                initialDelay = Optional.ofNullable( System.getenv( CASUAL_INBOUND_INITIAL_DELAY_ENV_NAME ) )
+                initialDelay = Optional.ofNullable( System.getenv(CASUAL_INBOUND_STARTUP_INITIAL_DELAY_ENV_NAME) )
                                        .map( delay -> delay.isEmpty() ? 0L : Long.parseLong( delay ) )
                                        .orElse(0L );
             }

--- a/casual/casual-api/src/main/java/se/laz/casual/config/Inbound.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/config/Inbound.java
@@ -13,7 +13,7 @@ public class Inbound
 {
     public static final String CASUAL_INBOUND_STARTUP_MODE = "CASUAL_INBOUND_STARTUP_MODE";
     public static final String CASUAL_INBOUND_USE_EPOLL = "CASUAL_INBOUND_USE_EPOLL";
-    public static final String CASUAL_INBOUND_STARTUP_INITIAL_DELAY_ENV_NAME = "CASUAL_INBOUND_STARTUP_INITIAL_DELAY_IN_SECONDS";
+    public static final String CASUAL_INBOUND_STARTUP_INITIAL_DELAY_ENV_NAME = "CASUAL_INBOUND_STARTUP_INITIAL_DELAY_SECONDS";
 
     private final Startup startup;
     private final boolean useEpoll;

--- a/casual/casual-api/src/main/java/se/laz/casual/jca/DelayFailedException.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/jca/DelayFailedException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
+package se.laz.casual.jca;
+
+import se.laz.casual.api.CasualRuntimeException;
+
+public class DelayFailedException extends CasualRuntimeException
+{
+    private static final long serialVersionUID = 1L;
+
+    public DelayFailedException()
+    {
+    }
+
+    public DelayFailedException(String message )
+    {
+        super( message );
+    }
+
+    public DelayFailedException(Throwable t )
+    {
+        super( t );
+    }
+
+    public DelayFailedException(String message, Throwable t )
+    {
+        super( message, t );
+    }
+}

--- a/casual/casual-api/src/test/groovy/se/laz/casual/config/ConfigurationServiceTest.groovy
+++ b/casual/casual-api/src/test/groovy/se/laz/casual/config/ConfigurationServiceTest.groovy
@@ -184,7 +184,7 @@ class ConfigurationServiceTest extends Specification
               .build()
       when:
       Configuration actual = null
-      withEnvironmentVariable( Inbound.CASUAL_INBOUND_INITIAL_DELAY_ENV_NAME, "${initialDelay}" )
+      withEnvironmentVariable( Inbound.CASUAL_INBOUND_STARTUP_INITIAL_DELAY_ENV_NAME, "${initialDelay}" )
               .execute( {
                  reinitialiseConfigurationService( )
                  actual = instance.getConfiguration()} )

--- a/casual/casual-api/src/test/groovy/se/laz/casual/config/ConfigurationServiceTest.groovy
+++ b/casual/casual-api/src/test/groovy/se/laz/casual/config/ConfigurationServiceTest.groovy
@@ -49,6 +49,7 @@ class ConfigurationServiceTest extends Specification
                                     .withServices( services )
                                     .build(  ) )
                             .withUseEpoll( epoll )
+                            .withInitialDelay( initialDelay )
                             .build(  ) )
                 .build(  )
 
@@ -63,11 +64,12 @@ class ConfigurationServiceTest extends Specification
         actual == expected
 
         where:
-        file                               || mode           | services                         | epoll
-        "casual-config-immediate.json"     || Mode.IMMEDIATE | []                               | false
-        "casual-config-trigger.json"       || Mode.TRIGGER   | [Mode.Constants.TRIGGER_SERVICE] | false
-        "casual-config-discover.json"      || Mode.DISCOVER  | ["service1", "service2"]         | false
-        "casual-config-inbound-epoll.json" || Mode.IMMEDIATE | []                               | true
+        file                                       || mode           | services                         | epoll | initialDelay
+        "casual-config-immediate.json"             || Mode.IMMEDIATE | []                               | false | 0
+        "casual-config-trigger.json"               || Mode.TRIGGER   | [Mode.Constants.TRIGGER_SERVICE] | false | 0
+        "casual-config-discover.json"              || Mode.DISCOVER  | ["service1", "service2"]         | false | 0
+        "casual-config-inbound-epoll.json"         || Mode.IMMEDIATE | []                               | true  | 0
+        "casual-config-inbound-initial-delay.json" || Mode.IMMEDIATE | []                               | false | 30
     }
 
     @Unroll
@@ -170,6 +172,25 @@ class ConfigurationServiceTest extends Specification
         then:
         actual == expected
     }
+
+   def 'no inbound config, inbound initial delay set via env var'()
+   {
+      given:
+      def initialDelay = 10L
+      Configuration expected = Configuration.newBuilder()
+              .withInbound(Inbound.newBuilder()
+                      .withInitialDelay(initialDelay)
+                      .build())
+              .build()
+      when:
+      Configuration actual = null
+      withEnvironmentVariable( Inbound.CASUAL_INBOUND_INITIAL_DELAY_ENV_NAME, "${initialDelay}" )
+              .execute( {
+                 reinitialiseConfigurationService( )
+                 actual = instance.getConfiguration()} )
+      then:
+      actual == expected
+   }
 
     def "Get configuration where file not found, throws CasualRuntimeException."()
     {

--- a/casual/casual-api/src/test/resources/casual-config-inbound-initial-delay.json
+++ b/casual/casual-api/src/test/resources/casual-config-inbound-initial-delay.json
@@ -1,0 +1,6 @@
+{
+  "inbound":
+  {
+    "initialDelay": 30
+  }
+}

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceAdapter.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceAdapter.java
@@ -140,7 +140,8 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
         Consumer<CasualServer> consumer = (CasualServer runningServer) -> server = runningServer;
         Supplier<CasualServer> supplier = () -> CasualServer.of(connectionInformation);
         Supplier<String> logMsg = () -> "Casual inbound server bound to port: " + connectionInformation.getPort();
-        Work work = StartInboundServerWork.of( getInboundStartupServices(), logMsg, consumer, supplier);
+        long delay = ConfigurationService.getInstance().getConfiguration().getInbound().getInitialDelay();
+        Work work = StartInboundServerWork.of( getInboundStartupServices(), logMsg, consumer, supplier, delay);
         startWork(work, StartInboundServerListener.of());
     }
 

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/work/Delayer.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/work/Delayer.java
@@ -5,7 +5,7 @@
  */
 package se.laz.casual.jca.work;
 
-import se.laz.casual.jca.InboundStartupException;
+import se.laz.casual.jca.DelayFailedException;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -30,7 +30,7 @@ public class Delayer
         catch (InterruptedException e)
         {
             Thread.currentThread().interrupt();
-            throw new InboundStartupException("Interrupted while delaying inbound startup", e);
+            throw new DelayFailedException("Interrupted while delaying something", e);
         }
     }
 }

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/work/Delayer.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/work/Delayer.java
@@ -15,6 +15,10 @@ import java.util.logging.Logger;
 public class Delayer
 {
     private static final Logger log = Logger.getLogger(Delayer.class.getName());
+
+    private Delayer()
+    {}
+
     public static void delay(long seconds)
     {
         try

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/work/Delayer.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/work/Delayer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+package se.laz.casual.jca.work;
+
+import se.laz.casual.jca.InboundStartupException;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+public class Delayer
+{
+    private static final Logger log = Logger.getLogger(Delayer.class.getName());
+    public static void delay(long seconds)
+    {
+        try
+        {
+            log.finest(() -> "delaying current thread by " + seconds + " seconds");
+            Duration delay = Duration.ofSeconds(seconds);
+            TimeUnit.SECONDS.sleep(delay.get(ChronoUnit.SECONDS));
+        }
+        catch (InterruptedException e)
+        {
+            Thread.currentThread().interrupt();
+            throw new InboundStartupException("Interrupted while delaying inbound startup", e);
+        }
+    }
+}

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartInboundServerWork.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartInboundServerWork.java
@@ -30,22 +30,29 @@ public final class StartInboundServerWork<T> implements Work
     private final Consumer<T> consumer;
     private final Supplier<T> supplier;
     private final Supplier<String> logMessage;
+    private long delay;
 
-    private StartInboundServerWork( List<String> startupServices, Supplier<String> logMessage, Consumer<T> consumer, Supplier<T> supplier)
+    private StartInboundServerWork( List<String> startupServices, Supplier<String> logMessage, Consumer<T> consumer, Supplier<T> supplier, long delay)
     {
         this.startupServices = startupServices;
         this.consumer = consumer;
         this.supplier = supplier;
         this.logMessage = logMessage;
+        this.delay = delay;
     }
 
     public static <T> Work of(List<String> startupServices, Supplier<String> logMessage, Consumer<T> consumer, Supplier<T> supplier )
+    {
+        return of(startupServices, logMessage, consumer, supplier, 0);
+    }
+
+    public static <T> Work of(List<String> startupServices, Supplier<String> logMessage, Consumer<T> consumer, Supplier<T> supplier, long delay )
     {
         Objects.requireNonNull(startupServices, "Startup Services is null.");
         Objects.requireNonNull(consumer, "Consumer is null.");
         Objects.requireNonNull(supplier, "supplier is null");
         // note: only needed to make the compiler, java 8, not spew out warnings
-        StartInboundServerWork<T> work = new StartInboundServerWork<>(startupServices, logMessage, consumer, supplier);
+        StartInboundServerWork<T> work = new StartInboundServerWork<>(startupServices, logMessage, consumer, supplier, delay);
         return work;
     }
 
@@ -61,6 +68,7 @@ public final class StartInboundServerWork<T> implements Work
     public void run()
     {
         waitForInboundStartupServices();
+        maybeDelay();
         startInboundServer();
     }
 
@@ -94,6 +102,23 @@ public final class StartInboundServerWork<T> implements Work
             log.info( ()-> "Startup service registered: " + foundService );
         }
         return found.get( false );
+    }
+
+    private void maybeDelay()
+    {
+        // Note:
+        // This, optional, delay of inbound is due to an issue on wls where once in a blue moon - the MessageEndpointFactory is in fact not ready
+        // and there are incoming domain discoveries ( during restart)
+        // That will then fail and continue to fail forever, even after endpointActivation for the resource adapter has completed - it should heal
+        // This is a horrible "work around" for that specific problem - the user decides how long inbound startup has to be delayed
+        // Never seen on wildfly
+        if(delay <= 0)
+        {
+            log.info(() -> "no inbound startup delay");
+            return;
+        }
+        Delayer.delay(delay);
+        log.info(() -> "inbound startup, delay of " + delay + " seconds - done");
     }
 
     private void startInboundServer()

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartInboundServerWork.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartInboundServerWork.java
@@ -112,7 +112,7 @@ public final class StartInboundServerWork<T> implements Work
         // That will then fail and continue to fail forever, even after endpointActivation for the resource adapter has completed - it should heal
         // This is a horrible "work around" for that specific problem - the user decides how long inbound startup has to be delayed
         // Never seen on wildfly
-        if(delay <= 0)
+        if(delay <= 0L)
         {
             log.info(() -> "no inbound startup delay");
             return;

--- a/configuration.md
+++ b/configuration.md
@@ -13,12 +13,12 @@ Casual supports the following configuration options which can be set using envir
     See [Inbound Startup Configuration](inbound.md#startup-configuration) for more details.
 * `CASUAL_OUTBOUND_USE_EPOLL` - If set to true, Netty uses epoll instead of NIO.
 * `CASUAL_INBOUND_USE_EPOLL` - If set to true, Netty uses epoll instead of NIO.
-* `CASUAL_INBOUND_STARTUP_INITIAL_DELAY_IN_SECONDS` - Delay the startup of the inbound server. Default is no delay.
+* `CASUAL_INBOUND_STARTUP_INITIAL_DELAY_SECONDS` - Delay the startup of the inbound server. Default is no delay.
 
 NB - if a `CASUAL_CONFIG_FILE` is provided, it take precedence over the `CASUAL_INBOUND_STARTUP_MODE` setting.
 However, if some configuration is missing from the configuration file but has a setting via an environment variable then this will be used before any hardcoded default setting.
 
-If `CASUAL_INBOUND_STARTUP_INITIAL_DELAY_IN_SECONDS` is configured then it will always delay the startup by that amount of seconds regardless of startup mode.
+If `CASUAL_INBOUND_STARTUP_INITIAL_DELAY_SECONDS` is configured then it will always delay the startup by that amount of seconds regardless of startup mode.
 That is - discovery is not running concurrently and the delay is always executed after any potential discovery.
 
 ## Casual Config File

--- a/configuration.md
+++ b/configuration.md
@@ -13,6 +13,7 @@ Casual supports the following configuration options which can be set using envir
     See [Inbound Startup Configuration](inbound.md#startup-configuration) for more details.
 * `CASUAL_OUTBOUND_USE_EPOLL` - If set to true, Netty uses epoll instead of NIO.
 * `CASUAL_INBOUND_USE_EPOLL` - If set to true, Netty uses epoll instead of NIO.
+* `CASUAL_INBOUND_INITIAL_DELAY` - Delay the startup of the inbound server. Default is no delay.
 
 NB - if a `CASUAL_CONFIG_FILE` is provided, it take precedence over the `CASUAL_INBOUND_STARTUP_MODE` setting.
 However, if some configuration is missing from the configuration file but has a setting via an environment variable then this will be used before any hardcoded default setting.
@@ -26,7 +27,7 @@ Within the casual configuration file you can currently specify:
 
 In the following example configuration file shows `discover` startup mode enabled with 2 startup services. 
 Also domain name configured as `my-casual-java-domain`, which is equivalent to setting the `CASUAL_DOMAIN_NAME` env if environment based configuration is used.
-Inbound epoll is also enabled - default false.
+Inbound epoll is also enabled - default false. Initial delay of inbound server is configured as well, default is no delay.
 
 ```json
 {
@@ -38,7 +39,8 @@ Inbound epoll is also enabled - default false.
         "service2"
       ]
     },
-    "useEpoll": true
+    "useEpoll": true,
+    "initialDelay": 30
   },
   "domain": {
     "name": "my-casual-java-domain"

--- a/configuration.md
+++ b/configuration.md
@@ -13,10 +13,13 @@ Casual supports the following configuration options which can be set using envir
     See [Inbound Startup Configuration](inbound.md#startup-configuration) for more details.
 * `CASUAL_OUTBOUND_USE_EPOLL` - If set to true, Netty uses epoll instead of NIO.
 * `CASUAL_INBOUND_USE_EPOLL` - If set to true, Netty uses epoll instead of NIO.
-* `CASUAL_INBOUND_INITIAL_DELAY` - Delay the startup of the inbound server. Default is no delay.
+* `CASUAL_INBOUND_STARTUP_INITIAL_DELAY_IN_SECONDS` - Delay the startup of the inbound server. Default is no delay.
 
 NB - if a `CASUAL_CONFIG_FILE` is provided, it take precedence over the `CASUAL_INBOUND_STARTUP_MODE` setting.
 However, if some configuration is missing from the configuration file but has a setting via an environment variable then this will be used before any hardcoded default setting.
+
+If `CASUAL_INBOUND_STARTUP_INITIAL_DELAY_IN_SECONDS` is configured then it will always delay the startup by that amount of seconds regardless of startup mode.
+That is - discovery is not running concurrently and the delay is always executed after any potential discovery.
 
 ## Casual Config File
 

--- a/inbound.md
+++ b/inbound.md
@@ -81,3 +81,7 @@ The `discover` startup mode ensures that all inbound startup services that are s
 registered and therefore up and running before allowing the inbound server to start accepting requests.
 The inbound startup services are provided as a list of service names. See [Configuration](README.md#configuration) for more details. 
 If there are no services defined in the configuration, then `discover` mode is equivalent to `immediate` mode.
+
+#### Initial inbound startup delay
+If initial inbound startup delay is configured ( see [Configuration](README.md#configuration) ) - 
+then that always it will always delay the startup by that amount of seconds regardless of startup mode.

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '2.2.10'
+version = '2.2.11'
 
 ext.casual_caller_app_version = '2.2.6'
 ext.casual_test_app_version = '1.0.2'


### PR DESCRIPTION
This is an optional setting to help with a problem that we've only seen on wls.
When starting the appserver, during the call to endPointActivation on the resource adapter, if there are incoming domain discoveries it may happen that we do not get a handle via the MessageEndpointFactory.
This then throws, which is according to the specification.
However, it never self heals - that is, the activation never completes.

With this optional setting a user can set an initial so that we delay the start of the inbound server.
The endpointActivation call from the appserver runs in another thread and should thus always be able to become activated and not trip over itself.