### PR TITLE
buggfix/2.2/pass real method to buffer handlers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,12 @@ subprojects{
   apply from: "$rootProject.projectDir/versions.gradle"
   apply plugin: 'java-library'
   apply from: "$rootProject.projectDir/publish.gradle"
+  test {
+    useJUnitPlatform()
+      testLogging {
+        events "passed", "skipped", "failed"
+      }
+    }
 }
 
 task dist(type: Sync) {

--- a/casual/casual-api/build.gradle
+++ b/casual/casual-api/build.gradle
@@ -22,7 +22,10 @@ dependencies {
   testImplementation libs.system_lambda
     
   // for spock
-  testImplementation libs.groovy_all
+  testImplementation platform(libs.groovy_bom)
+  testImplementation libs.groovy
+  testImplementation platform(libs.spock_bom)
   testImplementation libs.spock_core
-  testImplementation libs.cglib_nodep
+  testImplementation libs.byte_buddy
+  testImplementation libs.spock_junit4    
 }

--- a/casual/casual-fielded-annotations/build.gradle
+++ b/casual/casual-fielded-annotations/build.gradle
@@ -13,8 +13,10 @@ plugins {
 dependencies {
 
   // for spock
-  testImplementation libs.groovy_all
+  testImplementation platform(libs.groovy_bom)
+  testImplementation libs.groovy
+  testImplementation platform(libs.spock_bom)
   testImplementation libs.spock_core
-  testImplementation libs.cglib_nodep
-  testImplementation libs.objenesis
+  testImplementation libs.byte_buddy
+  testImplementation libs.objenesis    
 }

--- a/casual/casual-inbound-api/build.gradle
+++ b/casual/casual-inbound-api/build.gradle
@@ -22,8 +22,10 @@ dependencies {
   testRuntimeOnly libs.gson
 
   // for spock
-  testImplementation libs.groovy_all
+  testImplementation platform(libs.groovy_bom)
+  testImplementation libs.groovy
+  testImplementation platform(libs.spock_bom)
   testImplementation libs.spock_core
-  testImplementation libs.cglib_nodep
-  testImplementation libs.objenesis
+  testImplementation libs.byte_buddy
+  testImplementation libs.objenesis    
 }

--- a/casual/casual-inbound-handler-api/build.gradle
+++ b/casual/casual-inbound-handler-api/build.gradle
@@ -17,8 +17,10 @@ dependencies {
   testImplementation libs.javaee_api
 
   // for spock
-  testImplementation libs.groovy_all
+  testImplementation platform(libs.groovy_bom)
+  testImplementation libs.groovy
+  testImplementation platform(libs.spock_bom)
   testImplementation libs.spock_core
-  testImplementation libs.cglib_nodep
+  testImplementation libs.byte_buddy
   testImplementation libs.objenesis
 }

--- a/casual/casual-inbound-handler-api/src/main/java/se/laz/casual/jca/inbound/handler/buffer/BufferHandler.java
+++ b/casual/casual-inbound-handler-api/src/main/java/se/laz/casual/jca/inbound/handler/buffer/BufferHandler.java
@@ -10,11 +10,8 @@ import se.laz.casual.jca.inbound.handler.InboundRequest;
 import se.laz.casual.jca.inbound.handler.InboundResponse;
 import se.laz.casual.spi.Prioritisable;
 
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
-
 /**
- * Different buffers can required transformation before they are dispatched to their respective service.
+ * Different buffers can require transformation before they are dispatched to their respective service.
  * This interface provides a mechanism for creating custom handlers.
  */
 public interface BufferHandler extends Prioritisable
@@ -30,12 +27,11 @@ public interface BufferHandler extends Prioritisable
     /**
      * Convert an inbound request to the appropriate {@link ServiceCallInfo}.
      *
-     * @param p the proxy for service invocation.
-     * @param method that the buffer will be dispatched to.
-     * @param request that contains the buffer.
+     * @param requestInfo further request information
+     * @param request     that contains the buffer.
      * @return the transformed buffer and service call information.
      */
-    ServiceCallInfo fromRequest(Proxy p, Method method, InboundRequest request );
+    ServiceCallInfo fromRequest(InboundRequestInfo requestInfo, InboundRequest request );
 
     /**
      * Convert the response of the service request back to the appropriate {@link InboundResponse}.
@@ -44,5 +40,5 @@ public interface BufferHandler extends Prioritisable
      * @param result of calling the service.
      * @return response containing result buffer and/or error data.
      */
-    InboundResponse toResponse(ServiceCallInfo info, Object result );
+    InboundResponse toResponse( ServiceCallInfo info, Object result );
 }

--- a/casual/casual-inbound-handler-api/src/main/java/se/laz/casual/jca/inbound/handler/buffer/InboundRequestException.java
+++ b/casual/casual-inbound-handler-api/src/main/java/se/laz/casual/jca/inbound/handler/buffer/InboundRequestException.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+package se.laz.casual.jca.inbound.handler.buffer;
+
+import se.laz.casual.api.CasualRuntimeException;
+
+public class InboundRequestException extends CasualRuntimeException
+{
+    private static final long serialVersionUID = 1L;
+
+    public InboundRequestException(String message)
+    {
+        super(message);
+    }
+}

--- a/casual/casual-inbound-handler-api/src/main/java/se/laz/casual/jca/inbound/handler/buffer/InboundRequestInfo.java
+++ b/casual/casual-inbound-handler-api/src/main/java/se/laz/casual/jca/inbound/handler/buffer/InboundRequestInfo.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2023, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+package se.laz.casual.jca.inbound.handler.buffer;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Objects;
+import java.util.Optional;
+
+public final class InboundRequestInfo
+{
+    private final Method proxyMethod;
+    private final Method realMethod;
+    private final String serviceName;
+    private final Proxy proxy;
+
+    private InboundRequestInfo(Method proxyMethod, Method realMethod, String serviceName, Proxy proxy)
+    {
+        this.proxyMethod = proxyMethod;
+        this.realMethod = realMethod;
+        this.serviceName = serviceName;
+        this.proxy = proxy;
+    }
+
+    private InboundRequestInfo(Builder builder)
+    {
+        this(builder.proxyMethod, builder.realMethod, builder.serviceName, builder.proxy);
+    }
+
+    public Optional<Method> getProxyMethod()
+    {
+        return Optional.ofNullable(proxyMethod);
+    }
+
+    public Optional<Method> getRealMethod()
+    {
+        return Optional.ofNullable(realMethod);
+    }
+
+    public Optional<String> getServiceName()
+    {
+        return Optional.ofNullable(serviceName);
+    }
+
+    public Proxy getProxy()
+    {
+        return proxy;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+        InboundRequestInfo that = (InboundRequestInfo) o;
+        return Objects.equals(getProxyMethod(), that.getProxyMethod()) && Objects.equals(getRealMethod(), that.getRealMethod()) && Objects.equals(getServiceName(), that.getServiceName()) && Objects.equals(getProxy(), that.getProxy());
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(getProxyMethod(), getRealMethod(), getServiceName(), getProxy());
+    }
+
+    @Override
+    public String toString()
+    {
+        return "InboundRequestInfo{" +
+                "proxyMethod=" + proxyMethod +
+                ", realMethod=" + realMethod +
+                ", serviceName='" + serviceName + '\'' +
+                ", proxy=" + proxy +
+                '}';
+    }
+
+    public static Builder createBuilder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private Method proxyMethod;
+        private Method realMethod;
+        private String serviceName;
+        private Proxy proxy;
+
+        private Builder()
+        {}
+
+        public Builder withProxyMethod(Method proxyMethod)
+        {
+            this.proxyMethod = proxyMethod;
+            return this;
+        }
+
+        public Builder withRealMethod(Method realMethod)
+        {
+            this.realMethod = realMethod;
+            return this;
+        }
+
+        public Builder withServiceName(String serviceName)
+        {
+            this.serviceName = serviceName;
+            return this;
+        }
+
+        public Builder withProxy(Proxy proxy)
+        {
+            this.proxy = proxy;
+            return this;
+        }
+
+        public InboundRequestInfo build()
+        {
+            Objects.requireNonNull(proxy, "proxy can not be null");
+            return new InboundRequestInfo(this);
+        }
+    }
+}

