### PR TITLE
reverse-inbound: connection backoff

### DIFF
--- a/casual/casual-api/src/main/java/se/laz/casual/api/util/work/BackoffHelper.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/util/work/BackoffHelper.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2024, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
+package se.laz.casual.api.util.work;
+
+import java.util.Objects;
+
+/**
+ * Helper class to aid in counting failures and calculating backoff times for
+ * some specific task.
+ * <p>
+ * Uses a specific algorithm where backoff is incremented in 10 steps until some
+ * configured maximum backoff where each step is progressively longer according
+ * to 1/10th, 1/9th, 1/8th until 1/1 where the maximum backoff is reached. At
+ * that point every failure will yield the maximum backoff that was selected.
+ */
+public class BackoffHelper
+{
+    private final long maxBackoffMillis;
+    private long failures = 0;
+
+    private BackoffHelper(long maxBackoffMillis)
+    {
+        this.maxBackoffMillis = maxBackoffMillis;
+    }
+
+    public static BackoffHelper of(long maxBackoffMillis)
+    {
+        return new BackoffHelper(maxBackoffMillis);
+    }
+
+    private long getCurrentBackoff()
+    {
+        final long failuresUntilMaxBackoffDelay = 10;
+
+        // Backoff in steps of 1/10, 1/9 .. 1/2, 1/1 where maxBackoffMillis is reached
+        if (failures < failuresUntilMaxBackoffDelay)
+        {
+            long number = failuresUntilMaxBackoffDelay - failures;
+            return maxBackoffMillis / number;
+        }
+        else
+        {
+            return maxBackoffMillis;
+        }
+    }
+
+    public long getMaxBackoffMillis()
+    {
+        return maxBackoffMillis;
+    }
+
+    public long getFailures()
+    {
+        return failures;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "Backoff{" +
+                "maxBackoffMillis=" + maxBackoffMillis +
+                ", failures=" + failures +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+        BackoffHelper backoffHelper = (BackoffHelper) o;
+        return maxBackoffMillis == backoffHelper.maxBackoffMillis && failures == backoffHelper.failures;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(maxBackoffMillis, failures);
+    }
+
+    /**
+     * Records failure and returns the current backoff value to use. These are
+     * the same operation to ensure correct order of backoff calculation and
+     * incrementation of the failure counter.
+     * @return the current backoff in milliseconds the use before retrying after the current failure
+     */
+    public long registerFailure()
+    {
+        long backoff = getCurrentBackoff();
+        failures++;
+        return backoff;
+    }
+}

--- a/casual/casual-api/src/main/java/se/laz/casual/config/ReverseInbound.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/config/ReverseInbound.java
@@ -10,19 +10,28 @@ import java.util.Objects;
 public final class ReverseInbound
 {
     private static final int DEFAULT_SIZE = 1;
+    private static final long DEFAULT_MAX_CONNECTION_BACKOFF_MILLIS = 30000;
     private final Address address;
     private Integer size;
+    private Long maxConnectionBackoffMillis;
 
-    private ReverseInbound(Address address, int size)
+    private ReverseInbound(Address address, int size, long maxConnectionBackoffMillis)
     {
         this.address = address;
         this.size = size;
+        this.maxConnectionBackoffMillis = maxConnectionBackoffMillis;
+    }
+
+    public static ReverseInbound of(Address address, int size, long maxBackoffMillis)
+    {
+        Objects.requireNonNull(address, "address can not be null");
+        return new ReverseInbound(address, size, maxBackoffMillis);
     }
 
     public static ReverseInbound of(Address address, int size)
     {
         Objects.requireNonNull(address, "address can not be null");
-        return new ReverseInbound(address, size);
+        return new ReverseInbound(address, size, DEFAULT_MAX_CONNECTION_BACKOFF_MILLIS);
     }
 
     public static ReverseInbound of(Address address)
@@ -40,6 +49,11 @@ public final class ReverseInbound
         return null == size ? DEFAULT_SIZE : size;
     }
 
