### PR TITLE
Feature/3.2/event service testability

### DIFF
--- a/casual/casual-api/src/main/java/se/laz/casual/api/util/time/InstantUtil.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/util/time/InstantUtil.java
@@ -6,6 +6,7 @@
 package se.laz.casual.api.util.time;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -25,5 +26,24 @@ public final class InstantUtil
     public static Instant fromNanos(long nanos)
     {
         return Instant.ofEpochSecond( 0L, nanos);
+    }
+
+    public static long toEpochMicro( Instant instant )
+    {
+        return toDurationMicro(Instant.EPOCH, instant);
+    }
+
+    public static long toDurationMicro( Instant start, Instant end )
+    {
+        // from ChronoUnit.between:
+        // Implementations should perform any queries or calculations using the units available in ChronoUnit
+        // or the fields available in ChronoField.
+        // If the unit is not supported an UnsupportedTemporalTypeException must be thrown.
+        // Implementations must not alter the specified temporal objects.
+        //
+        // On the platform what we currently support, this is not a problem
+        // We also do not know of any platform where this does not work
+        // The same goes for end below
+        return ChronoUnit.MICROS.between(start, end);
     }
 }

--- a/casual/casual-api/src/main/java/se/laz/casual/api/util/time/InstantUtil.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/util/time/InstantUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2019, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */

--- a/casual/casual-api/src/main/java/se/laz/casual/config/Configuration.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/config/Configuration.java
@@ -78,10 +78,11 @@ public class Configuration
     public String toString()
     {
         return "Configuration{" +
-                "inbound=" + getInbound() +
-                ", domain=" + getDomain() +
-                ", outbound=" + getOutbound() +
-                ", reverseInbound=" + getReverseInbound() +
+                "inbound=" + inbound +
+                ", domain=" + domain +
+                ", outbound=" + outbound +
+                ", reverseInbound=" + reverseInbound +
+                ", eventServer=" + eventServer +
                 '}';
     }
 

--- a/casual/casual-api/src/main/java/se/laz/casual/config/Configuration.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/config/Configuration.java
@@ -78,11 +78,11 @@ public class Configuration
     public String toString()
     {
         return "Configuration{" +
-                "inbound=" + inbound +
-                ", domain=" + domain +
-                ", outbound=" + outbound +
-                ", reverseInbound=" + reverseInbound +
-                ", eventServer=" + eventServer +
+                "inbound=" + getInbound() +
+                ", domain=" + getDomain() +
+                ", outbound=" + getOutbound() +
+                ", reverseInbound=" + getReverseInbound() +
+                ", eventServer=" + getEventServer() +
                 '}';
     }
 

--- a/casual/casual-api/src/main/java/se/laz/casual/config/EventServer.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/config/EventServer.java
@@ -11,11 +11,13 @@ public final class EventServer
 {
     private final int portNumber;
     private final boolean useEpoll;
+    private final Shutdown shutdown;
 
     private EventServer(Builder builder)
     {
-        portNumber = builder.portNumber;
-        useEpoll = builder.useEpoll;
+        this.portNumber = builder.portNumber;
+        this.useEpoll = builder.useEpoll;
+        this.shutdown = builder.shutdown;
     }
 
     public int getPortNumber()
@@ -28,25 +30,30 @@ public final class EventServer
         return useEpoll;
     }
 
-    @Override
-    public boolean equals(Object o)
+    public Shutdown getShutdown()
     {
-        if (this == o)
+        return shutdown == null ? Shutdown.newBuilder().build() : shutdown;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if( this == o )
         {
             return true;
         }
-        if (o == null || getClass() != o.getClass())
+        if( o == null || getClass() != o.getClass() )
         {
             return false;
         }
         EventServer that = (EventServer) o;
-        return getPortNumber() == that.getPortNumber() && isUseEpoll() == that.isUseEpoll();
+        return getPortNumber() == that.getPortNumber() && isUseEpoll() == that.isUseEpoll() && Objects.equals( getShutdown(), that.getShutdown() );
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(getPortNumber(), isUseEpoll());
+        return Objects.hash( getPortNumber(), isUseEpoll(), getShutdown() );
     }
 
     @Override
@@ -55,6 +62,7 @@ public final class EventServer
         return "EventServer{" +
                 "portNumber=" + portNumber +
                 ", useEpoll=" + useEpoll +
+                ", shutdown=" + shutdown +
                 '}';
     }
 
