### PR TITLE
do not run prepare, commit, rollback on netty threads

### DIFF
--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundExceptionHandler.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundExceptionHandler.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
+package se.laz.casual.network.inbound.reverse;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+import java.util.logging.Logger;
+
+public final class ReverseInboundExceptionHandler extends ChannelInboundHandlerAdapter
+{
+    private static final Logger log = Logger.getLogger(ReverseInboundExceptionHandler.class.getName());
+    public static ReverseInboundExceptionHandler of()
+    {
+        return new ReverseInboundExceptionHandler();
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)
+    {
+        log.warning(() -> "casual reverse inbound exception caught: " + cause + " closing channel");
+        ctx.close();
+    }
+}

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundMessageHandler.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundMessageHandler.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2024, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
+package se.laz.casual.network.inbound.reverse;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import se.laz.casual.api.network.protocol.messages.CasualNWMessage;
+import se.laz.casual.jca.inflow.CasualMessageListener;
+import se.laz.casual.network.protocol.messages.domain.CasualDomainConnectRequestMessage;
+import se.laz.casual.network.protocol.messages.domain.CasualDomainDiscoveryRequestMessage;
+import se.laz.casual.network.protocol.messages.service.CasualServiceCallRequestMessage;
+import se.laz.casual.network.protocol.messages.transaction.CasualTransactionResourceCommitRequestMessage;
+import se.laz.casual.network.protocol.messages.transaction.CasualTransactionResourcePrepareRequestMessage;
+import se.laz.casual.network.protocol.messages.transaction.CasualTransactionResourceRollbackRequestMessage;
+
+import javax.resource.spi.XATerminator;
+import javax.resource.spi.endpoint.MessageEndpoint;
+import javax.resource.spi.endpoint.MessageEndpointFactory;
+import javax.resource.spi.work.WorkManager;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.logging.Logger;
+
+public final class ReverseInboundMessageHandler extends SimpleChannelInboundHandler<CasualNWMessage<?>>
+{
+    private static Logger log = Logger.getLogger(ReverseInboundMessageHandler.class.getName());
+    private static final ExecutorService executor = Executors.newCachedThreadPool();
+    private final MessageEndpointFactory factory;
+    private final XATerminator xaTerminator;
+    private final WorkManager workManager;
+
+    private ReverseInboundMessageHandler(MessageEndpointFactory factory, XATerminator xaTerminator, WorkManager workManager)
+    {
+        this.factory = factory;
+        this.xaTerminator = xaTerminator;
+        this.workManager = workManager;
+    }
+
+    public static ReverseInboundMessageHandler of(final MessageEndpointFactory factory, final XATerminator xaTerminator, final WorkManager workManager)
+    {
+        Objects.requireNonNull(factory, "factory can not be null");
+        Objects.requireNonNull(xaTerminator, "xaTerminator can not be null");
+        Objects.requireNonNull(workManager, "workManager can not be null");
+        return new ReverseInboundMessageHandler(factory, xaTerminator, workManager);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, CasualNWMessage<?> message) throws Exception
+    {
+        MessageEndpoint endpoint = factory.createEndpoint(null);
+        CasualMessageListener listener = (CasualMessageListener) endpoint;
+        switch ( message.getType() )
+        {
+            case COMMIT_REQUEST:
+                executor.execute(() -> listener.commitRequest((CasualNWMessage<CasualTransactionResourceCommitRequestMessage>)message, ctx.channel(), xaTerminator));
+                break;
+            case PREPARE_REQUEST:
+                executor.execute(() -> listener.prepareRequest((CasualNWMessage<CasualTransactionResourcePrepareRequestMessage>)message, ctx.channel(), xaTerminator));
+                break;
+            case REQUEST_ROLLBACK:
+                executor.execute(() -> listener.requestRollback((CasualNWMessage<CasualTransactionResourceRollbackRequestMessage>)message, ctx.channel(), xaTerminator));
+                break;
+            case SERVICE_CALL_REQUEST:
+                listener.serviceCallRequest((CasualNWMessage<CasualServiceCallRequestMessage>)message, ctx.channel(), workManager);
+                break;
+            case DOMAIN_CONNECT_REQUEST:
+                listener.domainConnectRequest((CasualNWMessage<CasualDomainConnectRequestMessage>)message, ctx.channel());
+                break;
+            case DOMAIN_DISCOVERY_REQUEST:
+                listener.domainDiscoveryRequest((CasualNWMessage<CasualDomainDiscoveryRequestMessage>)message, ctx.channel());
+                break;
+            default:
+                log.warning("Message type not supported: " + message.getType());
+        }
+    }
+
+}

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,9 +7,9 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '2.2.27'
+version = '2.2.28'
 
-def netty_version = '4.1.106.Final'
+def netty_version = '4.1.107.Final'
 def gson_version = '2.10.1'
 
 ext.libs = [


### PR DESCRIPTION
Reverse inbound is in fact a client and as such we do not want prepare/commit/rollback to run on any of nettys networking threads. This is especially true since in fact an inbound prepare can result in an oubound prepare call via CasualXAResource, that then blocks that thread until an answer is received.

All of the operations are expected to be short running as they are not service calls, service calls stil run on the supplied work manager.