--- a/casual/casual-inbound-handler-api/src/main/java/se/laz/casual/jca/inbound/handler/buffer/PassThroughBufferHandler.java
+++ b/casual/casual-inbound-handler-api/src/main/java/se/laz/casual/jca/inbound/handler/buffer/PassThroughBufferHandler.java
@@ -12,7 +12,6 @@ import se.laz.casual.jca.inbound.handler.InboundRequest;
 import se.laz.casual.jca.inbound.handler.InboundResponse;
 
 import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
 
 import static se.laz.casual.jca.inbound.handler.buffer.DispatchMethodUtil.methodAccepts;
 import static se.laz.casual.jca.inbound.handler.buffer.DispatchMethodUtil.toMethodParams;
@@ -30,23 +29,23 @@ public class PassThroughBufferHandler implements BufferHandler
     }
 
     @Override
-    public ServiceCallInfo fromRequest(Proxy p, Method method, InboundRequest request)
+    public ServiceCallInfo fromRequest(InboundRequestInfo requestInfo, InboundRequest request)
     {
         Object[] params;
-
-        if( methodAccepts( method, request ) )
+        Method proxyMethod = requestInfo.getProxyMethod().orElseThrow(() -> new InboundRequestException("Missing proxy method, requestInfo: " + requestInfo));
+        if( methodAccepts( proxyMethod, request ) )
         {
-            params = toMethodParams( method, request );
+            params = toMethodParams( proxyMethod, request );
         }
-        else if( methodAccepts( method, request.getBuffer() ) )
+        else if( methodAccepts( proxyMethod, request.getBuffer() ) )
         {
-            params = toMethodParams( method, request.getBuffer() );
+            params = toMethodParams( proxyMethod, request.getBuffer() );
         }
         else
         {
             throw new HandlerException("Unable to perform passthrough as dispatch method does not accept required parameter.");
         }
-        return ServiceCallInfo.of( method, params );
+        return ServiceCallInfo.of( proxyMethod, params );
     }
 
     @Override

--- a/casual/casual-inbound-handler-api/src/test/groovy/se/laz/casual/jca/inbound/handler/buffer/InboundRequestInfoTest.groovy
+++ b/casual/casual-inbound-handler-api/src/test/groovy/se/laz/casual/jca/inbound/handler/buffer/InboundRequestInfoTest.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+package se.laz.casual.jca.inbound.handler.buffer
+
+import spock.lang.Specification
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+
+class InboundRequestInfoTest extends Specification
+{
+   def 'creation'()
+   {
+      given:
+      def realMethodName = 'endsWith'
+      def proxyMethodName = 'startsWith'
+      Method realMethod = String.class.getMethod(realMethodName, String.class)
+      Method proxyMethod = String.class.getMethod(proxyMethodName, String.class)
+      String serviceName = 'shiny lemon'
+      Proxy proxy = Mock(Proxy)
+      when:
+      InboundRequestInfo requestInfo = InboundRequestInfo.createBuilder()
+              .withProxy(proxy)
+              .withProxyMethod(proxyMethod)
+              .withRealMethod(realMethod)
+              .withServiceName(serviceName)
+              .build()
+      then:
+      requestInfo.getProxy() == proxy
+      requestInfo.getProxyMethod().get() == proxyMethod
+      requestInfo.getRealMethod().get() == realMethod
+      requestInfo.getServiceName().get() == serviceName
+   }
+
+   def 'failed creation - mandatory missing '()
+   {
+      given:
+      def methodName = 'toString'
+      Method proxyMethod = String.class.getMethod(methodName)
+      Method realMethod = String.class.getMethod(methodName)
+      String serviceName = 'shiny lemon'
+      when:
+      InboundRequestInfo requestInfo = InboundRequestInfo.createBuilder()
+              .withProxyMethod(proxyMethod)
+              .withRealMethod(realMethod)
+              .withServiceName(serviceName)
+              .build()
+      then:
+      thrown(NullPointerException)
+   }
+
+}