@@ -67,6 +75,7 @@ public final class EventServer
     {
         private int portNumber = 7698;
         private boolean useEpoll;
+        private Shutdown shutdown;
 
         private Builder()
         {}
@@ -85,6 +94,12 @@ public final class EventServer
         public Builder withUseEpoll(boolean useEpoll)
         {
             this.useEpoll = useEpoll;
+            return this;
+        }
+
+        public Builder withShutdown( Shutdown shutdown )
+        {
+            this.shutdown = shutdown;
             return this;
         }
 

--- a/casual/casual-api/src/main/java/se/laz/casual/config/Shutdown.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/config/Shutdown.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, The casual project. All rights reserved.
+ * Copyright (c) 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */

--- a/casual/casual-api/src/main/java/se/laz/casual/config/Shutdown.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/config/Shutdown.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2021, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
+package se.laz.casual.config;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class Shutdown
+{
+    public static final String CASUAL_EVENT_SERVER_SHUTDOWN_QUIET_PERIOD_MILLIS_ENV_NAME = "CASUAL_EVENT_SERVER_SHUTDOWN_QUIET_PERIOD_MILLIS";
+    public static final String CASUAL_EVENT_SERVER_SHUTDOWN_TIMEOUT_MILLIS_ENV_NAME = "CASUAL_EVENT_SERVER_SHUTDOWN_TIMEOUT_MILLIS";
+    public static final long DEFAULT_QUIET_PERIOD_MILLIS = 2000;
+    public static final long DEFAULT_TIMEOUT_MILLIS = 15000;
+
+    private final long quietPeriod;
+    private final long timeout;
+
+    public Shutdown( Builder builder )
+    {
+        this.quietPeriod = builder.quietPeriod;
+        this.timeout = builder.timeout;
+    }
+
+    public long getQuietPeriod()
+    {
+        return quietPeriod;
+    }
+
+    public long getTimeout()
+    {
+        return timeout;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if( this == o )
+        {
+            return true;
+        }
+        if( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        Shutdown shutdown = (Shutdown) o;
+        return quietPeriod == shutdown.quietPeriod && timeout == shutdown.timeout;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( quietPeriod, timeout );
+    }
+
+    @Override
+    public String toString()
+    {
+        return "Shutdown{" +
+                "quietPeriod=" + quietPeriod +
+                ", timeout=" + timeout +
+                '}';
+    }
+
+    public static Builder newBuilder()
+    {
+        return new Builder();
+    }
+
+
+    public static final class Builder
+    {
+        private Long quietPeriod;
+        private Long timeout;
+
+        private Builder()
+        {
+        }
+
+        public Builder withQuietPeriod( long quietPeriod )
+        {
+            this.quietPeriod = quietPeriod;
+            return this;
+        }
+
+        public Builder withTimeout( long timeout )
+        {
+            this.timeout = timeout;
+            return this;
+        }
+
+        public Shutdown build()
+        {
+            if( quietPeriod == null )
+            {
+                quietPeriod = Long.parseLong(
+                        Optional.ofNullable(System.getenv(CASUAL_EVENT_SERVER_SHUTDOWN_QUIET_PERIOD_MILLIS_ENV_NAME))
+                                .orElse( String.valueOf( DEFAULT_QUIET_PERIOD_MILLIS ) ) );
+            }
+
+            if( timeout == null )
+            {
+                timeout = Long.parseLong(
+                        Optional.ofNullable(System.getenv(CASUAL_EVENT_SERVER_SHUTDOWN_TIMEOUT_MILLIS_ENV_NAME))
+                                .orElse( String.valueOf( DEFAULT_TIMEOUT_MILLIS ) ) );
+            }
+
+            return new Shutdown( this );
+        }
+    }
+}

--- a/casual/casual-api/src/test/groovy/se/laz/casual/api/util/time/InstantUtilTest.groovy
+++ b/casual/casual-api/src/test/groovy/se/laz/casual/api/util/time/InstantUtilTest.groovy
@@ -12,6 +12,8 @@ import spock.lang.Specification
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 
 class InstantUtilTest extends Specification
 {
@@ -28,6 +30,22 @@ class InstantUtilTest extends Specification
         Instant instantRecovered = InstantUtil.fromNanos(nanos)
         then:
         instant == instantRecovered
+    }
+
+    def "Convert to Epoch Micro"()
+    {
+        when:
+        Instant date = ZonedDateTime.parse( input, DateTimeFormatter.ISO_ZONED_DATE_TIME).toInstant(  )
+        long actual = InstantUtil.toEpochMicro( date )
+
+        then:
+        actual == expected
+
+        where:
+        input                         || expected
+        "2024-04-12T12:34:56.123456Z" || 1712925296123456
+        "2024-04-12T12:34:56.123455Z" || 1712925296123455
+        "2024-04-12T12:34:56.124456Z" || 1712925296124456
     }
 
 }

--- a/casual/casual-api/src/test/groovy/se/laz/casual/api/util/time/InstantUtilTest.groovy
+++ b/casual/casual-api/src/test/groovy/se/laz/casual/api/util/time/InstantUtilTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2019, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */

--- a/casual/casual-api/src/test/groovy/se/laz/casual/config/CasualConfigTest.groovy
+++ b/casual/casual-api/src/test/groovy/se/laz/casual/config/CasualConfigTest.groovy
@@ -13,6 +13,8 @@ import spock.lang.Unroll
 import java.nio.charset.StandardCharsets
 
 import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable
+import static se.laz.casual.config.Shutdown.DEFAULT_QUIET_PERIOD_MILLIS
+import static se.laz.casual.config.Shutdown.DEFAULT_TIMEOUT_MILLIS
 
 class CasualConfigTest extends Specification
 {
@@ -187,7 +189,14 @@ class CasualConfigTest extends Specification
       given:
       String config = new File( "src/test/resources/" + file ).getText( StandardCharsets.UTF_8.name(  ) )
       Configuration expected = Configuration.newBuilder()
-              .withEventServer(EventServer.createBuilder().withPortNumber(portNumber).withUseEpoll(useEpoll).build())
+              .withEventServer(EventServer.createBuilder()
+                      .withPortNumber(port)
+                      .withUseEpoll(epoll)
+                      .withShutdown( Shutdown.newBuilder()
+                              .withQuietPeriod(quietPeriod)
+                              .withTimeout(timeout)
+                              .build())
+                      .build())
               .build()
 
       when:
@@ -197,9 +206,11 @@ class CasualConfigTest extends Specification
       actual == expected
 
       where:
-      file                                        || portNumber | useEpoll
-      'casual-config-event-server-use-epoll.json' || 6699       | true
-      'casual-config-event-server-no-epoll.json'  || 9966       | false
+      file                                        || port | epoll | quietPeriod                 | timeout
+      'casual-config-event-server-use-epoll.json' || 6699 | true  | DEFAULT_QUIET_PERIOD_MILLIS | DEFAULT_TIMEOUT_MILLIS
+      'casual-config-event-server-no-epoll.json'  || 9966 | false | DEFAULT_QUIET_PERIOD_MILLIS | DEFAULT_TIMEOUT_MILLIS
+      'casual-config-event-server-shutdown.json'  || 5987 | true  | 100                         | 200
+
    }
 
 }

