### PR TITLE
Feature/3.2/metrics events/builder timer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ subprojects{
   }
 
   test{
-    jvmArgs '--add-opens=java.base/java.util=ALL-UNNAMED'
+    jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED', '--add-opens=java.base/java.util=ALL-UNNAMED'
   }
 }
 

--- a/casual/casual-event-api/src/main/java/se/laz/casual/event/ServiceCallEvent.java
+++ b/casual/casual-event-api/src/main/java/se/laz/casual/event/ServiceCallEvent.java
@@ -10,7 +10,6 @@ import se.laz.casual.api.util.PrettyPrinter;
 
 import javax.transaction.xa.Xid;
 import java.time.Instant;
-import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 import java.util.Optional;
@@ -140,22 +139,9 @@ public class ServiceCallEvent
             return this;
         }
 
-        public Builder withStart(Instant start)
-        {
-            this.started = start;
-            return this;
-        }
-
         public Builder start( )
         {
             this.started = Instant.now();
-            return this;
-        }
-
-        public Builder withEnd(Instant end)
-        {
-            Objects.requireNonNull(end, "end can not be null");
-            this.ended = end;
             return this;
         }
 

--- a/casual/casual-event-api/src/main/java/se/laz/casual/event/ServiceCallEvent.java
+++ b/casual/casual-event-api/src/main/java/se/laz/casual/event/ServiceCallEvent.java
@@ -109,8 +109,8 @@ public class ServiceCallEvent
         private Long end;
 
         private Instant created = Instant.now();
-        private Instant started = Instant.now();
-        private Instant ended = Instant.now();
+        private Instant started;
+        private Instant ended;
         private Long pending;
         private ErrorState code;
         private Order order;
@@ -184,8 +184,8 @@ public class ServiceCallEvent
             Objects.requireNonNull(code, "code can not be null");
             Objects.requireNonNull(order, "order can not be null");
 
-            Objects.requireNonNull( started, "start cannot be null" );
-            Objects.requireNonNull(ended, "end cannot be null" );
+            Objects.requireNonNull( started, "start cannot be null, you must call start()." );
+            Objects.requireNonNull(ended, "end cannot be null, you must call end()." );
 
             if( pending == null )
             {

--- a/casual/casual-event-api/src/main/java/se/laz/casual/event/ServiceCallEvent.java
+++ b/casual/casual-event-api/src/main/java/se/laz/casual/event/ServiceCallEvent.java
@@ -10,6 +10,7 @@ import se.laz.casual.api.util.PrettyPrinter;
 
 import javax.transaction.xa.Xid;
 import java.time.Instant;
+import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 import java.util.Optional;
@@ -105,9 +106,13 @@ public class ServiceCallEvent
         private long pid = Process.pid();
         private UUID execution;
         private Xid transactionId;
-        private long start;
-        private long end;
-        private long pending;
+        private Long start;
+        private Long end;
+
+        private Instant created = Instant.now();
+        private Instant started = Instant.now();
+        private Instant ended = Instant.now();
+        private Long pending;
         private ErrorState code;
         private Order order;
 
@@ -137,24 +142,26 @@ public class ServiceCallEvent
 
         public Builder withStart(Instant start)
         {
-            Objects.requireNonNull(start, "start can not be null");
-            // from ChronoUnit.between:
-            // Implementations should perform any queries or calculations using the units available in ChronoUnit
-            // or the fields available in ChronoField.
-            // If the unit is not supported an UnsupportedTemporalTypeException must be thrown.
-            // Implementations must not alter the specified temporal objects.
-            //
-            // On the platform what we currently support, this is not a problem
-            // We also do not know of any platform where this does not work
-            // The same goes for end below
-            this.start = ChronoUnit.MICROS.between(Instant.EPOCH, start);
+            this.started = start;
+            return this;
+        }
+
+        public Builder start( )
+        {
+            this.started = Instant.now();
             return this;
         }
 
         public Builder withEnd(Instant end)
         {
             Objects.requireNonNull(end, "end can not be null");
-            this.end = ChronoUnit.MICROS.between(Instant.EPOCH, end);
+            this.ended = end;
+            return this;
+        }
+
+        public Builder end( )
+        {
+            this.ended = Instant.now();
             return this;
         }
 
@@ -190,9 +197,38 @@ public class ServiceCallEvent
             Objects.requireNonNull(transactionId, "transactionId can not be null");
             Objects.requireNonNull(code, "code can not be null");
             Objects.requireNonNull(order, "order can not be null");
+
+            Objects.requireNonNull( started, "start cannot be null" );
+            Objects.requireNonNull(ended, "end cannot be null" );
+
+            if( pending == null )
+            {
+                pending = toDurationMicro( created, started );
+            }
+            start = toEpochMicro( started );
+            end = toEpochMicro( ended );
+
             return new ServiceCallEvent(this);
         }
 