--- a/casual/casual-inbound-handler-api/src/test/groovy/se/laz/casual/jca/inbound/handler/buffer/PassThroughBufferHandlerTest.groovy
+++ b/casual/casual-inbound-handler-api/src/test/groovy/se/laz/casual/jca/inbound/handler/buffer/PassThroughBufferHandlerTest.groovy
@@ -10,6 +10,7 @@ import spock.lang.Shared
 import spock.lang.Specification
 
 import java.lang.reflect.Method
+import java.lang.reflect.Proxy
 
 class PassThroughBufferHandlerTest extends Specification
 {
@@ -18,10 +19,14 @@ class PassThroughBufferHandlerTest extends Specification
     @Shared Method echoRequest = TestService.getMethod( "echo", InboundRequest.class )
     @Shared Method echoBuffer = TestService.getMethod( "echo", FieldedTypeBuffer.class )
     @Shared Method echoString = TestService.getMethod( "echo", String.class )
+    @Shared TestService proxyService
+    @Shared Proxy jndiObject
 
     def setup()
     {
         instance = new PassThroughBufferHandler()
+        proxyService = Mock( TestService )
+        jndiObject = Mock(Proxy)
     }
 
     def "Can handle buffer all"()
@@ -39,8 +44,13 @@ class PassThroughBufferHandlerTest extends Specification
         CasualBuffer buffer = FieldedTypeBuffer.create()
         InboundRequest request = InboundRequest.of( "test123", buffer )
 
+        InboundRequestInfo requestInfo = InboundRequestInfo.createBuilder()
+                .withProxy(jndiObject)
+                .withProxyMethod(echoRequest)
+                .build()
+
         when:
-        ServiceCallInfo actual = instance.fromRequest( null, echoRequest, request )
+        ServiceCallInfo actual = instance.fromRequest(requestInfo, request)
 
         then:
         actual != null
@@ -54,9 +64,13 @@ class PassThroughBufferHandlerTest extends Specification
         given:
         CasualBuffer buffer = FieldedTypeBuffer.create()
         InboundRequest request = InboundRequest.of( "test123", buffer )
+        InboundRequestInfo requestInfo = InboundRequestInfo.createBuilder()
+                .withProxy(jndiObject)
+                .withProxyMethod(echoBuffer)
+                .build()
 
         when:
-        ServiceCallInfo actual = instance.fromRequest( null, echoBuffer, request )
+        ServiceCallInfo actual = instance.fromRequest(requestInfo, request)
 
         then:
         actual != null
@@ -71,8 +85,13 @@ class PassThroughBufferHandlerTest extends Specification
         CasualBuffer buffer = FieldedTypeBuffer.create()
         InboundRequest request = InboundRequest.of( "test123", buffer )
 
+        InboundRequestInfo requestInfo = InboundRequestInfo.createBuilder()
+                .withProxy(jndiObject)
+                .withProxyMethod(echoString)
+                .build()
+
         when:
-        ServiceCallInfo actual = instance.fromRequest( null, echoString, request )
+        ServiceCallInfo actual = instance.fromRequest(requestInfo, request)
 
         then:
         thrown CasualRuntimeException
@@ -104,5 +123,8 @@ class PassThroughBufferHandlerTest extends Specification
         then:
         actual == response
     }
+
+    class TestPojo
+    {}
 
 }

--- a/casual/casual-inbound-handler-api/src/test/java/se/laz/casual/jca/inbound/handler/test/TestBufferHandler.java
+++ b/casual/casual-inbound-handler-api/src/test/java/se/laz/casual/jca/inbound/handler/test/TestBufferHandler.java
@@ -8,12 +8,10 @@ package se.laz.casual.jca.inbound.handler.test;
 
 import se.laz.casual.jca.inbound.handler.InboundRequest;
 import se.laz.casual.jca.inbound.handler.InboundResponse;
+import se.laz.casual.jca.inbound.handler.buffer.InboundRequestInfo;
 import se.laz.casual.spi.Priority;
 import se.laz.casual.jca.inbound.handler.buffer.BufferHandler;
 import se.laz.casual.jca.inbound.handler.buffer.ServiceCallInfo;
-
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
 
 public class TestBufferHandler implements BufferHandler
 {
@@ -27,7 +25,7 @@ public class TestBufferHandler implements BufferHandler
     }
 
     @Override
-    public ServiceCallInfo fromRequest(Proxy p, Method method, InboundRequest buffer)
+    public ServiceCallInfo fromRequest(InboundRequestInfo requestInfo, InboundRequest request)
     {
         return null;
     }

--- a/casual/casual-inbound-handler-api/src/test/java/se/laz/casual/jca/inbound/handler/test/TestBufferHandler2.java
+++ b/casual/casual-inbound-handler-api/src/test/java/se/laz/casual/jca/inbound/handler/test/TestBufferHandler2.java
@@ -8,12 +8,10 @@ package se.laz.casual.jca.inbound.handler.test;
 
 import se.laz.casual.jca.inbound.handler.InboundRequest;
 import se.laz.casual.jca.inbound.handler.InboundResponse;