--- a/casual/casual-api/src/test/resources/casual-config-event-server-shutdown.json
+++ b/casual/casual-api/src/test/resources/casual-config-event-server-shutdown.json
@@ -1,0 +1,10 @@
+{
+  "eventServer":{
+    "portNumber": 5987,
+    "useEpoll": true,
+    "shutdown": {
+      "quietPeriod": 100,
+      "timeout": 200
+    }
+  }
+}

--- a/casual/casual-event-api/src/main/java/se/laz/casual/event/ServiceCallEvent.java
+++ b/casual/casual-event-api/src/main/java/se/laz/casual/event/ServiceCallEvent.java
@@ -15,6 +15,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
+import static se.laz.casual.api.util.time.InstantUtil.toDurationMicro;
+import static se.laz.casual.api.util.time.InstantUtil.toEpochMicro;
+
 public class ServiceCallEvent
 {
     private final String service;
@@ -151,6 +154,18 @@ public class ServiceCallEvent
             return this;
         }
 
+        public Builder withStart( Instant start )
+        {
+            this.started = start;
+            return this;
+        }
+
+        public Builder withEnd( Instant end )
+        {
+            this.ended = end;
+            return this;
+        }
+
         public Builder withPending(long pending)
         {
             this.pending = pending;
@@ -195,25 +210,6 @@ public class ServiceCallEvent
             end = toEpochMicro( ended );
 
             return new ServiceCallEvent(this);
-        }
-
-        private long toEpochMicro( Instant instant )
-        {
-            return toDurationMicro(Instant.EPOCH, instant);
-        }
-
-        private long toDurationMicro( Instant start, Instant end )
-        {
-            // from ChronoUnit.between:
-            // Implementations should perform any queries or calculations using the units available in ChronoUnit
-            // or the fields available in ChronoField.
-            // If the unit is not supported an UnsupportedTemporalTypeException must be thrown.
-            // Implementations must not alter the specified temporal objects.
-            //
-            // On the platform what we currently support, this is not a problem
-            // We also do not know of any platform where this does not work
-            // The same goes for end below
-            return ChronoUnit.MICROS.between(start, end);
         }
     }
 