+        private long toEpochMicro( Instant instant )
+        {
+            return toDurationMicro(Instant.EPOCH, instant);
+        }
+
+        private long toDurationMicro( Instant start, Instant end )
+        {
+            // from ChronoUnit.between:
+            // Implementations should perform any queries or calculations using the units available in ChronoUnit
+            // or the fields available in ChronoField.
+            // If the unit is not supported an UnsupportedTemporalTypeException must be thrown.
+            // Implementations must not alter the specified temporal objects.
+            //
+            // On the platform what we currently support, this is not a problem
+            // We also do not know of any platform where this does not work
+            // The same goes for end below
+            return ChronoUnit.MICROS.between(start, end);
+        }
     }
 
     @Override

--- a/casual/casual-event-api/src/test/groovy/se/laz/casual/event/ServiceCallEventTest.groovy
+++ b/casual/casual-event-api/src/test/groovy/se/laz/casual/event/ServiceCallEventTest.groovy
@@ -30,48 +30,69 @@ class ServiceCallEventTest extends Specification
    def secondStart = Instant.now()
    def firstEnd = Instant.now()
    def secondEnd = Instant.now()
-   def firstPending = 0
+   def firstPending = 3
    def secondPending = 14
    def firstCode = ErrorState.OK
    def secondCode = ErrorState.TPENOENT
    def firstOrder = Order.SEQUENTIAL
    def secondOrder = Order.CONCURRENT