+import se.laz.casual.jca.inbound.handler.buffer.InboundRequestInfo;
 import se.laz.casual.spi.Priority;
 import se.laz.casual.jca.inbound.handler.buffer.BufferHandler;
 import se.laz.casual.jca.inbound.handler.buffer.ServiceCallInfo;
-
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
 
 public class TestBufferHandler2 implements BufferHandler
 {
@@ -27,7 +25,7 @@ public class TestBufferHandler2 implements BufferHandler
     }
 
     @Override
-    public ServiceCallInfo fromRequest(Proxy p, Method method, InboundRequest buffer)
+    public ServiceCallInfo fromRequest(InboundRequestInfo requestInfo, InboundRequest request)
     {
         return null;
     }

--- a/casual/casual-inbound-handler-casual-service/build.gradle
+++ b/casual/casual-inbound-handler-casual-service/build.gradle
@@ -23,9 +23,11 @@ dependencies {
   testImplementation libs.system_lambda
 
   // for spock
-  testImplementation libs.groovy_all
+  testImplementation platform(libs.groovy_bom)
+  testImplementation libs.groovy
+  testImplementation platform(libs.spock_bom)
   testImplementation libs.spock_core
-  testImplementation libs.cglib_nodep
+  testImplementation libs.byte_buddy
   testImplementation libs.objenesis
   testRuntimeOnly project(":casual:casual-inbound-handler-fielded-buffer" )
 }

--- a/casual/casual-inbound-handler-casual-service/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/CasualServiceHandler.java
+++ b/casual/casual-inbound-handler-casual-service/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/CasualServiceHandler.java
@@ -16,6 +16,7 @@ import se.laz.casual.jca.inbound.handler.InboundRequest;
 import se.laz.casual.jca.inbound.handler.InboundResponse;
 import se.laz.casual.jca.inbound.handler.buffer.BufferHandler;
 import se.laz.casual.jca.inbound.handler.buffer.BufferHandlerFactory;
+import se.laz.casual.jca.inbound.handler.buffer.InboundRequestInfo;
 import se.laz.casual.jca.inbound.handler.buffer.ServiceCallInfo;
 import se.laz.casual.jca.inbound.handler.service.extension.ServiceHandlerExtension;
 import se.laz.casual.jca.inbound.handler.service.extension.ServiceHandlerExtensionFactory;
