### PR TITLE
work rework, do not block service calls

### DIFF
--- a/casual/casual-inbound/src/test/groovy/se/laz/casual/jca/inflow/CasualMessageListenerImplTest.groovy
+++ b/casual/casual-inbound/src/test/groovy/se/laz/casual/jca/inflow/CasualMessageListenerImplTest.groovy
@@ -7,7 +7,13 @@
 package se.laz.casual.jca.inflow
 
 import io.netty.channel.embedded.EmbeddedChannel
+import jakarta.resource.spi.XATerminator
+import jakarta.resource.spi.work.ExecutionContext
+import jakarta.resource.spi.work.WorkException
+import jakarta.resource.spi.work.WorkListener
+import jakarta.resource.spi.work.WorkManager
 import se.laz.casual.api.buffer.type.JsonBuffer
+import se.laz.casual.api.buffer.type.ServiceBuffer
 import se.laz.casual.api.flags.AtmiFlags
 import se.laz.casual.api.flags.Flag
 import se.laz.casual.api.flags.XAFlags
@@ -17,8 +23,8 @@ import se.laz.casual.api.service.CasualService
 import se.laz.casual.api.xa.XAReturnCode
 import se.laz.casual.api.xa.XID
 import se.laz.casual.config.ConfigurationService
-import se.laz.casual.jca.CasualResourceAdapterException
 import se.laz.casual.config.Domain
+import se.laz.casual.jca.CasualResourceAdapterException
 import se.laz.casual.jca.inbound.handler.service.casual.CasualServiceMetaData
 import se.laz.casual.jca.inbound.handler.service.casual.CasualServiceRegistry
 import se.laz.casual.jca.inflow.work.CasualServiceCallWork
@@ -28,16 +34,10 @@ import se.laz.casual.network.messages.domain.TransactionType
 import se.laz.casual.network.protocol.messages.CasualNWMessageImpl
 import se.laz.casual.network.protocol.messages.domain.*
 import se.laz.casual.network.protocol.messages.service.CasualServiceCallRequestMessage
-import se.laz.casual.api.buffer.type.ServiceBuffer
 import se.laz.casual.network.protocol.messages.transaction.*
 import spock.lang.Shared
 import spock.lang.Specification
 
-import jakarta.resource.spi.XATerminator
-import jakarta.resource.spi.work.ExecutionContext
-import jakarta.resource.spi.work.WorkException
-import jakarta.resource.spi.work.WorkListener
-import jakarta.resource.spi.work.WorkManager
 import javax.transaction.xa.XAException
 import javax.transaction.xa.Xid
 import java.lang.annotation.Annotation
@@ -261,7 +261,7 @@ class CasualMessageListenerImplTest extends Specification
        actualStartTimeout != null
        actualStartTimeout == WorkManager.INDEFINITE
        actualExecutionContext == null
-       actualWorkListener == null
+       actualWorkListener != null
     }
 
     def "ServiceCallRequest TPNOREPLY, transactional - out of protocol, call will be issued but non transactional"()
@@ -303,7 +303,7 @@ class CasualMessageListenerImplTest extends Specification
        actualStartTimeout != null
        actualStartTimeout == WorkManager.INDEFINITE
        actualExecutionContext == null
-       actualWorkListener == null
+       actualWorkListener != null
     }
 
     def "ServiceCallRequest startWork throws exception, wrapped and thrown."()


### PR DESCRIPTION
Note, this is another branch that could go into the metric events branch if the changes are sufficient.
Created a new branch for these changes since they are rather large so that we can discuss it here more than anything else.

Things to ponder:
Why do we not use the async version since the only benefit now is a ms time that we get back, which can be -1, and we log that one.
Otherwise, we just block the calling thread for no reason.

Re pending:
https://docs.oracle.com/javaee/7/api/javax/resource/spi/work/WorkListener.html#workAccepted-javax.resource.spi.work.WorkEvent-
void workAccepted(WorkEvent e)
Invoked when a Work instance has been accepted.
Ok, so not useful
void workStarted(WorkEvent e)
Invoked when a Work instance has started execution. This only means that a thread has been allocated.
Also means that it's not exactly before the actual service call.
We do however have that point in the actual work, right before we make the call
Then it's when we should have the end time, afer the call or in WorkCompleted ( which will be some time later on)
Two things there, pending and start/end time for the actual call - if that also should be removed from the work task itself

The thread that gets block currently, both for normal inbound and reverse for a service call, is a netty thread.
I can't see a reason why not use the async version?

Then for inbound we really need to fix the exception handling black hole and also take care if there is no response when we expect a response:
https://github.com/casualcore/casual-java/issues/96 - however, that should be in a separate feature since it also needs to go into 2.2.

Another thing, there is no issue for this yet but - in case we get a WorkException when dispatching the actual work - as far as I can see, that is not handled at all?