-    
-   def 'identity'()
+
+   def "Create then get."()
    {
       given:
+      ServiceCallEvent instance
+      Instant beforeStart
+      Instant afterStart
+      Instant beforeEnd
+      Instant afterEnd
 
+      when:
+      ServiceCallEvent.Builder builder = ServiceCallEvent.createBuilder(  )
+              .withService(firstService)
+              .withParent(firstParent)
+              .withPID(firstPID)
+              .withExecution(firstExecution)
+              .withTransactionId(firstTransactionId)
+              .withPending( firstPending )
+      beforeStart = Instant.now()
+      builder.start()
+      afterStart = Instant.now()
+      beforeEnd = afterStart
+      builder.withCode(firstCode)
+              .withOrder(firstOrder)
+              .end()
+      afterEnd = Instant.now()
+      instance = builder.build()
+
+      then:
+      instance.getService() == firstService
+      instance.getParent().get() == firstParent
+      instance.getPid() == firstPID
+      instance.getExecution() == PrettyPrinter.casualStringify(firstExecution)
+      instance.getTransactionId() == PrettyPrinter.casualStringify(firstTransactionId)
+      instance.getCode() == firstCode.name()
+      instance.getOrder() == firstOrder.getValue()
+
+      instance.getPending() == firstPending
+
+      instance.getStart() >= ChronoUnit.MICROS.between(Instant.EPOCH, beforeStart)
+      instance.getStart() <= ChronoUnit.MICROS.between(Instant.EPOCH, afterStart)
+      instance.getEnd() >= ChronoUnit.MICROS.between(Instant.EPOCH, beforeEnd)
+      instance.getEnd() <= ChronoUnit.MICROS.between(Instant.EPOCH, afterEnd)
+   }
+
+   def 'identity'()
+   {
       when:
       ServiceCallEvent firstEntry = createEntry([service: firstService, parent: firstParent, pid: firstPID, execution: firstExecution, transactionId: firstTransactionId, start: firstStart, end: firstEnd, pending: firstPending, code: firstCode, order: firstOrder])
       ServiceCallEvent secondEntry = createEntry([service: secondService, parent: secondParent, pid: secondPID, execution: secondExecution, transactionId: secondTransactionId, start: secondStart, end: secondEnd, pending: secondPending, code: secondCode, order: secondOrder])
+
       then:
       firstEntry == firstEntry
       firstEntry != secondEntry
 
       firstEntry.hashCode() == firstEntry.hashCode()
       firstEntry.hashCode() != secondEntry.hashCode()
-
-      firstEntry.getService() == firstService
-      firstEntry.getParent().get() == firstParent
-      firstEntry.getPid() == firstPID
-      firstEntry.getExecution() == PrettyPrinter.casualStringify(firstExecution)
-      firstEntry.getTransactionId() == PrettyPrinter.casualStringify(firstTransactionId)
-      firstEntry.getStart() == ChronoUnit.MICROS.between(Instant.EPOCH, firstStart)
-      firstEntry.getEnd() == ChronoUnit.MICROS.between(Instant.EPOCH, firstEnd)
-      firstEntry.getPending() == firstPending
-      firstEntry.getCode() == firstCode.name()
-      firstEntry.getOrder() == firstOrder.getValue()
-
-      secondEntry.getService() == secondService
-      secondEntry.getParent().get() == secondParent
-      secondEntry.getPid() == secondPID
-      secondEntry.getExecution() == PrettyPrinter.casualStringify(secondExecution)
-      secondEntry.getTransactionId() == PrettyPrinter.casualStringify(secondTransactionId)
-      secondEntry.getStart() == ChronoUnit.MICROS.between(Instant.EPOCH, secondStart)
-      secondEntry.getEnd() == ChronoUnit.MICROS.between(Instant.EPOCH, secondEnd)
-      secondEntry.getPending() == secondPending
-      secondEntry.getCode() == secondCode.name()
-      secondEntry.getOrder() == secondOrder.getValue()
    }
 
    def createEntry(data)
@@ -82,15 +103,15 @@ class ServiceCallEventTest extends Specification
               .withPID(data.pid)
               .withExecution(data.execution)
               .withTransactionId(data.transactionId)
-              .withStart(data.start)
-              .withEnd(data.end)
+              .start()
+              .end()
               .withPending(data.pending)
               .withCode(data.code)
               .withOrder(data.order)
               .build()
    }
 