@@ -129,9 +130,13 @@ public class CasualServiceHandler implements ServiceHandler
     private InboundResponse callService( Object r, CasualServiceEntry entry, InboundRequest request, BufferHandler bufferHandler, ServiceHandlerExtension serviceHandlerExtension, ServiceHandlerExtensionContext context) throws Throwable
     {
         Proxy p = (Proxy)r;
-
-        ServiceCallInfo info = bufferHandler.fromRequest( p, entry.getProxyMethod(), request );
-
+        InboundRequestInfo requestInfo = InboundRequestInfo.createBuilder()
+                                                           .withProxy(p)
+                                                           .withProxyMethod(entry.getProxyMethod())
+                                                           .withRealMethod(entry.getMetaData().getServiceMethod())
+                                                           .withServiceName(entry.getServiceName())
+                                                           .build();
+        ServiceCallInfo info = bufferHandler.fromRequest(requestInfo, request);
         Method method = info.getMethod().orElseThrow( ()-> new HandlerException( "Buffer did not provide required details about the method end point." ) );
 
         Object[] params = serviceHandlerExtension.convertRequestParams(context, info.getParams());
@@ -162,8 +167,14 @@ public class CasualServiceHandler implements ServiceHandler
                 .findFirst()
                 .orElseThrow( () -> new NoSuchMethodException( "Unable to find method in proxy matching: " + method ));
         entry.setProxyMethod( proxyMethod );
-        ServiceCallInfo serviceCallInfo = bufferHandler.fromRequest( p, proxyMethod, request );
 
+        InboundRequestInfo requestInfo = InboundRequestInfo.createBuilder()
+                                                           .withProxy(p)
+                                                           .withProxyMethod(proxyMethod)
+                                                           .withRealMethod(entry.getMetaData().getServiceMethod())
+                                                           .withServiceName(entry.getServiceName())
+                                                           .build();
+        ServiceCallInfo serviceCallInfo = bufferHandler.fromRequest(requestInfo, request);
         Method m = serviceCallInfo.getMethod().orElseThrow( ()-> new HandlerException( "Buffer did not provided required details about the method end point." ) );
 
         return handler.invoke( p, m, params );

--- a/casual/casual-inbound-handler-casual-service/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/discovery/JndiSearchTimerEjbSingleton.java
+++ b/casual/casual-inbound-handler-casual-service/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/discovery/JndiSearchTimerEjbSingleton.java
@@ -111,7 +111,7 @@ public class JndiSearchTimerEjbSingleton
 
             Method proxyMethod = findMatchingProxyMethod( app.get( jndi ), method );
 
-            return jndi != null ? CasualServiceEntry.of( entry.getServiceName(), jndi, proxyMethod ) : null;
+            return jndi != null ? CasualServiceEntry.of( entry.getServiceName(), jndi, proxyMethod, entry ) : null;
         }
         catch( ClassNotFoundException | NoSuchMethodException e)
         {

--- a/casual/casual-inbound-handler-casual-service/src/test/groovy/se/laz/casual/jca/inbound/handler/service/casual/CasualServiceHandlerTest.groovy
+++ b/casual/casual-inbound-handler-casual-service/src/test/groovy/se/laz/casual/jca/inbound/handler/service/casual/CasualServiceHandlerTest.groovy
@@ -58,7 +58,7 @@ class CasualServiceHandlerTest extends Specification
                 .serviceMethod( method)
                 .implementationClass( SimpleService.class )
                 .build()
-        CasualServiceEntry e = CasualServiceEntry.of( casualServiceName, jndiServiceName, method )
+        CasualServiceEntry e = CasualServiceEntry.of( casualServiceName, jndiServiceName, method, s )
         CasualServiceRegistry.getInstance().register( s )
         CasualServiceRegistry.getInstance().register( e )
 

--- a/casual/casual-inbound-handler-fielded-buffer/build.gradle
+++ b/casual/casual-inbound-handler-fielded-buffer/build.gradle
@@ -17,8 +17,10 @@ dependencies {
   testRuntimeOnly libs.gson
 
   // for spock
-  testImplementation libs.groovy_all
+  testImplementation platform(libs.groovy_bom)
+  testImplementation libs.groovy
+  testImplementation platform(libs.spock_bom)
   testImplementation libs.spock_core
-  testImplementation libs.cglib_nodep
+  testImplementation libs.byte_buddy
   testImplementation libs.objenesis
 }

--- a/casual/casual-inbound-handler-fielded-buffer/src/test/groovy/se/laz/casual/jca/inbound/handler/buffer/fielded/FieldedBufferHandlerTest.groovy
+++ b/casual/casual-inbound-handler-fielded-buffer/src/test/groovy/se/laz/casual/jca/inbound/handler/buffer/fielded/FieldedBufferHandlerTest.groovy
@@ -11,12 +11,12 @@ import se.laz.casual.api.buffer.CasualBufferType
 import se.laz.casual.api.buffer.type.fielded.FieldedTypeBuffer
 import se.laz.casual.jca.inbound.handler.InboundRequest
 import se.laz.casual.jca.inbound.handler.InboundResponse
+import se.laz.casual.jca.inbound.handler.buffer.InboundRequestInfo
 import se.laz.casual.jca.inbound.handler.buffer.ServiceCallInfo
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.lang.reflect.Proxy
 
@@ -68,8 +68,15 @@ class FieldedBufferHandlerTest extends Specification
     {
         given:
         InboundRequest request = InboundRequest.of( methodName, buffer )
+
+        InboundRequestInfo requestInfo = InboundRequestInfo.createBuilder()
+                .withProxy(jndiObject)
+                .withProxyMethod(method)
+                .withRealMethod(method)
+                .build()
+
         when:
-        ServiceCallInfo info = instance.fromRequest( jndiObject, method, request )
+        ServiceCallInfo info = instance.fromRequest(requestInfo, request)
 
         then:
         info.getMethod().get() == method
@@ -84,8 +91,14 @@ class FieldedBufferHandlerTest extends Specification
         InboundRequest request = InboundRequest.of( "echoBuffer", buffer )
         Method m = SimpleService.getMethod( "echoBuffer", InboundRequest.class )
 
+        InboundRequestInfo requestInfo = InboundRequestInfo.createBuilder()
+                .withProxy(jndiObject)
+                .withProxyMethod(m)
+                .withRealMethod(m)
+                .build()
+
         when:
-        ServiceCallInfo info = instance.fromRequest( jndiObject, m, request )
+        ServiceCallInfo info = instance.fromRequest(requestInfo, request)
 
         then:
         info.getMethod().get() == m
@@ -100,8 +113,14 @@ class FieldedBufferHandlerTest extends Specification
         InboundRequest request = InboundRequest.of( "echoFieldedBuffer", buffer )
         Method m = SimpleService.getMethod( "echoFieldedBuffer", FieldedTypeBuffer.class )
 
+        InboundRequestInfo requestInfo = InboundRequestInfo.createBuilder()
+                .withProxy(jndiObject)
+                .withProxyMethod(m)
+                .withRealMethod(m)
+                .build()
+
         when:
-        ServiceCallInfo info = instance.fromRequest( jndiObject, m, request )
+        ServiceCallInfo info = instance.fromRequest(requestInfo, request)
 
         then:
         info.getMethod().get() == m

--- a/casual/casual-inbound-handler-javaee-service/build.gradle
+++ b/casual/casual-inbound-handler-javaee-service/build.gradle
@@ -18,9 +18,11 @@ dependencies {
   testImplementation libs.javaee_api
   testRuntimeOnly libs.gson
   // for spock
-  testImplementation libs.groovy_all
+  testImplementation platform(libs.groovy_bom)
+  testImplementation libs.groovy
+  testImplementation platform(libs.spock_bom)
   testImplementation libs.spock_core
-  testImplementation libs.cglib_nodep
+  testImplementation libs.byte_buddy
   testImplementation libs.objenesis
 
   testRuntimeOnly project(":casual:casual-inbound-handler-jscd-buffer" )

--- a/casual/casual-inbound-handler-javaee-service/src/main/java/se/laz/casual/jca/inbound/handler/service/javaee/JavaeeServiceHandler.java
+++ b/casual/casual-inbound-handler-javaee-service/src/main/java/se/laz/casual/jca/inbound/handler/service/javaee/JavaeeServiceHandler.java
@@ -15,6 +15,7 @@ import se.laz.casual.jca.inbound.handler.InboundRequest;
 import se.laz.casual.jca.inbound.handler.InboundResponse;
 import se.laz.casual.jca.inbound.handler.buffer.BufferHandler;
 import se.laz.casual.jca.inbound.handler.buffer.BufferHandlerFactory;
+import se.laz.casual.jca.inbound.handler.buffer.InboundRequestInfo;
 import se.laz.casual.jca.inbound.handler.buffer.ServiceCallInfo;
 import se.laz.casual.jca.inbound.handler.service.ServiceHandler;
 import se.laz.casual.jca.inbound.handler.service.extension.ServiceHandlerExtension;
@@ -111,12 +112,14 @@ public class JavaeeServiceHandler implements ServiceHandler
 
     //Use a specific exception. This is a help method for invokeService so any exceptions should bubble back up.
     @SuppressWarnings("squid:S00112")
-    private InboundResponse callService( Object r, InboundRequest payload, BufferHandler bufferHandler, ServiceHandlerExtension serviceHandlerExtension,
+    private InboundResponse callService( Object r, InboundRequest request, BufferHandler bufferHandler, ServiceHandlerExtension serviceHandlerExtension,
                                          ServiceHandlerExtensionContext extensionContext ) throws Throwable
     {
         Proxy p = (Proxy) r;
-
-        ServiceCallInfo serviceCallInfo = bufferHandler.fromRequest( p, null, payload );
+        InboundRequestInfo requestInfo = InboundRequestInfo.createBuilder()
+                                                           .withProxy(p)
+                                                           .build();
+        ServiceCallInfo serviceCallInfo = bufferHandler.fromRequest(requestInfo, request);
 
         Method method = serviceCallInfo.getMethod().orElseThrow( ()-> new HandlerException( "Buffer did not provided required details about the method end point." ) );
 

--- a/casual/casual-inbound-handler-jscd-buffer/build.gradle
+++ b/casual/casual-inbound-handler-jscd-buffer/build.gradle
@@ -16,8 +16,10 @@ dependencies {
 
   testRuntimeOnly libs.gson
   // for spock
-  testImplementation libs.groovy_all
+  testImplementation platform(libs.groovy_bom)
+  testImplementation libs.groovy
+  testImplementation platform(libs.spock_bom)
   testImplementation libs.spock_core
-  testImplementation libs.cglib_nodep
+  testImplementation libs.byte_buddy
   testImplementation libs.objenesis
 }

--- a/casual/casual-inbound-handler-jscd-buffer/src/main/java/se/laz/casual/jca/inbound/handler/buffer/jscd/JavaServiceCallBufferHandler.java
+++ b/casual/casual-inbound-handler-jscd-buffer/src/main/java/se/laz/casual/jca/inbound/handler/buffer/jscd/JavaServiceCallBufferHandler.java
@@ -16,11 +16,11 @@ import se.laz.casual.jca.inbound.handler.HandlerException;
 import se.laz.casual.jca.inbound.handler.InboundRequest;
 import se.laz.casual.jca.inbound.handler.InboundResponse;
 import se.laz.casual.jca.inbound.handler.buffer.BufferHandler;
+import se.laz.casual.jca.inbound.handler.buffer.InboundRequestInfo;
 import se.laz.casual.jca.inbound.handler.buffer.ServiceCallInfo;
 
 import javax.ejb.Stateless;
 import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -37,7 +37,7 @@ public class JavaServiceCallBufferHandler implements BufferHandler
     }
 
     @Override
-    public ServiceCallInfo fromRequest(Proxy p, Method m, InboundRequest request)
+    public ServiceCallInfo fromRequest(InboundRequestInfo requestInfo, InboundRequest request)
     {
         if( request.getBuffer().getBytes().size() != 1 )
         {
@@ -55,7 +55,7 @@ public class JavaServiceCallBufferHandler implements BufferHandler
             {
                 params[i] = Class.forName(methodParamTypes[i], true, Thread.currentThread().getContextClassLoader());
             }
-            Method method = p.getClass().getMethod(callDef.getMethodName(), params);
+            Method method = requestInfo.getProxy().getClass().getMethod(callDef.getMethodName(), params);
 
             return ServiceCallInfo.of(method, callDef.getMethodParams());
         }

--- a/casual/casual-inbound-handler-jscd-buffer/src/test/groovy/se/laz/casual/jca/inbound/handler/buffer/jscd/JavaServiceCallBufferHandlerTest.groovy
+++ b/casual/casual-inbound-handler-jscd-buffer/src/test/groovy/se/laz/casual/jca/inbound/handler/buffer/jscd/JavaServiceCallBufferHandlerTest.groovy
@@ -14,6 +14,7 @@ import se.laz.casual.api.external.json.JsonProviderFactory
 import se.laz.casual.jca.inbound.handler.HandlerException
 import se.laz.casual.jca.inbound.handler.InboundRequest
 import se.laz.casual.jca.inbound.handler.InboundResponse
+import se.laz.casual.jca.inbound.handler.buffer.InboundRequestInfo
 import se.laz.casual.jca.inbound.handler.buffer.ServiceCallInfo
 import se.laz.casual.api.buffer.type.ServiceBuffer
 import spock.lang.Shared
@@ -83,7 +84,10 @@ class JavaServiceCallBufferHandlerTest extends Specification
         InboundRequest request = InboundRequest.of( methodName, buffer )
 
         when:
-        ServiceCallInfo info = instance.fromRequest( jndiObject, null, request )
+        InboundRequestInfo requestInfo = InboundRequestInfo.createBuilder()
+                .withProxy(jndiObject)
+                .build()
+        ServiceCallInfo info = instance.fromRequest(requestInfo, request)
 
         then:
         info.getMethod().get() == jndiObject.getClass().getMethod( methodName, String.class )
@@ -100,8 +104,12 @@ class JavaServiceCallBufferHandlerTest extends Specification
 
         InboundRequest request = InboundRequest.of( methodName, buffer )
 
+        InboundRequestInfo requestInfo = InboundRequestInfo.createBuilder()
+                .withProxy(jndiObject)
+                .build()
+
         when:
-        instance.fromRequest( jndiObject, null, request )
+        instance.fromRequest(requestInfo, request)
 
         then:
         thrown IllegalArgumentException
@@ -119,8 +127,12 @@ class JavaServiceCallBufferHandlerTest extends Specification
 
         InboundRequest request = InboundRequest.of( methodName, buffer )
 
+        InboundRequestInfo requestInfo = InboundRequestInfo.createBuilder()
+                .withProxy(jndiObject)
+                .build()
+
         when:
-        instance.fromRequest( jndiObject, null, request )
+        instance.fromRequest(requestInfo, request)
 
         then:
         thrown HandlerException

--- a/casual/casual-inbound-startup-trigger/build.gradle
+++ b/casual/casual-inbound-startup-trigger/build.gradle
@@ -18,8 +18,10 @@ dependencies {
   compileOnly libs.javaee_api
 
   // for spock
-  testImplementation libs.groovy_all
+  testImplementation platform(libs.groovy_bom)
+  testImplementation libs.groovy
+  testImplementation platform(libs.spock_bom)
   testImplementation libs.spock_core
-  testImplementation libs.cglib_nodep
+  testImplementation libs.byte_buddy
   testImplementation libs.objenesis
 }

--- a/casual/casual-inbound/build.gradle
+++ b/casual/casual-inbound/build.gradle
@@ -22,8 +22,10 @@ dependencies {
   testImplementation project(':casual:casual-network')
 
   // for spock
-  testImplementation libs.groovy_all
+  testImplementation platform(libs.groovy_bom)
+  testImplementation libs.groovy
+  testImplementation platform(libs.spock_bom)
   testImplementation libs.spock_core
-  testImplementation libs.cglib_nodep
+  testImplementation libs.byte_buddy
   testImplementation libs.objenesis
 }

--- a/casual/casual-internal/build.gradle
+++ b/casual/casual-internal/build.gradle
@@ -20,8 +20,10 @@ dependencies {
     testImplementation libs.javaee_api
 
     // for spock
-    testImplementation libs.groovy_all
+    testImplementation platform(libs.groovy_bom)
+    testImplementation libs.groovy
+    testImplementation platform(libs.spock_bom)
     testImplementation libs.spock_core
-    testImplementation libs.cglib_nodep
+    testImplementation libs.byte_buddy
     testImplementation libs.objenesis
 }

--- a/casual/casual-jca/build.gradle
+++ b/casual/casual-jca/build.gradle
@@ -52,9 +52,11 @@ dependencies {
     testImplementation libs.javaee_api
     testImplementation libs.hamcrest_all
     // for spock
-    testImplementation libs.groovy_all
+    testImplementation platform(libs.groovy_bom)
+    testImplementation libs.groovy
+    testImplementation platform(libs.spock_bom)
     testImplementation libs.spock_core
-    testImplementation libs.cglib_nodep
+    testImplementation libs.byte_buddy
     testImplementation libs.objenesis
 }
 

--- a/casual/casual-jca/src/test/groovy/se/laz/casual/jca/work/StartInboundServerWorkTest.groovy
+++ b/casual/casual-jca/src/test/groovy/se/laz/casual/jca/work/StartInboundServerWorkTest.groovy
@@ -171,7 +171,7 @@ class StartInboundServerWorkTest extends Specification
 
         registry.register( metaData )
 
-        return CasualServiceEntry.of( serviceName, "", null )
+        return CasualServiceEntry.of( serviceName, "", null, null )
     }
 
 }

--- a/casual/casual-network-protocol/build.gradle
+++ b/casual/casual-network-protocol/build.gradle
@@ -18,8 +18,10 @@ dependencies {
   api project(':casual:casual-api')
 
   // for spock
-  testImplementation libs.groovy_all
+  testImplementation platform(libs.groovy_bom)
+  testImplementation libs.groovy
+  testImplementation platform(libs.spock_bom)
   testImplementation libs.spock_core
-  testImplementation libs.cglib_nodep
+  testImplementation libs.byte_buddy
   testImplementation libs.objenesis
 }

--- a/casual/casual-network/build.gradle
+++ b/casual/casual-network/build.gradle
@@ -25,8 +25,10 @@ dependencies {
   testImplementation libs.netty_epoll
   testImplementation libs.system_lambda
   // for spock
-  testImplementation libs.groovy_all
+  testImplementation platform(libs.groovy_bom)
+  testImplementation libs.groovy
+  testImplementation platform(libs.spock_bom)
   testImplementation libs.spock_core
-  testImplementation libs.cglib_nodep
+  testImplementation libs.byte_buddy
   testImplementation libs.objenesis
 }

--- a/casual/casual-service-discovery-extension/build.gradle
+++ b/casual/casual-service-discovery-extension/build.gradle
@@ -16,8 +16,10 @@ dependencies {
   compileOnly libs.javaee_api
 
   // for spock
-  testImplementation libs.groovy_all
+  testImplementation platform(libs.groovy_bom)
+  testImplementation libs.groovy
+  testImplementation platform(libs.spock_bom)
   testImplementation libs.spock_core
-  testImplementation libs.cglib_nodep
+  testImplementation libs.byte_buddy
   testImplementation libs.objenesis
 }

--- a/casual/casual-service-discovery-extension/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/CasualServiceEntry.java
+++ b/casual/casual-service-discovery-extension/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/CasualServiceEntry.java
@@ -17,17 +17,19 @@ public final class CasualServiceEntry
     private final String serviceName;
     private final String jndiName;
     private Method proxyMethod;
+    private final CasualServiceMetaData metaData;
 
-    private CasualServiceEntry( String serviceName, String jndiName, Method proxyMethod )
+    private CasualServiceEntry( String serviceName, String jndiName, Method proxyMethod, CasualServiceMetaData metaData )
     {
         this.serviceName = serviceName;
         this.jndiName = jndiName;
         this.proxyMethod = proxyMethod;
+        this.metaData = metaData;
     }
 
-    public static CasualServiceEntry of( String serviceName, String jndiName, Method proxyMethod )
+    public static CasualServiceEntry of( String serviceName, String jndiName, Method proxyMethod, CasualServiceMetaData metaData )
     {
-        return new CasualServiceEntry( serviceName, jndiName, proxyMethod );
+        return new CasualServiceEntry( serviceName, jndiName, proxyMethod, metaData );
     }
 
     public String getServiceName()
@@ -45,7 +47,12 @@ public final class CasualServiceEntry
         return proxyMethod;
     }
 
-    public void setProxyMethod( Method proxyMethod )
+    public CasualServiceMetaData getMetaData()
+    {
+        return metaData;
+    }
+
+    public void setProxyMethod(Method proxyMethod )
     {
         this.proxyMethod = proxyMethod;
     }

--- a/casual/casual-service-discovery-extension/src/test/groovy/se/laz/casual/jca/inbound/handler/service/casual/CasualServiceEntryTest.groovy
+++ b/casual/casual-service-discovery-extension/src/test/groovy/se/laz/casual/jca/inbound/handler/service/casual/CasualServiceEntryTest.groovy
@@ -6,6 +6,7 @@
 
 package se.laz.casual.jca.inbound.handler.service.casual
 
+import se.laz.casual.api.service.CasualService
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -18,10 +19,15 @@ class CasualServiceEntryTest extends Specification
     @Shared String name = "test-service-name"
     @Shared String jndi = "java:global/app/ejb!interface"
     @Shared Method method = String.class.getMethod( "toString" )
+    @Shared CasualServiceMetaData metaData = CasualServiceMetaData.newBuilder()
+            .service(Mock(CasualService))
+            .implementationClass(String.class)
+            .serviceMethod(Object.class.getMethods()[0])
+            .build()
 
     def setup()
     {
-        instance = CasualServiceEntry.of( name, jndi, method )
+        instance = CasualServiceEntry.of( name, jndi, method, metaData )
     }
 
     def "Get service name"()
@@ -41,4 +47,11 @@ class CasualServiceEntryTest extends Specification
         expect:
         instance.getProxyMethod() == method
     }
+
+   def "Get metaData"()
+   {
+      expect:
+      instance.getMetaData() == metaData
+   }
+
 }