+    public long getMaxConnectionBackoffMillis()
+    {
+        return null == maxConnectionBackoffMillis ? DEFAULT_MAX_CONNECTION_BACKOFF_MILLIS : maxConnectionBackoffMillis;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -52,13 +66,13 @@ public final class ReverseInbound
             return false;
         }
         ReverseInbound that = (ReverseInbound) o;
-        return getSize() == that.getSize() && Objects.equals(getAddress(), that.getAddress());
+        return getMaxConnectionBackoffMillis() == that.getMaxConnectionBackoffMillis() && getSize() == that.getSize() && Objects.equals(getAddress(), that.getAddress());
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(getAddress(), getSize());
+        return Objects.hash(getAddress(), getSize(), getMaxConnectionBackoffMillis());
     }
 
     @Override
@@ -67,6 +81,7 @@ public final class ReverseInbound
         return "ReverseInbound{" +
                 "address=" + address +
                 ", size=" + size +
+                ", maxConnectionBackoffMillis=" + maxConnectionBackoffMillis +
                 '}';
     }
 }

--- a/casual/casual-api/src/test/groovy/se/laz/casual/api/util/work/BackoffHelperTest.groovy
+++ b/casual/casual-api/src/test/groovy/se/laz/casual/api/util/work/BackoffHelperTest.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2024, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
+package se.laz.casual.api.util.work
+
+import spock.lang.Specification
+
+class BackoffHelperTest extends Specification {
+    def setup() {}
+
+    def 'maxBackoffMillis is set correctly on construction'()
+    {
+        given:
+        long maxBackoff = 10000000000
+        BackoffHelper backoffHelper = BackoffHelper.of(maxBackoff)
+
+        expect:
+        backoffHelper.getMaxBackoffMillis() == maxBackoff
+    }
+
+    def 'first failure has backoff 1/10th of maxBackoff'()
+    {
+        given:
+        long maxBackoff = 2500
+        long expectedBackoff = maxBackoff.intdiv(10)
+        BackoffHelper backoffHelper = BackoffHelper.of(maxBackoff)
+
+        when:
+        long currentBackoff = backoffHelper.registerFailure()
+
+        then:
+        currentBackoff == expectedBackoff
+    }
+
+    def 'backoff increases for first 10 failures'()
+    {
+        given:
+        long maxBackoff = 1000
+        BackoffHelper backoffHelper = BackoffHelper.of(maxBackoff)
+        List<Long> backoffList = []
+
+        when:
+        // Record backoff for 10 failures
+        (1..10).each({
+            backoffList << backoffHelper.registerFailure()
+        })
+
+        then:
+        // Compare each failure with the one before it
+        (1..9).each({
+            backoffList[it-1] < backoffList[it]
+        })
+    }
+
+    def 'backoff does not increase from 10th failure and onward'()
+    {
+        given:
+        long maxBackoff = 20000
+        BackoffHelper backoffHelper = BackoffHelper.of(maxBackoff)
+        List<Long> backoffList = []
+
+        when:
+        (1..9).each({
+            // These should be increasing
+            backoffHelper.registerFailure()
+        })
+
+        // Get some more failure backoffs
+        (1..25).each({
+            backoffList << backoffHelper.registerFailure()
+        })
+
+        then:
+        // Compare each failure with the one before it
+        (1..25).each({
+            backoffList[it-1] == backoffList[it]
+        })
+    }
+
+    def 'backoffs are 10th, 9th, 8th and so on of maxBackoff for the first 10 failures'()
+    {
+        given:
+        long maxBackoff = 31415926525
+        BackoffHelper backoffHelper = BackoffHelper.of(maxBackoff)
+
+        expect:
+        (10..1).each({
+            backoffHelper.registerFailure() == maxBackoff.intdiv(it)
+        })
+    }
+}

