### PR TITLE
Bugfix/2.2/log tool handle all messages

### DIFF
--- a/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/domain/CasualDomainConnectReplyMessage.java
+++ b/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/domain/CasualDomainConnectReplyMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
-public final class CasualDomainConnectReplyMessage implements CasualNetworkTransmittable
+public class CasualDomainConnectReplyMessage implements CasualNetworkTransmittable
 {
     private UUID execution;
     private UUID domainId;

--- a/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/domain/CasualDomainConnectRequestMessage.java
+++ b/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/domain/CasualDomainConnectRequestMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -8,8 +8,8 @@ package se.laz.casual.network.protocol.messages.domain;
 
 import se.laz.casual.api.network.protocol.messages.CasualNWMessageType;
 import se.laz.casual.api.network.protocol.messages.CasualNetworkTransmittable;
-import se.laz.casual.network.protocol.encoding.utils.CasualEncoderUtils;
 import se.laz.casual.api.network.protocol.messages.exception.CasualProtocolException;
+import se.laz.casual.network.protocol.encoding.utils.CasualEncoderUtils;
 import se.laz.casual.network.protocol.messages.parseinfo.ConnectRequestSizes;
 
 import java.nio.ByteBuffer;
@@ -20,7 +20,7 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-public final class CasualDomainConnectRequestMessage implements CasualNetworkTransmittable
+public class CasualDomainConnectRequestMessage implements CasualNetworkTransmittable
 {
     private UUID execution;
     private UUID domainId;

--- a/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/domain/CasualDomainDiscoveryReplyMessage.java
+++ b/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/domain/CasualDomainDiscoveryReplyMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -23,7 +23,7 @@ import java.util.UUID;
  * Created by aleph on 2017-03-07.
  */
 
-public final class CasualDomainDiscoveryReplyMessage implements CasualNetworkTransmittable
+public class CasualDomainDiscoveryReplyMessage implements CasualNetworkTransmittable
 {
     private final UUID execution;
     private final UUID domainId;

--- a/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/domain/CasualDomainDiscoveryRequestMessage.java
+++ b/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/domain/CasualDomainDiscoveryRequestMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
  */
 // We suppress this since the builder code is much cleaner using the private setters of the class
 @SuppressWarnings("squid:S3398")
-public final class CasualDomainDiscoveryRequestMessage implements CasualNetworkTransmittable
+public class CasualDomainDiscoveryRequestMessage implements CasualNetworkTransmittable
 {
     private UUID execution;
     private UUID domainId;

--- a/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/domain/DomainDisconnectReplyMessage.java
+++ b/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/domain/DomainDisconnectReplyMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, The casual project. All rights reserved.
+ * Copyright (c) 2022 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -34,6 +34,11 @@ public class DomainDisconnectReplyMessage implements CasualNetworkTransmittable
     {
         Objects.requireNonNull(execution, "execution can not be null");
         return new DomainDisconnectReplyMessage(execution);
+    }
+
+    public UUID getExecution()
+    {
+        return execution;
     }
 
     @Override

--- a/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/queue/CasualDequeueReplyMessage.java
+++ b/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/queue/CasualDequeueReplyMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -18,7 +18,7 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-public final class CasualDequeueReplyMessage implements CasualNetworkTransmittable
+public class CasualDequeueReplyMessage implements CasualNetworkTransmittable
 {
     private final UUID execution;
     private final List<DequeueMessage> messages;

--- a/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/queue/CasualDequeueRequestMessage.java
+++ b/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/queue/CasualDequeueRequestMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
-public final class CasualDequeueRequestMessage implements CasualNetworkTransmittable
+public class CasualDequeueRequestMessage implements CasualNetworkTransmittable
 {
     private final UUID execution;
     private final String queueName;

--- a/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/queue/CasualEnqueueReplyMessage.java
+++ b/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/queue/CasualEnqueueReplyMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
-public final class CasualEnqueueReplyMessage implements CasualNetworkTransmittable
+public class CasualEnqueueReplyMessage implements CasualNetworkTransmittable
 {
     private final UUID execution;
     private final UUID id;

--- a/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/queue/CasualEnqueueRequestMessage.java
+++ b/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/queue/CasualEnqueueRequestMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
-public final class CasualEnqueueRequestMessage implements CasualNetworkTransmittable
+public class CasualEnqueueRequestMessage implements CasualNetworkTransmittable
 {
     private final UUID execution;
     private final String queueName;

--- a/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/service/CasualServiceCallRequestMessage.java
+++ b/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/service/CasualServiceCallRequestMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -28,7 +28,7 @@ import java.util.UUID;
 /**
  * Created by aleph on 2017-03-14.
  */
-public final class CasualServiceCallRequestMessage implements CasualNetworkTransmittable
+public class CasualServiceCallRequestMessage implements CasualNetworkTransmittable
 {
     private UUID execution;
     private String serviceName;

--- a/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/transaction/CasualTransactionResourceCommitReplyMessage.java
+++ b/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/transaction/CasualTransactionResourceCommitReplyMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -16,7 +16,7 @@ import java.util.UUID;
 /**
  * Created by aleph on 2017-04-03.
  */
-public final class CasualTransactionResourceCommitReplyMessage extends AbstractCasualTransactionReplyMessage
+public class CasualTransactionResourceCommitReplyMessage extends AbstractCasualTransactionReplyMessage
 {
     private CasualTransactionResourceCommitReplyMessage(final UUID execution, final Xid xid, int resourceId, final XAReturnCode transactionReturnCode)
     {

--- a/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/transaction/CasualTransactionResourceCommitRequestMessage.java
+++ b/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/transaction/CasualTransactionResourceCommitRequestMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -17,7 +17,7 @@ import java.util.UUID;
 /**
  * Created by aleph on 2017-04-03.
  */
-public final class CasualTransactionResourceCommitRequestMessage extends AbstractCasualTransactionRequestMessage
+public class CasualTransactionResourceCommitRequestMessage extends AbstractCasualTransactionRequestMessage
 {
     protected CasualTransactionResourceCommitRequestMessage(final UUID execution, final Xid xid, int resourceId, int flags)
     {

--- a/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/transaction/CasualTransactionResourcePrepareReplyMessage.java
+++ b/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/transaction/CasualTransactionResourcePrepareReplyMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -15,7 +15,7 @@ import java.util.UUID;
 /**
  * Created by aleph on 2017-04-03.
  */
-public final class CasualTransactionResourcePrepareReplyMessage extends AbstractCasualTransactionReplyMessage
+public class CasualTransactionResourcePrepareReplyMessage extends AbstractCasualTransactionReplyMessage
 {
     private CasualTransactionResourcePrepareReplyMessage(final UUID execution, final Xid xid, int resourceId, final XAReturnCode transactionReturnCode)
     {

--- a/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/transaction/CasualTransactionResourcePrepareRequestMessage.java
+++ b/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/transaction/CasualTransactionResourcePrepareRequestMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -17,7 +17,7 @@ import java.util.UUID;
 /**
  * Created by aleph on 2017-03-30.
  */
-public final class CasualTransactionResourcePrepareRequestMessage extends AbstractCasualTransactionRequestMessage
+public class CasualTransactionResourcePrepareRequestMessage extends AbstractCasualTransactionRequestMessage
 {
     private CasualTransactionResourcePrepareRequestMessage(final UUID execution, final Xid xid, int resourceId, int flags)
     {

--- a/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/transaction/CasualTransactionResourceRollbackRequestMessage.java
+++ b/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/transaction/CasualTransactionResourceRollbackRequestMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -17,7 +17,7 @@ import java.util.UUID;
 /**
  * Created by aleph on 2017-04-03.
  */
-public final class CasualTransactionResourceRollbackRequestMessage extends AbstractCasualTransactionRequestMessage
+public class CasualTransactionResourceRollbackRequestMessage extends AbstractCasualTransactionRequestMessage
 {
     protected CasualTransactionResourceRollbackRequestMessage(final UUID execution, final Xid xid, int resourceId, int flags)
     {

--- a/casual/casual-network/src/main/java/se/laz/casual/network/outbound/LogTool.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/outbound/LogTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, The casual project. All rights reserved.
+ * Copyright (c) 2021 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -16,6 +16,9 @@ import se.laz.casual.network.protocol.messages.domain.CasualDomainConnectReplyMe
 import se.laz.casual.network.protocol.messages.domain.CasualDomainConnectRequestMessage;
 import se.laz.casual.network.protocol.messages.domain.CasualDomainDiscoveryReplyMessage;
 import se.laz.casual.network.protocol.messages.domain.CasualDomainDiscoveryRequestMessage;
+import se.laz.casual.network.protocol.messages.domain.DomainDisconnectReplyMessage;
+import se.laz.casual.network.protocol.messages.domain.DomainDisconnectRequestMessage;
+import se.laz.casual.network.protocol.messages.domain.DomainDiscoveryTopologyUpdateMessage;
 import se.laz.casual.network.protocol.messages.queue.CasualDequeueReplyMessage;
 import se.laz.casual.network.protocol.messages.queue.CasualDequeueRequestMessage;
 import se.laz.casual.network.protocol.messages.queue.CasualEnqueueReplyMessage;
@@ -100,6 +103,15 @@ public final class LogTool
                 break;
             case CONVERSATION_DISCONNECT:
                 execution = ((Disconnect)message.getMessage()).getExecution();
+                break;
+            case DOMAIN_DISCOVERY_TOPOLOGY_UPDATE:
+                execution = ((DomainDiscoveryTopologyUpdateMessage)message.getMessage()).getExecution();
+                break;
+            case DOMAIN_DISCONNECT_REPLY:
+                execution = ((DomainDisconnectReplyMessage)message.getMessage()).getExecution();
+                break;
+            case DOMAIN_DISCONNECT_REQUEST:
+                execution = ((DomainDisconnectRequestMessage)message.getMessage()).getExecution();
                 break;
             default:
                 return String.format("Unknown message type: %s", message.getType().name());

--- a/casual/casual-network/src/test/groovy/se/laz/casual/network/outbound/LogToolTest.groovy
+++ b/casual/casual-network/src/test/groovy/se/laz/casual/network/outbound/LogToolTest.groovy
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2024, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
+package se.laz.casual.network.outbound
+
+import se.laz.casual.api.network.protocol.messages.CasualNWMessage
+import se.laz.casual.api.network.protocol.messages.CasualNWMessageType
+import se.laz.casual.api.network.protocol.messages.CasualNetworkTransmittable
+import se.laz.casual.api.util.PrettyPrinter
+import se.laz.casual.network.protocol.messages.conversation.ConnectReply
+import se.laz.casual.network.protocol.messages.conversation.ConnectRequest
+import se.laz.casual.network.protocol.messages.conversation.Disconnect
+import se.laz.casual.network.protocol.messages.conversation.Request
+import se.laz.casual.network.protocol.messages.domain.*
+import se.laz.casual.network.protocol.messages.queue.CasualDequeueReplyMessage
+import se.laz.casual.network.protocol.messages.queue.CasualDequeueRequestMessage
+import se.laz.casual.network.protocol.messages.queue.CasualEnqueueReplyMessage
+import se.laz.casual.network.protocol.messages.queue.CasualEnqueueRequestMessage
+import se.laz.casual.network.protocol.messages.service.CasualServiceCallReplyMessage
+import se.laz.casual.network.protocol.messages.service.CasualServiceCallRequestMessage
+import se.laz.casual.network.protocol.messages.transaction.*
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class LogToolTest extends Specification
+{
+    @Shared
+    UUID execution = UUID.randomUUID()
+    @Shared
+    UUID corrid = UUID.randomUUID()
+    @Unroll
+    def 'ok log entry for #messageType'()
+    {
+        given:
+        CasualNWMessage<CasualNetworkTransmittable> envelope = Mock(CasualNWMessage){
+            getMessage() >> createMessage(messageType)
+            getType() >> messageType
+            getCorrelationId() >> corrid
+        }
+        expect:
+        LogTool.asLogEntry(envelope).contains(PrettyPrinter.casualStringify(execution))
+        LogTool.asLogEntry(envelope).contains(PrettyPrinter.casualStringify(corrid))
+        where:
+        messageType << CasualNWMessageType.values()
+    }
+
+
+    CasualNetworkTransmittable createMessage(CasualNWMessageType messageType)
+    {
+        switch(messageType)
+        {
+            case CasualNWMessageType.DOMAIN_CONNECT_REQUEST:
+                CasualDomainConnectRequestMessage message = Mock(CasualDomainConnectRequestMessage){
+                    getExecution() >> execution
+                }
+                return message
+            case CasualNWMessageType.DOMAIN_CONNECT_REPLY:
+                CasualDomainConnectReplyMessage message = Mock(CasualDomainConnectReplyMessage){
+                    getExecution() >> execution
+                }
+                return message
+            case CasualNWMessageType.DOMAIN_DISCONNECT_REQUEST:
+                DomainDisconnectRequestMessage message = Mock(DomainDisconnectRequestMessage){
+                    getExecution() >> execution
+                }
+                return message
+            case CasualNWMessageType.DOMAIN_DISCONNECT_REPLY:
+                DomainDisconnectReplyMessage message = Mock(DomainDisconnectReplyMessage){
+                    getExecution() >> execution
+                }
+                return message
+            case CasualNWMessageType.DOMAIN_DISCOVERY_REQUEST:
+                CasualDomainDiscoveryRequestMessage message = Mock(CasualDomainDiscoveryRequestMessage){
+                    getExecution() >> execution
+                }
+                return message
+            case CasualNWMessageType.DOMAIN_DISCOVERY_REPLY:
+                CasualDomainDiscoveryReplyMessage message = Mock(CasualDomainDiscoveryReplyMessage){
+                    getExecution() >> execution
+                }
+                return message
+            case CasualNWMessageType.DOMAIN_DISCOVERY_TOPOLOGY_UPDATE:
+                DomainDiscoveryTopologyUpdateMessage message = Mock(DomainDiscoveryTopologyUpdateMessage){
+                    getExecution() >> execution
+                }
+                return message
+            case CasualNWMessageType.SERVICE_CALL_REQUEST:
+                CasualServiceCallRequestMessage message = Mock(CasualServiceCallRequestMessage){
+                    getExecution() >> execution
+                }
+                return message
+            case CasualNWMessageType.SERVICE_CALL_REPLY:
+                CasualServiceCallReplyMessage message = Mock(CasualServiceCallReplyMessage){
+                    getExecution() >> execution
+                }
+                return message
+            case CasualNWMessageType.ENQUEUE_REQUEST:
+                CasualEnqueueRequestMessage message = Mock(CasualEnqueueRequestMessage){
+                    getExecution() >> execution
+                }
+                return message
+            case CasualNWMessageType.ENQUEUE_REPLY:
+                CasualEnqueueReplyMessage message = Mock(CasualEnqueueReplyMessage){
+                    getExecution() >> execution
+                }
+                return message
+            case CasualNWMessageType.DEQUEUE_REQUEST:
+                CasualDequeueRequestMessage message = Mock(CasualDequeueRequestMessage){
+                    getExecution() >> execution
+                }
+                return message
+            case CasualNWMessageType.DEQUEUE_REPLY:
+                CasualDequeueReplyMessage message = Mock(CasualDequeueReplyMessage){
+                    getExecution() >> execution
+                }
+                return message
+            case CasualNWMessageType.PREPARE_REQUEST:
+                CasualTransactionResourcePrepareRequestMessage message = Mock(CasualTransactionResourcePrepareRequestMessage){
+                    getExecution() >> execution
+                }
+                return message
+            case CasualNWMessageType.PREPARE_REQUEST_REPLY:
+                CasualTransactionResourcePrepareReplyMessage message = Mock(CasualTransactionResourcePrepareReplyMessage){
+                    getExecution() >> execution
+                }
+                return message
+            case CasualNWMessageType.COMMIT_REQUEST:
+                CasualTransactionResourceCommitRequestMessage message = Mock(CasualTransactionResourceCommitRequestMessage){
+                    getExecution() >> execution
+                }
+                return message
+            case CasualNWMessageType.COMMIT_REQUEST_REPLY:
+                CasualTransactionResourceCommitReplyMessage message = Mock(CasualTransactionResourceCommitReplyMessage){
+                    getExecution() >> execution
+                }
+                return message
+            case CasualNWMessageType.REQUEST_ROLLBACK:
+                CasualTransactionResourceRollbackRequestMessage message = Mock(CasualTransactionResourceRollbackRequestMessage){
+                    getExecution() >> execution
+                }
+                return message
+            case CasualNWMessageType.REQUEST_ROLLBACK_REPLY:
+                CasualTransactionResourceRollbackReplyMessage message = Mock(CasualTransactionResourceRollbackReplyMessage){
+                    getExecution() >> execution
+                }
+                return message
+            case CasualNWMessageType.CONVERSATION_CONNECT:
+                ConnectRequest message = Mock(ConnectRequest){
+                    getExecution() >> execution
+                }
+                return message
+            case CasualNWMessageType.CONVERSATION_CONNECT_REPLY:
+                ConnectReply message = Mock(ConnectReply){
+                    getExecution() >> execution
+                }
+                return message
+            case CasualNWMessageType.CONVERSATION_REQUEST:
+                Request message = Mock(Request){
+                    getExecution() >> execution
+                }
+                return message
+            case CasualNWMessageType.CONVERSATION_DISCONNECT:
+                Disconnect message = Mock(Disconnect){
+                    getExecution() >> execution
+                }
+                return message
+            default:
+                throw new RuntimeException("Unknown message type: " + messageType)
+        }
+    }
+}

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '2.2.29'
+version = '2.2.30'
 
 def netty_version = '4.1.107.Final'
 def gson_version = '2.10.1'


### PR DESCRIPTION
The log tool that we use for pretty printing log messages should always handle the whole set of messages.

Note: For the network messages, there was a mix of final and non final messages for no reason at all honestly. They are now all non final so that we can mock them.