--- a/casual/casual-service-discovery-extension/src/test/groovy/se/laz/casual/jca/inbound/handler/service/casual/CasualServiceMetaDataTest.groovy
+++ b/casual/casual-service-discovery-extension/src/test/groovy/se/laz/casual/jca/inbound/handler/service/casual/CasualServiceMetaDataTest.groovy
@@ -28,6 +28,12 @@ class CasualServiceMetaDataTest extends Specification
     @Shared String serviceName = "service name"
     @Shared String category = "some category"
     @Shared Method method = String.class.getMethod( "toString" )
+    @Shared CasualServiceMetaData metaData = CasualServiceMetaData.newBuilder()
+            .service(Mock(CasualService))
+            .implementationClass(String.class)
+            .serviceMethod(Object.class.getMethods()[0])
+            .build()
+
 
     def setup()
     {
@@ -97,7 +103,7 @@ class CasualServiceMetaDataTest extends Specification
     def "Set resolved entry."()
     {
         given:
-        instance.setResolvedEntry( CasualServiceEntry.of( serviceName, jndiName, method ) )
+        instance.setResolvedEntry( CasualServiceEntry.of( serviceName, jndiName, method, metaData ) )
 
         expect:
         ! instance.isUnresolved()

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,10 +7,9 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-
 version = '2.2.23'
 
-def netty_version = '4.1.97.Final'
+def netty_version = '4.1.100.Final'
 def gson_version = '2.10.1'
 
 ext.libs = [
@@ -18,14 +17,17 @@ ext.libs = [
   netty_epoll: "io.netty:netty-transport-native-epoll:${netty_version}",
   javaee_api: 'javax:javaee-api:7.0',
   gson: "com.google.code.gson:gson:${gson_version}",
-  objenesis: 'org.objenesis:objenesis:2.6',
+  objenesis: 'org.objenesis:objenesis:3.3',
   microprofile_config: 'org.eclipse.microprofile.config:microprofile-config-api:1.4',
   // test
   hamcrest_all: 'org.hamcrest:hamcrest-all:1.3',
   commons_io: 'commons-io:commons-io:2.11.0',
   system_lambda: 'com.github.stefanbirkner:system-lambda:1.2.0',
   // for spock
-  groovy_all: 'org.codehaus.groovy:groovy-all:2.5+',
-  spock_core: 'org.spockframework:spock-core:1.3-groovy-2.5',
-  cglib_nodep: 'cglib:cglib-nodep:3.2.4',
+  groovy_bom: 'org.apache.groovy:groovy-bom:4.0.5',
+  groovy: 'org.apache.groovy:groovy',
+  spock_bom: 'org.spockframework:spock-bom:2.3-groovy-4.0',
+  spock_core: 'org.spockframework:spock-core',
+  spock_junit4: 'org.spockframework:spock-junit4',
+  byte_buddy: 'net.bytebuddy:byte-buddy:1.14.8'
 ]

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '2.2.23'
+version = '2.2.24'
 
 def netty_version = '4.1.100.Final'
 def gson_version = '2.10.1'


### PR DESCRIPTION
The real method needs to be available for buffer handlers since annotations may only exist there and not on the proxy method.
We also future proof the API by using a wrapper class for the inbound request info that can be further expanded upon when need be.
    
    Other changes:
      * spock, same changes as for 3.2
      * using bytebuddy instead of cglib since it gives better error messages when things go wrong
      * up version of netty to 4.1.100