--- a/casual/casual-event-api/src/test/groovy/se/laz/casual/event/ServiceCallEventTest.groovy
+++ b/casual/casual-event-api/src/test/groovy/se/laz/casual/event/ServiceCallEventTest.groovy
@@ -6,6 +6,7 @@
 
 import se.laz.casual.api.flags.ErrorState
 import se.laz.casual.api.util.PrettyPrinter
+import se.laz.casual.api.util.time.InstantUtil
 import se.laz.casual.event.Order
 import se.laz.casual.event.ServiceCallEvent
 import spock.lang.Shared
@@ -14,7 +15,9 @@ import spock.lang.Unroll
 
 import javax.transaction.xa.Xid
 import java.time.Instant
+import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
+import java.time.temporal.TemporalField
 
 class ServiceCallEventTest extends Specification
 {
@@ -169,5 +172,31 @@ class ServiceCallEventTest extends Specification
       then:
       instance.getPending(  ) >= 1000
       instance.getStart(  ) < instance.getEnd(  )
+   }
+
+   def "Create event with manually provided start and end times"()
+   {
+      given:
+      ServiceCallEvent.Builder builder = ServiceCallEvent.createBuilder(  )
+              .withService(service1)
+              .withParent(parent1)
+              .withPID(pid1)
+              .withExecution(execution1)
+              .withTransactionId(transactionId1)
+              .withOrder(order1)
+              .withCode( code1 )
+
+      ZonedDateTime now = ZonedDateTime.now()
+      Instant start = now.minusMinutes( 1 ).toInstant()
+      Instant end = now.toInstant()
+
+      when:
+      builder.withStart( start )
+              .withEnd( end )
+      ServiceCallEvent instance = builder.build()
+
+      then:
+      instance.getStart() == InstantUtil.toEpochMicro( start )
+      instance.getEnd() == InstantUtil.toEpochMicro( end )
    }
 }

--- a/casual/casual-event-server/src/main/java/se/laz/casual/event/server/EventServer.java
+++ b/casual/casual-event-server/src/main/java/se/laz/casual/event/server/EventServer.java
@@ -25,7 +25,7 @@ public class EventServer
     private final long shutdownQuietPeriod;
     private final long shutdownTimeout;
 