--- a/casual/casual-api/src/test/groovy/se/laz/casual/api/util/work/RepeatUntilSuccessTaskWorkTest.groovy
+++ b/casual/casual-api/src/test/groovy/se/laz/casual/api/util/work/RepeatUntilSuccessTaskWorkTest.groovy
@@ -9,6 +9,8 @@ import spock.lang.Specification
 
 import jakarta.resource.spi.work.WorkException
 import jakarta.resource.spi.work.WorkManager
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
 import java.util.function.Consumer
 import java.util.function.Supplier
 
@@ -30,7 +32,8 @@ class RepeatUntilSuccessTaskWorkTest extends Specification
          workManager
       }
       when:
-      RepeatUntilSuccessTaskWork taskWork = RepeatUntilSuccessTaskWork.of(supplier, consumer, workManagerSupplier)
+      RepeatUntilSuccessTaskWork taskWork = RepeatUntilSuccessTaskWork.of(supplier, consumer, workManagerSupplier,
+              1000, Mock(ScheduledExecutorService))
       taskWork.start()
       then:
       thrown(CasualWorkException)
@@ -51,9 +54,61 @@ class RepeatUntilSuccessTaskWorkTest extends Specification
          workManager
       }
       when:
-      RepeatUntilSuccessTaskWork taskWork = RepeatUntilSuccessTaskWork.of(supplier, consumer, workManagerSupplier)
+      RepeatUntilSuccessTaskWork taskWork = RepeatUntilSuccessTaskWork.of(supplier, consumer, workManagerSupplier,
+              1000, Mock(ScheduledExecutorService))
       taskWork.start()
       then:
+      noExceptionThrown()
+   }
+
+   def 'reschedules work after each failure and backoff keeps increasing for 10 failures'()
+   {
+      given:
+      RepeatUntilSuccessTaskWork taskWork
+      long maxBackoff = 1969
+
+      long lastBackoff = -1 // backoff is never negative, just a smaller-than-possible backoff to start comparing to
+      ScheduledExecutorService mockScheduler = Mock(ScheduledExecutorService) {
+         // 10 failures will lead to 10 reschedules by the ScheduledExecutorService
+         10 * schedule(_ as Runnable, _ as Long, TimeUnit.MILLISECONDS) >> { arguments ->
+            Runnable runnable = arguments.get(0)
+            long backoff = arguments.get(1)
+
+            // Check backoff is increasing for each failure and reschedule
+            assert backoff > lastBackoff // Please note, this assert can fail fore sufficiently small max backoffs
+            assert backoff <= maxBackoff
+            assert backoff >= maxBackoff.intdiv(10)
+
+            lastBackoff = backoff
+
+            runnable.run()
+         }
+      }
+
+      Consumer<String> consumer = Mock(Consumer) {
+         10 * accept(_) >> {
+            throw new ConnectException("Connection failed, have fun")
+         }
+         1 * accept(_) >> {
+            //Yay?
+         }
+      }
+
+      WorkManager workManager = Mock(WorkManager) {
+         // 10 failures + 1 last successful run
+         11 * scheduleWork(_ as RepeatUntilSuccessTaskWork, WorkManager.INDEFINITE, null, _ as RepeatUntilSuccessTaskWorkListener) >> {
+            taskWork.run()
+         }
+      }
+
+      taskWork = RepeatUntilSuccessTaskWork.of(()->'some sought after result', consumer, () -> workManager, maxBackoff, mockScheduler)
+
+      when:
+      taskWork.start()
+
+      then:
+      taskWork.backoffHelper.maxBackoffMillis == maxBackoff
+      taskWork.backoffHelper.failures == 10
       noExceptionThrown()
    }
 }

--- a/casual/casual-api/src/test/groovy/se/laz/casual/config/ConfigurationServiceTest.groovy
+++ b/casual/casual-api/src/test/groovy/se/laz/casual/config/ConfigurationServiceTest.groovy
@@ -240,11 +240,11 @@ class ConfigurationServiceTest extends Specification
     }
 
    @Unroll
