### PR TITLE
Feature/3.2/inbound log waiting for service registration

### DIFF
--- a/casual/casual-jca/build.gradle
+++ b/casual/casual-jca/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation project(':casual:casual-network-protocol')
     implementation libs.netty
     compileOnly libs.javaee_api
+    compileOnly libs.gson
 
     resourceAdapter( project(':casual:casual-network') )
     resourceAdapter project(':casual:casual-network-protocol')

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,8 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '3.2.22'
+version = '3.2.23'
+
 
 def netty_version = '4.1.91.Final'
 def gson_version = '2.10.1'


### PR DESCRIPTION
If the inbound startup mode is discovery, log the initial set of services and keep logging which service registrations that inbound is still waiting for. This is due to a demand from a customer and it is not an unreasonable request.