-    public EventServer(Channel channel, long quietPeriod, long timeout )
+    private EventServer(Channel channel, long quietPeriod, long timeout )
     {
         Objects.requireNonNull(channel, "channel can not be null");
         this.channel = channel;

--- a/casual/casual-event-server/src/test/groovy/se/laz/casual/event/server/EventServerConnectionInformationTest.groovy
+++ b/casual/casual-event-server/src/test/groovy/se/laz/casual/event/server/EventServerConnectionInformationTest.groovy
@@ -1,6 +1,11 @@
+/*
+ * Copyright (c) 2024, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
 package se.laz.casual.event.server
 
-import io.netty.channel.EventLoopGroup
 import io.netty.channel.epoll.EpollServerSocketChannel
 import io.netty.channel.socket.nio.NioServerSocketChannel
 import spock.lang.Specification

--- a/casual/casual-event-server/src/test/groovy/se/laz/casual/event/server/EventServerConnectionInformationTest.groovy
+++ b/casual/casual-event-server/src/test/groovy/se/laz/casual/event/server/EventServerConnectionInformationTest.groovy
@@ -1,0 +1,84 @@
+package se.laz.casual.event.server
+
+import io.netty.channel.EventLoopGroup
+import io.netty.channel.epoll.EpollServerSocketChannel
+import io.netty.channel.socket.nio.NioServerSocketChannel
+import spock.lang.Specification
+
+class EventServerConnectionInformationTest extends Specification
+{
+    boolean useEpoll = true
+    int port = 4567
+    long timeout = 3000
+    long quiet = 2000
+
+    EventServerConnectionInformation instance
+
+    def setup()
+    {
+        instance = EventServerConnectionInformation.createBuilder(  )
+            .withPort( port )
+            .withUseEpoll( useEpoll )
+            .withShutdownTimeout( timeout )
+            .withShutdownQuietPeriod( quiet )
+            .build()
+    }
+
+    def "Create then get."()
+    {
+        expect:
+        instance.getPort(  ) == port
+        instance.isUseEpoll(  ) == useEpoll
+        instance.getShutdownTimeout( ) == timeout
+        instance.getShutdownQuietPeriod( ) == quiet
+    }
+
+    def "Equals and hashcode"()
+    {
+        when:
+        EventServerConnectionInformation instance2 = EventServerConnectionInformation.createBuilder( instance ).build()
+        EventServerConnectionInformation instance3 = EventServerConnectionInformation.createBuilder( instance )
+                .withUseEpoll( !useEpoll )
+                .build(  )
+
+        then:
+        instance == instance
+        instance == instance2
+        instance != instance3
+        instance.hashCode(  ) == instance.hashCode(  )
+        instance2.hashCode(  ) == instance.hashCode(  )
+        instance3.hashCode(  ) != instance.hashCode(  )
+        !instance.equals( "String")
+    }
+
+    def "to string"()
+    {
+        when:
+        String actual = instance.toString(  )
+
+        then:
+        actual.contains( ""+useEpoll )
+        actual.contains( ""+port )
+        actual.contains( ""+quiet )
+        actual.contains( ""+timeout )
+    }
+
+    def "channel class dependant on epoll."()
+    {
+        given:
+        EventServerConnectionInformation info = EventServerConnectionInformation.createBuilder( instance )
+                .withUseEpoll( epoll )
+                .build(  )
+
+        when:
+        Class<?> actual = info.getChannelClass(  )
+
+        then:
+        actual == expected
+
+        where:
+        epoll || expected
+        true  || EpollServerSocketChannel.class
+        false || NioServerSocketChannel.class
+    }
+}

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceAdapter.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceAdapter.java
@@ -85,9 +85,11 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
         configurationService.getConfiguration().getEventServer().ifPresent(config -> {
             log.info("starting event server with config: " + config);
             eventServer = EventServer.of(EventServerConnectionInformation.createBuilder()
-                                                           .withUseEpoll(config.isUseEpoll())
-                                                           .withPort(config.getPortNumber())
-                                                           .build());
+                    .withUseEpoll( config.isUseEpoll() )
+                    .withPort( config.getPortNumber() )
+                    .withShutdownTimeout( config.getShutdown().getTimeout() )
+                    .withShutdownQuietPeriod( config.getShutdown().getQuietPeriod() )
+                    .build() );
             log.info("event server started at port: " + config.getPortNumber());
             RuntimeInformation.setEventServerStarted(true);
         });

--- a/configuration.md
+++ b/configuration.md
@@ -17,6 +17,8 @@ Casual supports the following configuration options which can be set using envir
 * `CASUAL_OUTBOUND_USE_EPOLL` - If set to true, Netty uses epoll instead of NIO.
 * `CASUAL_INBOUND_USE_EPOLL` - If set to true, Netty uses epoll instead of NIO.
 * `CASUAL_INBOUND_STARTUP_INITIAL_DELAY_SECONDS` - Delay the startup of the inbound server. Default is no delay.
+* `CASUAL_EVENT_SERVER_SHUTDOWN_QUIET_PERIOD_MILLIS` - Quiet period during event server shutdown to wait whilst closing the channel. Default `2000`
+* `CASUAL_EVENT_SERVER_SHUTDOWN_TIMEOUT_MILLIS` - Timeout for the event server event loop to shutdown. Default `15000`
 
 NB - if a `CASUAL_CONFIG_FILE` is provided, it take precedence over the `CASUAL_INBOUND_STARTUP_MODE` setting.
 However, if some configuration is missing from the configuration file but has a setting via an environment variable then this will be used before any hardcoded default setting.

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '3.2.33'
+version = '3.2.34'
 
 def netty_version = '4.1.107.Final'
 def gson_version = '2.10.1'


### PR DESCRIPTION
Changes for testability of EventServer.

- Added `withStart` and `withEnd` to generate fake events.
- Moved time caluations into existing InstantUtil.
- Added configuration for EventServer shutdown, so default of 2 second quietPeriod is not longer mandatory when cleaning up during unit testing.