-   def "reverse inbound config #host, #port, #size"()
+   def "reverse inbound config #host, #port, #size, #backoff"()
    {
       given:
       Configuration expected = Configuration.newBuilder()
-              .withReverseInbound(ReverseInbound.of(Address.of(host, port), size))
+              .withReverseInbound(ReverseInbound.of(Address.of(host, port), size, backoff))
               .build()
 
       when:
@@ -259,8 +259,9 @@ class ConfigurationServiceTest extends Specification
       actual == expected
 
       where:
-      file                                                       || host              || port || size
-      'casual-config-reverse-inbound.json'                       || '10.96.186.114'   || 7771 || 1
-      'casual-config-reverse-inbound-with-size.json'             || '10.96.186.114'   || 7771 || 42
+      file                                                       || host              || port || size || backoff
+      'casual-config-reverse-inbound.json'                       || '10.96.186.114'   || 7771 || 1    || 30000
+      'casual-config-reverse-inbound-with-size.json'             || '10.96.186.114'   || 7771 || 42   || 30000
+      'casual-config-reverse-inbound-with-backoff.json'          || '10.96.186.114'   || 7771 || 1    || 12345
    }
 }

--- a/casual/casual-api/src/test/resources/casual-config-reverse-inbound-with-backoff.json
+++ b/casual/casual-api/src/test/resources/casual-config-reverse-inbound-with-backoff.json
@@ -1,0 +1,10 @@
+{
+  "reverseInbound":[
+    {
+      "address": {
+        "host": "10.96.186.114",
+        "port": 7771},
+      "maxConnectionBackoffMillis": 12345
+    }
+  ]
+}

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceAdapter.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceAdapter.java
@@ -132,6 +132,7 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
                                                                    .withWorkManager(workManager)
                                                                    .withXaTerminator(xaTerminator)
                                                                    .withProtocolVersion(ProtocolVersion.VERSION_1_0)
+                                                                   .withMaxBackoffMillils(instance.getMaxConnectionBackoffMillis())
                                                                    .build(), instance.getSize());
         }
     }

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/AutoConnect.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/AutoConnect.java
@@ -7,6 +7,7 @@
 package se.laz.casual.network.inbound.reverse;
 
 import se.laz.casual.api.util.work.RepeatUntilSuccessTaskWork;
+import se.laz.casual.network.outbound.JEEConcurrencyFactory;
 import se.laz.casual.network.reverse.inbound.ReverseInboundConnectListener;
 import se.laz.casual.network.reverse.inbound.ReverseInboundListener;
 import se.laz.casual.network.reverse.inbound.ReverseInboundServer;
@@ -39,7 +40,12 @@ public class AutoConnect
          connectListener.connected(server);
          eventListener.connected(server);
       };
-      RepeatUntilSuccessTaskWork<ReverseInboundServer> task = RepeatUntilSuccessTaskWork.of(supplier, consumer, workManagerSupplier);
+      RepeatUntilSuccessTaskWork<ReverseInboundServer> task = RepeatUntilSuccessTaskWork.of(
+              supplier,
+              consumer,
+              workManagerSupplier,
+              reverseInboundConnectionInformation.getMaxBackoffMillis(),
+              JEEConcurrencyFactory.getManagedScheduledExecutorService());
       return new AutoConnect(task);
    }
 

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/AutoReconnect.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/AutoReconnect.java
@@ -7,6 +7,7 @@
 package se.laz.casual.network.inbound.reverse;
 
 import se.laz.casual.api.util.work.RepeatUntilSuccessTaskWork;
+import se.laz.casual.network.outbound.JEEConcurrencyFactory;
 import se.laz.casual.network.reverse.inbound.ReverseInboundListener;
 import se.laz.casual.network.reverse.inbound.ReverseInboundServer;
 
