### PR TITLE
Feature/2.2/inbound log waiting for service registration

### DIFF
--- a/casual/casual-jca/build.gradle
+++ b/casual/casual-jca/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation project(':casual:casual-network-protocol')
     implementation libs.netty
     compileOnly libs.javaee_api
+    compileOnly libs.gson
 
     resourceAdapter( project(':casual:casual-network') )
     resourceAdapter project(':casual:casual-network-protocol')

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartInboundServerWork.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartInboundServerWork.java
@@ -80,9 +80,9 @@ public final class StartInboundServerWork<T> implements Work
         Set<String> remaining = checkRemainingServices( new HashSet<>( this.startupServices ) );
         while(!remaining.isEmpty())
         {
-            int previouslyNumberOfServicesRemaining = remaining.size();
+            int previousNumberOfServicesRemaining = remaining.size();
             remaining = checkRemainingServices( remaining );
-            if(!remaining.isEmpty() && remaining.size() < previouslyNumberOfServicesRemaining)
+            if(!remaining.isEmpty() && remaining.size() < previousNumberOfServicesRemaining)
             {
                 logWaitingForStartupServices(remaining);
             }

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartInboundServerWork.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartInboundServerWork.java
@@ -79,11 +79,14 @@ public final class StartInboundServerWork<T> implements Work
     {
         logInitialStartupServices(startupServices);
         Set<String> remaining = checkRemainingServices( new HashSet<>( this.startupServices ) );
-        logWaitingForStartupServices(remaining);
         while(!remaining.isEmpty())
         {
+            int remainingServices = remaining.size();
             remaining = checkRemainingServices( remaining );
-            logWaitingForStartupServices(remaining);
+            if(!remaining.isEmpty() && remaining.size() < remainingServices)
+            {
+                logWaitingForStartupServices(remaining);
+            }
             try
             {
                 Thread.sleep( 1000 );

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartInboundServerWork.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartInboundServerWork.java
@@ -101,21 +101,16 @@ public final class StartInboundServerWork<T> implements Work
 
     private void logInitialStartupServices(List<String> startupServices)
     {
-        if(ConfigurationService.getInstance().getConfiguration().getInbound().getStartup().getMode() == Mode.DISCOVER)
-        {
-            log.info(() -> "Waiting for " + startupServices.size() + " services to be registered before inbound starts.");
-            log.info(() -> "Initial services list: " + startupServices.stream()
-                                                                      .collect(Collectors.joining()));
-        }
+        log.info(() -> "Inbound startup mode: " + ConfigurationService.getInstance().getConfiguration().getInbound().getStartup().getMode());
+        log.info(() -> "Waiting for " + startupServices.size() + " services to be registered before inbound starts.");
+        log.info(() -> "Initial services list: " + startupServices.stream()
+                                                                  .collect(Collectors.joining()));
     }
 
     private void logWaitingForStartupServices(Set<String> remaining)
     {
-        if(ConfigurationService.getInstance().getConfiguration().getInbound().getStartup().getMode() == Mode.DISCOVER)
-        {
-            log.info(() -> "Waiting for registration of the following services: " + remaining.stream()
-                                                                                             .collect(Collectors.joining()));
-        }
+        log.info(() -> "Waiting for registration of the following services: " + remaining.stream()
+                                                                                         .collect(Collectors.joining()));
     }
 
     private Set<String> checkRemainingServices( Set<String> remaining )

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartInboundServerWork.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartInboundServerWork.java
@@ -6,6 +6,9 @@
 
 package se.laz.casual.jca.work;
 
+import se.laz.casual.config.ConfigurationService;
+import se.laz.casual.config.Mode;
+import se.laz.casual.config.Startup;
 import se.laz.casual.jca.InboundStartupException;
 import se.laz.casual.jca.inbound.handler.service.casual.CasualServiceRegistry;
 
@@ -74,11 +77,13 @@ public final class StartInboundServerWork<T> implements Work
 
     private void waitForInboundStartupServices()
     {
-        log.info(() -> "Waiting for " + startupServices.size() + " startup services to be registered before inbound starts.");
+        logInitialStartupServices(startupServices);
         Set<String> remaining = checkRemainingServices( new HashSet<>( this.startupServices ) );
+        logWaitingForStartupServices(remaining);
         while(!remaining.isEmpty())
         {
             remaining = checkRemainingServices( remaining );
+            logWaitingForStartupServices(remaining);
             try
             {
                 Thread.sleep( 1000 );
@@ -90,6 +95,25 @@ public final class StartInboundServerWork<T> implements Work
             }
         }
         log.info(() -> "All startup services registered.");
+    }
+
+    private void logInitialStartupServices(List<String> startupServices)
+    {
+        if(ConfigurationService.getInstance().getConfiguration().getInbound().getStartup().getMode() == Mode.DISCOVER)
+        {
+            log.info(() -> "Waiting for " + startupServices.size() + " services to be registered before inbound starts.");
+            log.info(() -> "Initial services list: " + startupServices.stream()
+                                                                      .collect(Collectors.joining()));
+        }
+    }
+
+    private void logWaitingForStartupServices(Set<String> remaining)
+    {
+        if(ConfigurationService.getInstance().getConfiguration().getInbound().getStartup().getMode() == Mode.DISCOVER)
+        {
+            log.info(() -> "Waiting for registration of the following services: " + remaining.stream()
+                                                                                             .collect(Collectors.joining()));
+        }
     }
 
     private Set<String> checkRemainingServices( Set<String> remaining )

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartInboundServerWork.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartInboundServerWork.java
@@ -8,7 +8,6 @@ package se.laz.casual.jca.work;
 
 import se.laz.casual.config.ConfigurationService;
 import se.laz.casual.config.Mode;
-import se.laz.casual.config.Startup;
 import se.laz.casual.jca.InboundStartupException;
 import se.laz.casual.jca.inbound.handler.service.casual.CasualServiceRegistry;
 
@@ -81,9 +80,9 @@ public final class StartInboundServerWork<T> implements Work
         Set<String> remaining = checkRemainingServices( new HashSet<>( this.startupServices ) );
         while(!remaining.isEmpty())
         {
-            int remainingServices = remaining.size();
+            int previouslyNumberOfServicesRemaining = remaining.size();
             remaining = checkRemainingServices( remaining );
-            if(!remaining.isEmpty() && remaining.size() < remainingServices)
+            if(!remaining.isEmpty() && remaining.size() < previouslyNumberOfServicesRemaining)
             {
                 logWaitingForStartupServices(remaining);
             }

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '2.2.20'
+version = '2.2.21'
 
 def netty_version = '4.1.91.Final'
 def gson_version = '2.10.1'


### PR DESCRIPTION
If the inbound startup mode is discovery, log the initial set of services and keep logging which service registrations that inbound is still waiting for.
This is due to a demand from a customer and it is not an unreasonable request.