### PR TITLE
Feature/casual xa is same rm

### DIFF
--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualXAResource.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualXAResource.java
@@ -119,7 +119,12 @@ public class CasualXAResource implements XAResource
     @Override
     public boolean isSameRM(XAResource xaResource) throws XAException
     {
-        return false;
+        if(!(xaResource instanceof CasualXAResource))
+        {
+            return false;
+        }
+        CasualXAResource casualXAResource = (CasualXAResource) xaResource;
+        return casualXAResource.casualManagedConnection.getDomainId().equals(casualManagedConnection.getDomainId());
     }
 
     @Override

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualXAResource.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualXAResource.java
@@ -119,12 +119,12 @@ public class CasualXAResource implements XAResource
     @Override
     public boolean isSameRM(XAResource xaResource) throws XAException
     {
-        if(!(xaResource instanceof CasualXAResource))
+        if(xaResource instanceof CasualXAResource)
         {
-            return false;
+            CasualXAResource casualXAResource = (CasualXAResource) xaResource;
+            return casualXAResource.casualManagedConnection.getDomainId().equals(casualManagedConnection.getDomainId());
         }
-        CasualXAResource casualXAResource = (CasualXAResource) xaResource;
-        return casualXAResource.casualManagedConnection.getDomainId().equals(casualManagedConnection.getDomainId());
+        return false;
     }
 
     @Override

--- a/casual/casual-jca/src/test/groovy/se/laz/casual/jca/CasualXAResourceTest.groovy
+++ b/casual/casual-jca/src/test/groovy/se/laz/casual/jca/CasualXAResourceTest.groovy
@@ -340,10 +340,40 @@ class CasualXAResourceTest extends Specification
         thrown UnsupportedOperationException
     }
 
-    def "IsSameRM"()
+    def "isSameRM"()
     {
-        expect:
-        instance.isSameRM( instance ) == false
+       setup:
+       def rmIdOne = 1
+       DomainId firstDomainId = DomainId.of(UUID.randomUUID())
+       CasualManagedConnection casualManagedConnectionOne = Mock(CasualManagedConnection) {
+           getDomainId() >> {
+              firstDomainId
+           }
+       }
+
+       def rmIdTwo = 2
+       DomainId secondDomainId = DomainId.of(UUID.randomUUID())
+       CasualManagedConnection casualManagedConnectionTwo = Mock(CasualManagedConnection) {
+           getDomainId() >> {
+              secondDomainId
+           }
+       }
+
+       def rmIdThree = 3
+       CasualManagedConnection casualManagedConnectionThree = Mock(CasualManagedConnection) {
+           getDomainId() >> {
+              firstDomainId
+           }
+       }
+       when:
+       CasualXAResource xaResourceOne = new CasualXAResource(casualManagedConnectionOne, rmIdOne)
+       CasualXAResource xaResourceTwo = new CasualXAResource(casualManagedConnectionTwo, rmIdTwo)
+       CasualXAResource xaResourceThree = new CasualXAResource(casualManagedConnectionThree, rmIdThree)
+
+       then:
+       !xaResourceOne.isSameRM(xaResourceTwo)
+       xaResourceOne.isSameRM(xaResourceThree)
+       !xaResourceTwo.isSameRM(xaResourceThree)
     }
 
     def "Prepare returns ok."()
@@ -486,4 +516,5 @@ class CasualXAResourceTest extends Specification
         instance.getTransactionTimeout() == timeout
         instance.getTransactionTimeout() != defaultTimeout
     }
+
 }

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '2.2.13'
+version = '2.2.14'
 
 ext.casual_caller_app_version = '2.2.7'
 ext.casual_test_app_version = '1.0.2'


### PR DESCRIPTION
This feature solves issue #59 
From the JTA spec:
"If the target transaction already has another XAResource object participating
in the transaction, the transaction manager invokes the XAResource.isSameRM
method to determine if the specified XAResource represents the same resource
manager instance. This information allows the transaction manager to group the
resource managers that are performing work on behalf of the transaction.
If the XAResource object represents a resource manager instance that has
seen the global transaction before, the transaction manager groups the newly
registered resource together with the previous XAResource object and ensures
that the same resource manager only receives one set of prepare-commit calls for
completing the target global transaction."

We store the domain id of the resource manager we are connected to during the initial handshake.
We match on the domain id, if it is the same domain id then it is the same resource manager.