@@ -33,7 +34,12 @@ public class AutoReconnect
       Objects.requireNonNull(workManagerSupplier, "workManagerSupplier can not be null");
       Supplier<ReverseInboundServer> supplier = () -> ReverseInboundServerImpl.of(reverseInboundConnectionInformation, eventListener, workManagerSupplier);
       Consumer<ReverseInboundServer> consumer = eventListener::connected;
-      RepeatUntilSuccessTaskWork<ReverseInboundServer> task = RepeatUntilSuccessTaskWork.of(supplier, consumer, workManagerSupplier);
+      RepeatUntilSuccessTaskWork<ReverseInboundServer> task = RepeatUntilSuccessTaskWork.of(
+              supplier,
+              consumer,
+              workManagerSupplier,
+              reverseInboundConnectionInformation.getMaxBackoffMillis(),
+              JEEConcurrencyFactory.getManagedScheduledExecutorService());
       return new AutoReconnect(task);
    }
 

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundConnectionInformation.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundConnectionInformation.java
@@ -34,6 +34,7 @@ public class ReverseInboundConnectionInformation
     private final String domainName;
     private final Class<? extends Channel> channelClass;
     private boolean useEpoll;
+    private final long maxBackoffMillis;
 
     private ReverseInboundConnectionInformation(Builder builder)
     {
@@ -48,6 +49,7 @@ public class ReverseInboundConnectionInformation
         this.domainName = builder.domainName;
         this.channelClass = builder.channelClass;
         this.useEpoll = builder.useEpoll;
+        this.maxBackoffMillis = builder.maxBackoffMillis;
     }
 
     public InetSocketAddress getAddress()
@@ -110,6 +112,11 @@ public class ReverseInboundConnectionInformation
         return useEpoll;
     }
 
+    public long getMaxBackoffMillis()
+    {
+        return maxBackoffMillis;
+    }
+
     public static final class Builder
     {
         private InetSocketAddress address;
@@ -123,6 +130,7 @@ public class ReverseInboundConnectionInformation
         private Class<? extends Channel> channelClass;
         private boolean logHandlerEnabled;
         private boolean useEpoll;
+        private long maxBackoffMillis;
 
         public Builder withAddress(InetSocketAddress address)
         {
@@ -178,6 +186,12 @@ public class ReverseInboundConnectionInformation
             return this;
         }
 
+        public Builder withMaxBackoffMillils(long maxBackoffMillis)
+        {
+            this.maxBackoffMillis = maxBackoffMillis;
+            return this;
+        }
+
         public ReverseInboundConnectionInformation build()
         {
             Objects.requireNonNull(address, "address can not be null");
@@ -192,6 +206,5 @@ public class ReverseInboundConnectionInformation
             logHandlerEnabled = Boolean.parseBoolean(System.getenv(USE_LOG_HANDLER_ENV_NAME));
             return new ReverseInboundConnectionInformation(this);
         }
-
     }
 }

--- a/casual/casual-network/src/main/java/se/laz/casual/network/outbound/JEEConcurrencyFactory.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/outbound/JEEConcurrencyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, The casual project. All rights reserved.
+ * Copyright (c) 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -12,6 +12,8 @@ import se.laz.casual.jca.CasualResourceAdapterException;
 import jakarta.enterprise.concurrent.ManagedExecutorService;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.logging.Logger;
 
 public class JEEConcurrencyFactory
@@ -26,6 +28,18 @@ public class JEEConcurrencyFactory
     // * we have not found what the direct names are so if you run on wls it will throw unless direct a direct JNDI-name is configured
     // * this goes for conversation, it needs an ExecutorService, and Outbound - if not set to run unmanaged
     private static final String DEFAULT_MANAGED_EXECUTOR_SERVICE_NAME_JBOSS_DIRECT = "java:jboss/ee/concurrency/executor/default";
