### PR TITLE
Reduce JndiUtil logging from WARN to FINEST

### DIFF
--- a/casual/casual-inbound-handler-casual-service/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/discovery/JndiUtil.java
+++ b/casual/casual-inbound-handler-casual-service/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/discovery/JndiUtil.java
@@ -13,6 +13,7 @@ import javax.naming.NamingException;
 import java.lang.reflect.Proxy;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class JndiUtil
@@ -98,7 +99,7 @@ public class JndiUtil
             }
             catch(NamingException e)
             {
-                logger.warning(() -> "lookup failed for: " + name);
+                logger.log( Level.FINEST, e, () -> "lookup failed for: " + name);
             }
         }
         return results;

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '2.2.11'
+version = '2.2.12'
 
 ext.casual_caller_app_version = '2.2.6'
 ext.casual_test_app_version = '1.0.2'


### PR DESCRIPTION
When failures during jndi traversal occur that are probably not that interesting, so WARN is too high as they occur each time the timer runs, resulting in the log being spammed.
Reducing the log from WARN to FINEST end users will not see this as often. Adding the throwable into the message provide more details in the case where something is wrong and end user chooses to log at FINEST level.