### PR TITLE
Feature/discovery request names sorted and unique

### DIFF
--- a/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/domain/CasualDomainDiscoveryRequestMessage.java
+++ b/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/domain/CasualDomainDiscoveryRequestMessage.java
@@ -140,13 +140,19 @@ public final class CasualDomainDiscoveryRequestMessage implements CasualNetworkT
 
     private CasualDomainDiscoveryRequestMessage setServiceNames(List<String> serviceNames)
     {
-        this.serviceNames = new ArrayList<>(serviceNames);
+        this.serviceNames = serviceNames.stream()
+                                        .distinct()
+                                        .sorted()
+                                        .collect(Collectors.toList());
         return this;
     }
 
     private CasualDomainDiscoveryRequestMessage setQueueNames(List<String> queueNames)
     {
-        this.queueNames = new ArrayList<>(queueNames);
+        this.queueNames = queueNames.stream()
+                                    .distinct()
+                                    .sorted()
+                                    .collect(Collectors.toList());
         return this;
     }
 

--- a/casual/casual-network-protocol/src/test/groovy/se/laz/casual/network/protocol/messages/domain/CasualDomainDiscoveryRequestMessageTest.groovy
+++ b/casual/casual-network-protocol/src/test/groovy/se/laz/casual/network/protocol/messages/domain/CasualDomainDiscoveryRequestMessageTest.groovy
@@ -60,7 +60,7 @@ class CasualDomainDiscoveryRequestMessageTest extends Specification
         def domainId = UUID.randomUUID()
         def domainName = 'Casually owned domain'
         def serviceNames = ['Very nice service', 'Hola!']
-        def queueNames = ['Queues of the world unite!']
+        def queueNames = ['Queues of the world unite!', 'Another queue bites the dust']
         def requestMessage = CasualDomainDiscoveryRequestMessage.createBuilder()
                 .setExecution(execution)
                 .setDomainId(domainId)
@@ -70,6 +70,16 @@ class CasualDomainDiscoveryRequestMessageTest extends Specification
                 .build()
         CasualNWMessageImpl msg = CasualNWMessageImpl.of(UUID.randomUUID(), requestMessage)
         def sink = new LocalByteChannel()
+
+        def uniqueAndSortedServiceNames = serviceNames.stream()
+                                                                 .distinct()
+                                                                 .sorted()
+                                                                 .collect(Collectors.toList())
+
+        def uniqueAndSortedQueueNames = queueNames.stream()
+                                                             .distinct()
+                                                             .sorted()
+                                                             .collect(Collectors.toList())
 
         when:
         def networkBytes = msg.toNetworkBytes()
@@ -81,10 +91,10 @@ class CasualDomainDiscoveryRequestMessageTest extends Specification
         networkBytes.size() == 2
         msg == resurrectedMsg
         domainName == resurrectedMsg.getMessage().getDomainName()
-        serviceNames.size() == resurrectedMsg.getMessage().getNumberOfRequestedServicesToFollow()
-        queueNames.size() == resurrectedMsg.getMessage().getNumberOfRequestedQueuesToFollow()
-        serviceNames == resurrectedMsg.getMessage().getServiceNames()
-        queueNames == resurrectedMsg.getMessage().getQueueNames()
+        uniqueAndSortedServiceNames.size() == resurrectedMsg.getMessage().getNumberOfRequestedServicesToFollow()
+        uniqueAndSortedQueueNames.size() == resurrectedMsg.getMessage().getNumberOfRequestedQueuesToFollow()
+        uniqueAndSortedServiceNames == resurrectedMsg.getMessage().getServiceNames()
+        uniqueAndSortedQueueNames == resurrectedMsg.getMessage().getQueueNames()
     }
 
     def "Roundtrip forced to chunk - one service and no queues, sync"()

--- a/casual/casual-network-protocol/src/test/groovy/se/laz/casual/network/protocol/messages/domain/CasualDomainDiscoveryRequestMessageTest.groovy
+++ b/casual/casual-network-protocol/src/test/groovy/se/laz/casual/network/protocol/messages/domain/CasualDomainDiscoveryRequestMessageTest.groovy
@@ -12,6 +12,8 @@ import se.laz.casual.network.protocol.messages.CasualNWMessageImpl
 import se.laz.casual.network.protocol.utils.LocalByteChannel
 import spock.lang.Specification
 
+import java.util.stream.Collectors
+
 /**
  * Created by aleph on 2017-03-02.
  */
@@ -152,5 +154,37 @@ class CasualDomainDiscoveryRequestMessageTest extends Specification
         serviceNames == resurrectedMsg.getMessage().getServiceNames()
         queueNames == resurrectedMsg.getMessage().getQueueNames()
     }
+
+   def 'service and queue names are always unique and sorted regardless of input'()
+   {
+      setup:
+      def execution = UUID.randomUUID()
+      def domainId = UUID.randomUUID()
+      def domainName = 'Casually owned domain'
+      def serviceNames = ['Z','B', 'C', 'C', 'F', 'FA', 'FB','AA', 'AB']
+      def queueNames = ['Z','B', 'C', 'C', 'F', 'FA', 'FB','AA', 'AB']
+      def requestMessage = CasualDomainDiscoveryRequestMessage.createBuilder()
+              .setExecution(execution)
+              .setDomainId(domainId)
+              .setDomainName(domainName)
+              .setServiceNames(serviceNames)
+              .setQueueNames(queueNames)
+              .setMaxMessageSize(1)
+              .build()
+      def uniqueAndSortedServiceNames = serviceNames.stream()
+                                                               .distinct()
+                                                               .sorted()
+                                                               .collect(Collectors.toList())
+      def uniqueAndSortedQueueNames = queueNames.stream()
+                                                           .distinct()
+                                                           .sorted()
+                                                           .collect(Collectors.toList())
+      when:
+      def actualServiceNames = requestMessage.getServiceNames()
+      def actualQueueNames = requestMessage.getQueueNames()
+      then:
+      uniqueAndSortedServiceNames == actualServiceNames
+      uniqueAndSortedQueueNames == actualQueueNames
+   }
 
 }

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '2.2.12'
+version = '2.2.13'
 
 ext.casual_caller_app_version = '2.2.6'
 ext.casual_test_app_version = '1.0.2'


### PR DESCRIPTION
Domain discovery request messages should always have the service/queue names unique and sorted.
This is a gateway protocol change.