+
+    public static final String DEFAULT_MANAGED_SCHEDULED_EXECUTOR_SERVICE_NAME_JBOSS_DIRECT = "java:jboss/ee/concurrency/scheduler/default";
+    public static final String DEFAULT_MANAGED_SCHEDULED_EXECUTOR_SERVICE_NAME_INDIRECT = "java:comp/DefaultManagedScheduledExecutorService";
+
+    // For configuring the concurrency of the normal java.util.concurrency-based ScheduledExecutorService which is
+    // only used whenever the direct jboss-variant or the jee-spec indirect jndi name lookups fail for a scheduled
+    // executor service.
+    public static final String CASUAL_UNMANAGED_SCHEDULED_EXECUTOR_SERVICE_POOL_SIZE_ENV_NAME = "CASUAL_UNMANAGED_SCHEDULED_EXECUTOR_SERVICE_POOL_SIZE";
+    public static final int DEFAULT_CASUAL_UNMANAGED_SCHEDULED_EXECUTOR_SERVICE_POOL_SIZE = 10;
+
+    /** Fallback ScheduledExecutorService that is used when nothing is found through jndi */
+    private static ScheduledExecutorService sharedScheduledExecutor;
 
     private JEEConcurrencyFactory()
     {}
@@ -62,4 +76,70 @@ public class JEEConcurrencyFactory
         }
     }
 
+    /**
+     * Gets the default ManagedScheduledExecutorService on jboss. On some non-standard implementation
+     * it will fetch the default through java:comp/DefaultManagedScheduledExecutorService
+     * which normally shouldn't be accessible in this context.
+     * <p>
+     * If both of those fail a ScheduledExecutorService instance will be created
+     * through the standard java.util.concurrent.Executor which will share the
+     * same ScheduledExecutorService among all users.
+     *
+     * @return A ScheduledExecutorService instance.
+     */
+    public static ScheduledExecutorService getManagedScheduledExecutorService()
+    {
+        try
+        {
+            // First try jboss variant
+            return InitialContext.doLookup(DEFAULT_MANAGED_SCHEDULED_EXECUTOR_SERVICE_NAME_JBOSS_DIRECT);
+        }
+        catch (NamingException e)
+        {
+            LOG.info("Failed lookup for " + DEFAULT_MANAGED_SCHEDULED_EXECUTOR_SERVICE_NAME_JBOSS_DIRECT + ", will retry indirect jndi name (may exist in this context on some non-standard application servers)");
+            try
+            {
+                // Second try non-standard use of indirect jndi name defined in JSR-236
+                return InitialContext.doLookup(DEFAULT_MANAGED_SCHEDULED_EXECUTOR_SERVICE_NAME_INDIRECT);
+            }
+            catch (NamingException ex)
+            {
+                LOG.info("Failed lookup for " + DEFAULT_MANAGED_SCHEDULED_EXECUTOR_SERVICE_NAME_INDIRECT + ", will use scheduled executor from java.util.concurrent.Executors");
+                // If all else fails, use java.util.concurrent variant as scheduler
+                return getSharedJavaUtilScheduledExecutor();
+            }
+        }
+    }
+
+    static synchronized ScheduledExecutorService getSharedJavaUtilScheduledExecutor()
+    {
+        if (null == sharedScheduledExecutor)
+        {
+            int schedulerPoolSize = DEFAULT_CASUAL_UNMANAGED_SCHEDULED_EXECUTOR_SERVICE_POOL_SIZE;
+
+            final String poolSizeEnvValue = System.getenv(CASUAL_UNMANAGED_SCHEDULED_EXECUTOR_SERVICE_POOL_SIZE_ENV_NAME);
+            try
+            {
+                schedulerPoolSize = Integer.parseInt(poolSizeEnvValue);
+            }
+            catch (NumberFormatException e)
+            {
+                LOG.info("Failed to read env '" + CASUAL_UNMANAGED_SCHEDULED_EXECUTOR_SERVICE_POOL_SIZE_ENV_NAME
+                        + "' as int, value was '" + poolSizeEnvValue
+                        + "'. Will use default pool size=" + schedulerPoolSize);
+            }
+
+            sharedScheduledExecutor = Executors.newScheduledThreadPool(schedulerPoolSize);
+        }
+
+        return sharedScheduledExecutor;
+    }
+
+    /**
+     * For testing purposes only
+     */
+    static void resetScheduler()
+    {
+        sharedScheduledExecutor = null;
+    }
 }