-   def "Create event without caller explicitly using Instant."()
+   def "Create event with small pauses."()
    {
       given:
       ServiceCallEvent.Builder builder = ServiceCallEvent.createBuilder(  )

--- a/casual/casual-event-api/src/test/groovy/se/laz/casual/event/ServiceCallEventTest.groovy
+++ b/casual/casual-event-api/src/test/groovy/se/laz/casual/event/ServiceCallEventTest.groovy
@@ -8,7 +8,9 @@ import se.laz.casual.api.flags.ErrorState
 import se.laz.casual.api.util.PrettyPrinter
 import se.laz.casual.event.Order
 import se.laz.casual.event.ServiceCallEvent
+import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.Unroll
 
 import javax.transaction.xa.Xid
 import java.time.Instant
@@ -16,26 +18,22 @@ import java.time.temporal.ChronoUnit
 
 class ServiceCallEventTest extends Specification
 {
-   def firstService = 'Service One'
-   def secondService = 'Service Two'
-   def firstParent = 'Elvira'
-   def secondParent = 'Elvis'
-   def firstExecution = UUID.randomUUID()
-   def secondExecution = UUID.randomUUID()
-   def firstPID = 128
-   def secondPID = 256
-   def firstTransactionId = Mock(Xid)
-   def secondTransactionId = Mock(Xid)
-   def firstStart = Instant.now()
-   def secondStart = Instant.now()
-   def firstEnd = Instant.now()
-   def secondEnd = Instant.now()
-   def firstPending = 3
-   def secondPending = 14
-   def firstCode = ErrorState.OK
-   def secondCode = ErrorState.TPENOENT
-   def firstOrder = Order.SEQUENTIAL
-   def secondOrder = Order.CONCURRENT
+   @Shared def service1 = 'Service One'
+   @Shared def service2 = 'Service Two'
+   @Shared def parent1 = 'Elvira'
+   @Shared def parent2 = 'Elvis'
+   @Shared def execution1 = UUID.randomUUID()
+   @Shared def execution2 = UUID.randomUUID()
+   @Shared def pid1 = 128
+   @Shared def pid2 = 256
+   @Shared def transactionId1 = Mock(Xid)
+   @Shared def transactionId2 = Mock(Xid)
+   @Shared def pending1 = 3
+   @Shared def pending2 = 14
+   @Shared def code1 = ErrorState.OK
+   @Shared def code2 = ErrorState.TPENOENT
+   @Shared def order1 = Order.SEQUENTIAL
+   @Shared def order2 = Order.CONCURRENT
 
    def "Create then get."()
    {
@@ -48,32 +46,32 @@ class ServiceCallEventTest extends Specification
 
       when:
       ServiceCallEvent.Builder builder = ServiceCallEvent.createBuilder(  )
-              .withService(firstService)
-              .withParent(firstParent)
-              .withPID(firstPID)
-              .withExecution(firstExecution)
-              .withTransactionId(firstTransactionId)
-              .withPending( firstPending )
+              .withService(service1)
+              .withParent(parent1)
+              .withPID(pid1)
+              .withExecution(execution1)
+              .withTransactionId(transactionId1)
+              .withPending( pending1 )
       beforeStart = Instant.now()
       builder.start()
       afterStart = Instant.now()
       beforeEnd = afterStart
-      builder.withCode(firstCode)
-              .withOrder(firstOrder)
+      builder.withCode(code1)
+              .withOrder(order1)
               .end()
       afterEnd = Instant.now()
       instance = builder.build()
 
       then:
-      instance.getService() == firstService
-      instance.getParent().get() == firstParent
-      instance.getPid() == firstPID
-      instance.getExecution() == PrettyPrinter.casualStringify(firstExecution)
-      instance.getTransactionId() == PrettyPrinter.casualStringify(firstTransactionId)
-      instance.getCode() == firstCode.name()
-      instance.getOrder() == firstOrder.getValue()
+      instance.getService() == service1
+      instance.getParent().get() == parent1
+      instance.getPid() == pid1
+      instance.getExecution() == PrettyPrinter.casualStringify(execution1)
+      instance.getTransactionId() == PrettyPrinter.casualStringify(transactionId1)
+      instance.getCode() == code1.name()
+      instance.getOrder() == order1.getValue()
 
-      instance.getPending() == firstPending
+      instance.getPending() == pending1
 
       instance.getStart() >= ChronoUnit.MICROS.between(Instant.EPOCH, beforeStart)
       instance.getStart() <= ChronoUnit.MICROS.between(Instant.EPOCH, afterStart)
@@ -81,11 +79,49 @@ class ServiceCallEventTest extends Specification
       instance.getEnd() <= ChronoUnit.MICROS.between(Instant.EPOCH, afterEnd)
    }
 
+   @Unroll
+   def "Build, null checks"()
+   {
+      given:
+      ServiceCallEvent.Builder builder = ServiceCallEvent.createBuilder(  )
+              .withService(service)
+              .withParent(parent)
+              .withExecution(execution)
+              .withTransactionId(transaction)
+              .withCode(code)
+              .withOrder(order)
+      if( start )
+      {
+         builder.start()
+      }
+      if( end )
+      {
+         builder.end()
+      }
+
+      when:
+      builder.build()
+
+      then:
+      thrown NullPointerException
+
+      where:
+      service  | parent  | execution  | transaction    | start | end   | code  | order
+      null     | parent1 | execution1 | transactionId1 | true  | true  | code1 | order1
+      service1 | null    | execution1 | transactionId1 | true  | true  | code1 | order1
+      service1 | parent1 | null       | transactionId1 | true  | true  | code1 | order1
+      service1 | parent1 | execution1 | null           | true  | true  | code1 | order1
+      service1 | parent1 | execution1 | transactionId1 | false | true  | code1 | order1
+      service1 | parent1 | execution1 | transactionId1 | true  | false | code1 | order1
+      service1 | parent1 | execution1 | transactionId1 | true  | true  | null  | order1
+      service1 | parent1 | execution1 | transactionId1 | true  | true  | code1 | null
+   }
+
    def 'identity'()
    {
       when:
-      ServiceCallEvent firstEntry = createEntry([service: firstService, parent: firstParent, pid: firstPID, execution: firstExecution, transactionId: firstTransactionId, start: firstStart, end: firstEnd, pending: firstPending, code: firstCode, order: firstOrder])
-      ServiceCallEvent secondEntry = createEntry([service: secondService, parent: secondParent, pid: secondPID, execution: secondExecution, transactionId: secondTransactionId, start: secondStart, end: secondEnd, pending: secondPending, code: secondCode, order: secondOrder])
+      ServiceCallEvent firstEntry = createEntry([service: service1, parent: parent1, pid: pid1, execution: execution1, transactionId: transactionId1, pending: pending1, code: code1, order: order1])
+      ServiceCallEvent secondEntry = createEntry([service: service2, parent: parent2, pid: pid2, execution: execution2, transactionId: transactionId2, pending: pending2, code: code2, order: order2])
 
       then:
       firstEntry == firstEntry
@@ -115,17 +151,17 @@ class ServiceCallEventTest extends Specification
    {
       given:
       ServiceCallEvent.Builder builder = ServiceCallEvent.createBuilder(  )
-              .withService(firstService)
-              .withParent(firstParent)
-              .withPID(firstPID)
-              .withExecution(firstExecution)
-              .withTransactionId(firstTransactionId)
-              .withOrder(firstOrder)
+              .withService(service1)
+              .withParent(parent1)
+              .withPID(pid1)
+              .withExecution(execution1)
+              .withTransactionId(transactionId1)
+              .withOrder(order1)
 
       when:
       Thread.sleep( 1 )
       builder.start(  )
-      builder.withCode( firstCode )
+      builder.withCode( code1 )
       Thread.sleep( 1 )
       builder.end( )
       ServiceCallEvent instance = builder.build(  )

--- a/casual/casual-event-api/src/test/groovy/se/laz/casual/event/ServiceCallEventTest.groovy
+++ b/casual/casual-event-api/src/test/groovy/se/laz/casual/event/ServiceCallEventTest.groovy
@@ -89,4 +89,28 @@ class ServiceCallEventTest extends Specification
               .withOrder(data.order)
               .build()
    }
+
+   def "Create event without caller explicitly using Instant."()
+   {
+      given:
+      ServiceCallEvent.Builder builder = ServiceCallEvent.createBuilder(  )
+              .withService(firstService)
+              .withParent(firstParent)
+              .withPID(firstPID)
+              .withExecution(firstExecution)
+              .withTransactionId(firstTransactionId)
+              .withOrder(firstOrder)
+
+      when:
+      Thread.sleep( 1 )
+      builder.start(  )
+      builder.withCode( firstCode )
+      Thread.sleep( 1 )
+      builder.end( )
+      ServiceCallEvent instance = builder.build(  )
+
+      then:
+      instance.getPending(  ) >= 1000
+      instance.getStart(  ) < instance.getEnd(  )
+   }
 }

--- a/casual/casual-event-server/src/test/groovy/se/laz/casual/event/server/EventMessageEncoderTest.groovy
+++ b/casual/casual-event-server/src/test/groovy/se/laz/casual/event/server/EventMessageEncoderTest.groovy
@@ -33,6 +33,8 @@ class EventMessageEncoderTest extends Specification
               .withPID(42)
               .withService('nice service')
               .withTransactionId(transactionId)
+              .start()
+              .end()
               .build()
       def asJsonBytes =  JsonProviderFactory.getJsonProvider().toJson(msg).getBytes(StandardCharsets.UTF_8)
       ByteBuf out = Mock(ByteBuf){

--- a/casual/casual-inbound/src/main/java/se/laz/casual/jca/inflow/ServiceCallWorkListener.java
+++ b/casual/casual-inbound/src/main/java/se/laz/casual/jca/inflow/ServiceCallWorkListener.java
@@ -20,7 +20,6 @@ import se.laz.casual.network.protocol.messages.service.CasualServiceCallReplyMes
 import se.laz.casual.network.protocol.messages.service.CasualServiceCallRequestMessage;
 
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 
 /**
  * Work Listener to handle completion of {@link jakarta.resource.spi.work.Work} item by

--- a/casual/casual-inbound/src/main/java/se/laz/casual/jca/inflow/ServiceCallWorkListener.java
+++ b/casual/casual-inbound/src/main/java/se/laz/casual/jca/inflow/ServiceCallWorkListener.java
@@ -19,8 +19,6 @@ import se.laz.casual.jca.inflow.work.CasualServiceCallWork;
 import se.laz.casual.network.protocol.messages.service.CasualServiceCallReplyMessage;
 import se.laz.casual.network.protocol.messages.service.CasualServiceCallRequestMessage;
 
-import java.time.Instant;
-
 /**
  * Work Listener to handle completion of {@link jakarta.resource.spi.work.Work} item by
  * {@link jakarta.resource.spi.work.WorkManager} to flush the response to the netty {@link Channel}.
@@ -30,7 +28,6 @@ public class ServiceCallWorkListener implements WorkListener
     private final Channel channel;
     private final boolean isTpNoReply;
     private final CasualServiceCallRequestMessage message;
-    private Instant sometimeBeforeServiceCall;
     private ServiceCallEventPublisher eventPublisher;
 
     private final ServiceCallEvent.Builder eventBuilder;

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/service/CasualServiceCaller.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/service/CasualServiceCaller.java
@@ -111,8 +111,7 @@ public class CasualServiceCaller implements CasualServiceApi
                             }
                             LOG.finest(() -> "service call request ok for corrid: " + PrettyPrinter.casualStringify(corrId) + SERVICE_NAME_LITERAL + serviceName);
                     eventBuilder.withCode(v.getMessage().getError())
-                            .end()
-                            .build();
+                            .end();
                             getEventPublisher().post(eventBuilder.build());
                     if(!f.isDone())
                     {
@@ -122,8 +121,7 @@ public class CasualServiceCaller implements CasualServiceApi
         if(noReply)
         {
             eventBuilder.withCode(ErrorState.OK)
-                     .end()
-                     .build();
+                     .end();
             getEventPublisher().post(eventBuilder.build());
             f.complete(Optional.empty());
         }


### PR DESCRIPTION
Changed ServiceCallEvent builder to implement timer functionality to remove need for working with Instant objects inside the calling code.
Simplified usage of builder in work listener and removed duplication in caller.
Added fix for issue with module access on windows for using system lambda.