--- a/casual/casual-network/src/test/groovy/se/laz/casual/network/inbound/reverse/ReverseInboundConnectionInformationTest.groovy
+++ b/casual/casual-network/src/test/groovy/se/laz/casual/network/inbound/reverse/ReverseInboundConnectionInformationTest.groovy
@@ -24,6 +24,7 @@ class ReverseInboundConnectionInformationTest extends Specification {
       String domainName = "testDomain"
       Class<? extends Channel> channelClass = EpollSocketChannel
       boolean useEpoll = true
+      long maxBackoffMillis = 12345
       boolean isLogHandlerEnabled = true
 
       ReverseInboundConnectionInformation connectionInfo
@@ -38,6 +39,7 @@ class ReverseInboundConnectionInformationTest extends Specification {
                  .withDomainId(domainId)
                  .withDomainName(domainName)
                  .withUseEpoll(useEpoll)
+                 .withMaxBackoffMillils(maxBackoffMillis)
                  .build()
       } )
 
@@ -51,6 +53,7 @@ class ReverseInboundConnectionInformationTest extends Specification {
       connectionInfo.getDomainId() == domainId
       connectionInfo.getDomainName() == domainName
       connectionInfo.isUseEpoll() == useEpoll
+      connectionInfo.getMaxBackoffMillis() == maxBackoffMillis
       connectionInfo.getChannelClass() == channelClass
       connectionInfo.isLogHandlerEnabled() == isLogHandlerEnabled
    }
@@ -67,6 +70,7 @@ class ReverseInboundConnectionInformationTest extends Specification {
       String domainName = "testDomain"
       Class<? extends Channel> channelClass = NioSocketChannel
       boolean useEpoll = false
+      long maxBackoffMillis = 12345
       boolean isLogHandlerEnabled = false
 
       ReverseInboundConnectionInformation connectionInfo
@@ -81,6 +85,7 @@ class ReverseInboundConnectionInformationTest extends Specification {
                  .withDomainId(domainId)
                  .withDomainName(domainName)
                  .withUseEpoll(useEpoll)
+                 .withMaxBackoffMillils(maxBackoffMillis)
                  .build()
       } )
 
@@ -94,6 +99,7 @@ class ReverseInboundConnectionInformationTest extends Specification {
       connectionInfo.getDomainId() == domainId
       connectionInfo.getDomainName() == domainName
       connectionInfo.isUseEpoll() == useEpoll
+      connectionInfo.getMaxBackoffMillis() == maxBackoffMillis
       connectionInfo.getChannelClass() == channelClass
       connectionInfo.isLogHandlerEnabled() == isLogHandlerEnabled
    }

--- a/casual/casual-network/src/test/groovy/se/laz/casual/network/outbound/JEEConcurrencyFactoryTest.groovy
+++ b/casual/casual-network/src/test/groovy/se/laz/casual/network/outbound/JEEConcurrencyFactoryTest.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2024, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+package se.laz.casual.network.outbound
+
+import spock.lang.Specification
+
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledThreadPoolExecutor
+
+import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable
+
+class JEEConcurrencyFactoryTest extends Specification {
+    def setup()
+    {
+        JEEConcurrencyFactory.resetScheduler()
+    }
+
+    def cleanupSpec()
+    {
+        JEEConcurrencyFactory.resetScheduler()
+    }
+
+    def 'java util concurrency scheduler uses default threads when no config env is set'()
+    {
+        given:
+        ScheduledExecutorService scheduler = JEEConcurrencyFactory.getSharedJavaUtilScheduledExecutor()
+
+        expect:
+        ((ScheduledThreadPoolExecutor) scheduler).getCorePoolSize() == JEEConcurrencyFactory.DEFAULT_CASUAL_UNMANAGED_SCHEDULED_EXECUTOR_SERVICE_POOL_SIZE
+    }
+
+    def 'java util concurrency scheduler uses environment configured threads with valid config'()
+    {
+        given:
+        int configuredPoolSize = 1579
+        ScheduledExecutorService scheduler = null
+        withEnvironmentVariable(JEEConcurrencyFactory.CASUAL_UNMANAGED_SCHEDULED_EXECUTOR_SERVICE_POOL_SIZE_ENV_NAME, Integer.toString(configuredPoolSize))
+                .execute( {
+                    scheduler = JEEConcurrencyFactory.getSharedJavaUtilScheduledExecutor()
+                })
+
+        expect:
+        ((ScheduledThreadPoolExecutor) scheduler).getCorePoolSize() == configuredPoolSize
+    }
+
+    def 'java util concurrency scheduler uses default threads when environment config is invalid'()
+    {
+        String configuredPoolSize = "something outrageous"
+        ScheduledExecutorService scheduler = null
+        withEnvironmentVariable(JEEConcurrencyFactory.CASUAL_UNMANAGED_SCHEDULED_EXECUTOR_SERVICE_POOL_SIZE_ENV_NAME, configuredPoolSize)
+                .execute( {
+                    scheduler = JEEConcurrencyFactory.getSharedJavaUtilScheduledExecutor()
+                })
+
+        expect:
+        ((ScheduledThreadPoolExecutor) scheduler).getCorePoolSize() == JEEConcurrencyFactory.DEFAULT_CASUAL_UNMANAGED_SCHEDULED_EXECUTOR_SERVICE_POOL_SIZE
+    }
+
+    def 'multiple calls for shared java util concurrency scheduler yields same instance'()
+    {
+        given:
+        ScheduledExecutorService schedulerA = JEEConcurrencyFactory.getSharedJavaUtilScheduledExecutor()
+        ScheduledExecutorService schedulerB = JEEConcurrencyFactory.getSharedJavaUtilScheduledExecutor()
+
+        expect:
+        schedulerA == schedulerB
+    }
+}

--- a/configuration.md
+++ b/configuration.md
@@ -19,6 +19,7 @@ Casual supports the following configuration options which can be set using envir
 * `CASUAL_INBOUND_STARTUP_INITIAL_DELAY_SECONDS` - Delay the startup of the inbound server. Default is no delay.
 * `CASUAL_EVENT_SERVER_SHUTDOWN_QUIET_PERIOD_MILLIS` - Quiet period during event server shutdown to wait whilst closing the channel. Default `2000`
 * `CASUAL_EVENT_SERVER_SHUTDOWN_TIMEOUT_MILLIS` - Timeout for the event server event loop to shutdown. Default `15000`
+* `CASUAL_UNMANAGED_SCHEDULED_EXECUTOR_SERVICE_POOL_SIZE` - The pool size of casual's scheduled executor service instance. Defaults to 10.
 
 NB - if a `CASUAL_CONFIG_FILE` is provided, it take precedence over the `CASUAL_INBOUND_STARTUP_MODE` setting.
 However, if some configuration is missing from the configuration file but has a setting via an environment variable then this will be used before any hardcoded default setting.

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '3.2.34'
+version = '3.2.35'
 
 def netty_version = '4.1.107.Final'
 def gson_version = '2.10.1'


### PR DESCRIPTION
Added a backoff delay before retrying connections when reverse-inbound can't connect.

This fixes an issue where connection retries were performed rapidly which could cause exessive logging and even cause out-of-memory errors on servers with small heap.

The backoff will increment the delay time for each failure for a specific connection, up to some configurable max connection backoff for reverse-inbound (30 seconds).