### PR TITLE
Feature/2.2/reverse inbound share event loop group

### DIFF
--- a/casual/casual-api/src/main/java/se/laz/casual/config/Configuration.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/config/Configuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, The casual project. All rights reserved.
+ * Copyright (c) 2021 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -10,19 +10,26 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 public class Configuration
 {
+    public static final String USE_EPOLL_ENV_VAR_NAME = "CASUAL_OUTBOUND_USE_EPOLL";
+    public static final String UNMANAGED_ENV_VAR_NAME = "CASUAL_OUTBOUND_UNMANAGED";
     private final Inbound inbound;
     private final Domain domain;
     private final Outbound outbound;
     private final List<ReverseInbound> reverseInbound;
-    public Configuration(Domain domain, Inbound inbound, Outbound outbound, List<ReverseInbound> reverseInbound)
+    private final Boolean useEpoll;
+    private final Boolean unmanaged;
+    public Configuration(Domain domain, Inbound inbound, Outbound outbound, List<ReverseInbound> reverseInbound, Boolean useEpoll, Boolean unmanaged)
     {
         this.domain = domain;
         this.inbound = inbound;
         this.outbound = outbound;
         this.reverseInbound = reverseInbound;
+        this.useEpoll = useEpoll;
+        this.unmanaged = unmanaged;
     }
 
     public Domain getDomain()
@@ -45,6 +52,16 @@ public class Configuration
         return null == reverseInbound ? Collections.emptyList() : Collections.unmodifiableList(reverseInbound);
     }
 
+    public Optional<Boolean> getUseEpoll()
+    {
+        return null == useEpoll ? getUseEPollFromEnv() : Optional.of(useEpoll);
+    }
+
+    public Optional<Boolean> getUnmanaged()
+    {
+        return null == unmanaged ? getUnmanagedFromEnv() : Optional.of(unmanaged);
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -60,13 +77,15 @@ public class Configuration
         return Objects.equals(getInbound(), that.getInbound()) &&
                 Objects.equals(getDomain(), that.getDomain()) &&
                 Objects.equals(getOutbound(), that.getOutbound()) &&
-                Objects.equals(getReverseInbound(), that.getReverseInbound());
+                Objects.equals(getReverseInbound(), that.getReverseInbound()) &&
+                Objects.equals(getUseEpoll(), that.getUseEpoll()) &&
+                Objects.equals(getUnmanaged(), that.getUnmanaged());
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(getInbound(), getDomain(), getOutbound(), getReverseInbound());
+        return Objects.hash(getInbound(), getDomain(), getOutbound(), getReverseInbound(), getUseEpoll(), getUnmanaged());
     }
 
     @Override
@@ -77,6 +96,8 @@ public class Configuration
                 ", domain=" + getDomain() +
                 ", outbound=" + getOutbound() +
                 ", reverseInbound=" + getReverseInbound() +
+                ", useEpoll=" + getUseEpoll() +
+                ", unmanaged=" + getUnmanaged() +
                 '}';
     }
 
@@ -91,6 +112,8 @@ public class Configuration
         private Domain domain;
         private Outbound outbound;
         private List<ReverseInbound> reverseInbound = new ArrayList<>();
+        private Boolean useEpoll;
+        private Boolean unmanaged;
 
         private Builder()
         {
@@ -120,9 +143,39 @@ public class Configuration
             return this;
         }
 
+        public Builder withUseEpoll( boolean useEpoll )
+        {
+            this.useEpoll = useEpoll;
+            return this;
+        }
+
+        public Builder withUnmanaged( boolean unmanaged )
+        {
+            this.unmanaged = unmanaged;
+            return this;
+        }
+
         public Configuration build()
         {
-            return new Configuration(domain, inbound, outbound, reverseInbound );
+            return new Configuration(domain, inbound, outbound, reverseInbound, useEpoll, unmanaged );
         }
     }
+
+    private Optional<Boolean> getUseEPollFromEnv()
+    {
+        return getEnvValue(USE_EPOLL_ENV_VAR_NAME);
+    }
+
+    private Optional<Boolean> getUnmanagedFromEnv()
+    {
+        return getEnvValue(UNMANAGED_ENV_VAR_NAME);
+    }
+
+    private Optional<Boolean> getEnvValue(String envVarName)
+    {
+        String envString = System.getenv(envVarName);
+        Boolean envValue = null == envString ? null : Boolean.parseBoolean(envString);
+        return Optional.ofNullable(envValue);
+    }
+
 }

--- a/casual/casual-api/src/main/java/se/laz/casual/config/Configuration.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/config/Configuration.java
@@ -14,8 +14,8 @@ import java.util.Optional;
 
 public class Configuration
 {
-    public static final String USE_EPOLL_ENV_VAR_NAME = "CASUAL_OUTBOUND_USE_EPOLL";
-    public static final String UNMANAGED_ENV_VAR_NAME = "CASUAL_OUTBOUND_UNMANAGED";
+    public static final String USE_EPOLL_ENV_VAR_NAME = "CASUAL_USE_EPOLL";
+    public static final String UNMANAGED_ENV_VAR_NAME = "CASUAL_UNMANAGED";
     private final Inbound inbound;
     private final Domain domain;
     private final Outbound outbound;

--- a/casual/casual-api/src/main/java/se/laz/casual/config/Configuration.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/config/Configuration.java
@@ -96,8 +96,8 @@ public class Configuration
                 ", domain=" + getDomain() +
                 ", outbound=" + getOutbound() +
                 ", reverseInbound=" + getReverseInbound() +
-                ", useEpoll=" + getUseEpoll() +
-                ", unmanaged=" + getUnmanaged() +
+                ", useEpoll=" + getUseEpoll().orElse(null) +
+                ", unmanaged=" + getUnmanaged().orElse(null) +
                 '}';
     }
 

--- a/casual/casual-api/src/main/java/se/laz/casual/config/Inbound.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/config/Inbound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, The casual project. All rights reserved.
+ * Copyright (c) 2021 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -14,9 +14,10 @@ public class Inbound
     public static final String CASUAL_INBOUND_STARTUP_MODE = "CASUAL_INBOUND_STARTUP_MODE";
     public static final String CASUAL_INBOUND_USE_EPOLL = "CASUAL_INBOUND_USE_EPOLL";
     public static final String CASUAL_INBOUND_STARTUP_INITIAL_DELAY_ENV_NAME = "CASUAL_INBOUND_STARTUP_INITIAL_DELAY_SECONDS";
+    private static final boolean DEFAULT_USE_EPOLL = false;
 
     private final Startup startup;
-    private final boolean useEpoll;
+    private final Boolean useEpoll;
     private final long initialDelay;
 
     public Inbound( Builder builder )
@@ -33,7 +34,8 @@ public class Inbound
 
     public boolean isUseEpoll()
     {
-        return useEpoll;
+        Optional<Boolean> maybeAlreadySet = ConfigurationService.getInstance().getConfiguration().getUseEpoll();
+        return maybeAlreadySet.orElseGet(() -> null == useEpoll ? DEFAULT_USE_EPOLL : useEpoll);
     }
 
     public long getInitialDelay()
@@ -120,7 +122,8 @@ public class Inbound
             }
             if( useEpoll == null )
             {
-                useEpoll = Boolean.parseBoolean( Optional.ofNullable( System.getenv( CASUAL_INBOUND_USE_EPOLL ) ).orElse( "false" ) );
+                boolean envVarSet = Boolean.parseBoolean( Optional.ofNullable( System.getenv( CASUAL_INBOUND_USE_EPOLL ) ).orElse( "false" ) );
+                useEpoll = envVarSet ? true : null;
             }
             if( initialDelay == null )
             {

--- a/casual/casual-api/src/main/java/se/laz/casual/config/Inbound.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/config/Inbound.java
@@ -69,8 +69,8 @@ public class Inbound
     public String toString()
     {
         return "Inbound{" +
-                "startup=" + startup +
-                ", useEpoll=" + useEpoll +
+                "startup=" + getStartup() +
+                ", useEpoll=" + isUseEpoll() +
                 ", initialDelay=" + initialDelay +
                 '}';
     }
@@ -122,8 +122,8 @@ public class Inbound
             }
             if( useEpoll == null )
             {
-                boolean envVarSet = Boolean.parseBoolean( Optional.ofNullable( System.getenv( CASUAL_INBOUND_USE_EPOLL ) ).orElse( "false" ) );
-                useEpoll = envVarSet ? true : null;
+                String useEpollMode = Optional.ofNullable(System.getenv(CASUAL_INBOUND_USE_EPOLL)).orElse(null);
+                useEpoll = null != useEpollMode ? Boolean.parseBoolean(useEpollMode) : null;
             }
             if( initialDelay == null )
             {

--- a/casual/casual-api/src/main/java/se/laz/casual/config/Outbound.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/config/Outbound.java
@@ -16,7 +16,7 @@ public final class Outbound
     // for the EventLoopGroup
     private static final int DEFAULT_NUMBER_OF_THREADS = 0;
     private static final boolean DEFAULT_UNMANAGED = false;
-    private static final boolean DEFAULT_USE_EPOLL = false;
+    private static final String DEFAULT_USE_EPOLL = "false";
 
     private final String managedExecutorServiceName;
     private int numberOfThreads;
@@ -136,7 +136,7 @@ public final class Outbound
 
     private boolean getUseEPollFromEnv()
     {
-        return Boolean.valueOf(Optional.ofNullable(System.getenv(USE_EPOLL_ENV_VAR_NAME)).orElse("false"));
+        return Boolean.valueOf(Optional.ofNullable(System.getenv(USE_EPOLL_ENV_VAR_NAME)).orElse(DEFAULT_USE_EPOLL));
     }
 
 }

--- a/casual/casual-api/src/main/java/se/laz/casual/config/Outbound.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/config/Outbound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, The casual project. All rights reserved.
+ * Copyright (c) 2021 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -16,14 +16,12 @@ public final class Outbound
     // for the EventLoopGroup
     private static final int DEFAULT_NUMBER_OF_THREADS = 0;
     private static final boolean DEFAULT_UNMANAGED = false;
+    private static final boolean DEFAULT_USE_EPOLL = false;
 
     private final String managedExecutorServiceName;
     private int numberOfThreads;
-    private boolean unmanaged;
-    private Boolean useEpoll;
-
-
-    public static final String USE_EPOLL_ENV_VAR_NAME = "CASUAL_OUTBOUND_USE_EPOLL";
+    private final Boolean unmanaged;
+    private final Boolean useEpoll;
 
     private Outbound(Builder builder)
     {
@@ -38,11 +36,6 @@ public final class Outbound
         return new Builder();
     }
 
-    private boolean getUseEPollFromEnv()
-    {
-        return Boolean.valueOf(Optional.ofNullable(System.getenv(USE_EPOLL_ENV_VAR_NAME)).orElse("false"));
-    }
-
     public String getManagedExecutorServiceName()
     {
         return null == managedExecutorServiceName ? DEFAULT_MANAGED_EXECUTOR_SERVICE_NAME : managedExecutorServiceName;
@@ -55,12 +48,14 @@ public final class Outbound
 
     public boolean getUnmanaged()
     {
-        return unmanaged;
+        Optional<Boolean> maybeAlreadySet = ConfigurationService.getInstance().getConfiguration().getUnmanaged();
+        return maybeAlreadySet.orElseGet(() -> null == unmanaged ? DEFAULT_UNMANAGED : unmanaged);
     }
 
     public boolean getUseEpoll()
     {
-        return null == useEpoll ?  getUseEPollFromEnv() : useEpoll;
+        Optional<Boolean> maybeAlreadySet = ConfigurationService.getInstance().getConfiguration().getUseEpoll();
+        return maybeAlreadySet.orElseGet(() -> null == useEpoll ? DEFAULT_USE_EPOLL : useEpoll);
     }
 
     @Override
@@ -133,7 +128,6 @@ public final class Outbound
         {
             managedExecutorServiceName = null == managedExecutorServiceName ? DEFAULT_MANAGED_EXECUTOR_SERVICE_NAME : managedExecutorServiceName;
             numberOfThreads = null == numberOfThreads ? DEFAULT_NUMBER_OF_THREADS : numberOfThreads;
-            unmanaged = null == unmanaged ? DEFAULT_UNMANAGED : unmanaged;
             return new Outbound(this);
         }
     }

--- a/casual/casual-api/src/main/java/se/laz/casual/config/Outbound.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/config/Outbound.java
@@ -23,6 +23,8 @@ public final class Outbound
     private final Boolean unmanaged;
     private final Boolean useEpoll;
 
+    public static final String USE_EPOLL_ENV_VAR_NAME = "CASUAL_OUTBOUND_USE_EPOLL";
+
     private Outbound(Builder builder)
     {
         managedExecutorServiceName = builder.managedExecutorServiceName;
@@ -55,7 +57,7 @@ public final class Outbound
     public boolean getUseEpoll()
     {
         Optional<Boolean> maybeAlreadySet = ConfigurationService.getInstance().getConfiguration().getUseEpoll();
-        return maybeAlreadySet.orElseGet(() -> null == useEpoll ? DEFAULT_USE_EPOLL : useEpoll);
+        return maybeAlreadySet.orElseGet(() -> null != useEpoll ? useEpoll : getUseEPollFromEnv());
     }
 
     @Override
@@ -130,6 +132,11 @@ public final class Outbound
             numberOfThreads = null == numberOfThreads ? DEFAULT_NUMBER_OF_THREADS : numberOfThreads;
             return new Outbound(this);
         }
+    }
+
+    private boolean getUseEPollFromEnv()
+    {
+        return Boolean.valueOf(Optional.ofNullable(System.getenv(USE_EPOLL_ENV_VAR_NAME)).orElse("false"));
     }
 
 }

--- a/casual/casual-api/src/test/groovy/se/laz/casual/config/ConfigurationServiceTest.groovy
+++ b/casual/casual-api/src/test/groovy/se/laz/casual/config/ConfigurationServiceTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, The casual project. All rights reserved.
+ * Copyright (c) 2021 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -120,7 +120,6 @@ class ConfigurationServiceTest extends Specification
    def 'no outbound config, useEpoll set via env var'()
    {
       given:
-      // Outbound.of('java:comp/DefaultManagedExecutorService', 0, false, true)
       Configuration expected = Configuration.newBuilder()
               .withOutbound(Outbound.newBuilder()
                       .withManagedExecutorServiceName('java:comp/DefaultManagedExecutorService')
@@ -131,13 +130,38 @@ class ConfigurationServiceTest extends Specification
               .build()
       when:
       Configuration actual
-      withEnvironmentVariable( Outbound.USE_EPOLL_ENV_VAR_NAME, "true" )
+      withEnvironmentVariable( Configuration.USE_EPOLL_ENV_VAR_NAME, "true" )
               .execute( {
                   reinitialiseConfigurationService( )
                   actual = instance.getConfiguration()
               } )
       then:
-      withEnvironmentVariable( Outbound.USE_EPOLL_ENV_VAR_NAME, "true" )
+      withEnvironmentVariable( Configuration.USE_EPOLL_ENV_VAR_NAME, "true" )
+              .execute( {
+                 actual == expected
+              } )
+   }
+
+   def 'no outbound config, unmanaged set via env var'()
+   {
+      given:
+      Configuration expected = Configuration.newBuilder()
+              .withOutbound(Outbound.newBuilder()
+                      .withManagedExecutorServiceName('java:comp/DefaultManagedExecutorService')
+                      .withNumberOfThreads(0)
+                      .withUnmanaged(true)
+                      .withUseEpoll(false)
+                      .build())
+              .build()
+      when:
+      Configuration actual
+      withEnvironmentVariable( Configuration.UNMANAGED_ENV_VAR_NAME, "true" )
+              .execute( {
+                 reinitialiseConfigurationService( )
+                 actual = instance.getConfiguration()
+              } )
+      then:
+      withEnvironmentVariable( Configuration.UNMANAGED_ENV_VAR_NAME, "true" )
               .execute( {
                  actual == expected
               } )

--- a/casual/casual-api/src/test/groovy/se/laz/casual/config/ConfigurationServiceTest.groovy
+++ b/casual/casual-api/src/test/groovy/se/laz/casual/config/ConfigurationServiceTest.groovy
@@ -127,6 +127,7 @@ class ConfigurationServiceTest extends Specification
                       .withUnmanaged(false)
                       .withUseEpoll(true)
                       .build())
+              .withInbound(Inbound.newBuilder().withUseEpoll(true).build())
               .build()
       when:
       Configuration actual

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceAdapter.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -111,7 +111,7 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
                                                                    .withAddress(new InetSocketAddress(instance.getAddress().getHost(), instance.getAddress().getPort()))
                                                                    .withDomainId(configurationService.getConfiguration().getDomain().getId())
                                                                    .withDomainName(configurationService.getConfiguration().getDomain().getName())
-                                                                   .withUseEpoll(configurationService.getConfiguration().getInbound().isUseEpoll())
+                                                                   .withUseEpoll(configurationService.getConfiguration().getOutbound().getUseEpoll())
                                                                    .withFactory(endpointFactory)
                                                                    .withWorkManager(workManager)
                                                                    .withXaTerminator(xaTerminator)

--- a/casual/casual-network/src/main/java/se/laz/casual/network/EventLoopClient.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/EventLoopClient.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
+package se.laz.casual.network;
+
+public enum EventLoopClient
+{
+    OUTBOUND,
+    REVERSE
+}

--- a/casual/casual-network/src/main/java/se/laz/casual/network/EventLoopFactory.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/EventLoopFactory.java
@@ -1,29 +1,36 @@
 /*
- * Copyright (c) 2021, The casual project. All rights reserved.
+ * Copyright (c) 2021 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
-package se.laz.casual.network.outbound;
+package se.laz.casual.network;
 
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import se.laz.casual.config.ConfigurationService;
 import se.laz.casual.config.Outbound;
+import se.laz.casual.network.outbound.JEEConcurrencyFactory;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
 public final class EventLoopFactory
 {
     private static final Logger LOG = Logger.getLogger(EventLoopFactory.class.getName());
-    private static final EventLoopGroup INSTANCE = createEventLoopGroup();
+    private static final Map<EventLoopClient, EventLoopGroup> INSTANCES = new ConcurrentHashMap<>();
+    static
+    {
+        INSTANCES.put(EventLoopClient.OUTBOUND, createEventLoopGroup());
+        INSTANCES.put(EventLoopClient.REVERSE, createEventLoopGroup());
+    }
     private EventLoopFactory()
     {}
-    public static synchronized EventLoopGroup getInstance()
+    public static synchronized EventLoopGroup getInstance(EventLoopClient type)
     {
-        return INSTANCE;
+        return INSTANCES.get(type);
     }
-
     private static EventLoopGroup createEventLoopGroup()
     {
         Outbound outbound = ConfigurationService.getInstance().getConfiguration().getOutbound();

--- a/casual/casual-network/src/main/java/se/laz/casual/network/EventLoopFactory.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/EventLoopFactory.java
@@ -19,9 +19,10 @@ import java.util.logging.Logger;
 public final class EventLoopFactory
 {
     private static final Logger LOG = Logger.getLogger(EventLoopFactory.class.getName());
-    private static final Map<EventLoopClient, EventLoopGroup> INSTANCES = new ConcurrentHashMap<>();
+    private static final Map<EventLoopClient, EventLoopGroup> INSTANCES;
     static
     {
+        INSTANCES = new ConcurrentHashMap<>();
         INSTANCES.put(EventLoopClient.OUTBOUND, createEventLoopGroup());
         INSTANCES.put(EventLoopClient.REVERSE, createEventLoopGroup());
     }

--- a/casual/casual-network/src/main/java/se/laz/casual/network/EventLoopFactory.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/EventLoopFactory.java
@@ -44,7 +44,7 @@ public final class EventLoopFactory
 
     private static EventLoopGroup getUnmanagedEventLoopGroup(boolean useEpoll, int numberOfThreads)
     {
-        LOG.info(() -> "outbound not using any ManagedExecutorService, running unmanaged");
+        LOG.info(() -> "event loop group not using any ManagedExecutorService, running unmanaged");
         if(useEpoll)
         {
             LOG.info(() -> "using EpollEventLoopGroup");

--- a/casual/casual-network/src/main/java/se/laz/casual/network/LogLevelMapper.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/LogLevelMapper.java
@@ -10,6 +10,8 @@ import se.laz.casual.api.CasualTypeException;
 
 public final class LogLevelMapper
 {
+    private LogLevelMapper()
+    {}
     public static LogLevel map(ExternalLogLevel level)
     {
         switch(level)

--- a/casual/casual-network/src/main/java/se/laz/casual/network/LogLevelProvider.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/LogLevelProvider.java
@@ -18,7 +18,8 @@ public final class LogLevelProvider
     public static final LogLevel REVERSE_LOGGING_LEVEL = getOrDefault(CASUAL_REVERSE_INBOUND_NETTY_LOGGING_LEVEL_NAME);
     public static final LogLevel INBOUND_LOGGING_LEVEL = getOrDefault(CASUAL_INBOUND_NETTY_LOGGING_LEVEL_NAME);
     public static final LogLevel OUTBOUND_LOGGING_LEVEL = getOrDefault(CASUAL_OUTBOUND_NETTY_LOGGING_LEVEL_NAME);
-
+    private LogLevelProvider()
+    {}
     public static LogLevel getOrDefault(String envName)
     {
         ExternalLogLevel externalLogLevel = ExternalLogLevel.unmarshall(Optional.ofNullable(getEnv(envName)).orElse(DEFAULT_LOGGING_LEVEL));

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/CasualServer.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/CasualServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -17,7 +17,6 @@ import io.netty.channel.epoll.EpollServerSocketChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
-import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 import se.laz.casual.network.CasualNWMessageDecoder;
 import se.laz.casual.network.CasualNWMessageEncoder;

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundServerImpl.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundServerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, The casual project. All rights reserved.
+ * Copyright (c) 2022 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -11,12 +11,12 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.epoll.EpollEventLoopGroup;
-import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.logging.LoggingHandler;
 import se.laz.casual.network.CasualNWMessageDecoder;
 import se.laz.casual.network.CasualNWMessageEncoder;
+import se.laz.casual.network.EventLoopClient;
+import se.laz.casual.network.EventLoopFactory;
 import se.laz.casual.network.LogLevelProvider;
 import se.laz.casual.network.reverse.inbound.ReverseInboundListener;
 import se.laz.casual.network.reverse.inbound.ReverseInboundServer;
@@ -51,7 +51,7 @@ public class ReverseInboundServerImpl implements ReverseInboundServer
     {
         Objects.requireNonNull(reverseInboundConnectionInformation, "connectionInformation can not be null");
         ReverseInboundMessageHandler messageHandler = ReverseInboundMessageHandler.of(reverseInboundConnectionInformation.getFactory(), reverseInboundConnectionInformation.getXaTerminator(), reverseInboundConnectionInformation.getWorkManager());
-        Channel ch = init(reverseInboundConnectionInformation.getAddress(), reverseInboundConnectionInformation.isUseEpoll(), messageHandler, ReverseInboundExceptionHandler.of(), reverseInboundConnectionInformation.isLogHandlerEnabled(), reverseInboundConnectionInformation.getChannelClass());
+        Channel ch = init(reverseInboundConnectionInformation.getAddress(), messageHandler, ReverseInboundExceptionHandler.of(), reverseInboundConnectionInformation.isLogHandlerEnabled(), reverseInboundConnectionInformation.getChannelClass());
         ReverseInboundServerImpl server = new ReverseInboundServerImpl(ch, reverseInboundConnectionInformation.getAddress(), workManagerSupplier);
         ch.closeFuture().addListener(f -> server.onClose(reverseInboundConnectionInformation, eventListener));
         LOG.info(() -> "reverse inbound connected to: " + reverseInboundConnectionInformation.getAddress());
@@ -64,9 +64,9 @@ public class ReverseInboundServerImpl implements ReverseInboundServer
         AutoReconnect.of(reverseInboundConnectionInformation, eventListener, workManagerSupplier);
     }
 
-    private static Channel init(final InetSocketAddress address, boolean useEpoll , final ReverseInboundMessageHandler messageHandler, ReverseInboundExceptionHandler exceptionHandler, boolean enableLogHandler, Class<? extends Channel> channelClass)
+    private static Channel init(final InetSocketAddress address, final ReverseInboundMessageHandler messageHandler, ReverseInboundExceptionHandler exceptionHandler, boolean enableLogHandler, Class<? extends Channel> channelClass)
     {
-        EventLoopGroup workerGroup = useEpoll ? new EpollEventLoopGroup() : new NioEventLoopGroup();
+        EventLoopGroup workerGroup = EventLoopFactory.getInstance(EventLoopClient.REVERSE);
         Bootstrap b = new Bootstrap()
                 .group(workerGroup)
                 .channel(channelClass)

--- a/casual/casual-network/src/main/java/se/laz/casual/network/outbound/NettyNetworkConnection.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/outbound/NettyNetworkConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2023, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -13,7 +13,6 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
-import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 import se.laz.casual.api.conversation.ConversationClose;
 import se.laz.casual.api.network.protocol.messages.CasualNWMessage;
@@ -24,6 +23,8 @@ import se.laz.casual.jca.ConnectionObserver;
 import se.laz.casual.jca.DomainId;
 import se.laz.casual.network.CasualNWMessageDecoder;
 import se.laz.casual.network.CasualNWMessageEncoder;
+import se.laz.casual.network.EventLoopClient;
+import se.laz.casual.network.EventLoopFactory;
 import se.laz.casual.network.LogLevelProvider;
 import se.laz.casual.network.ProtocolVersion;
 import se.laz.casual.network.connection.CasualConnectionException;
@@ -84,7 +85,7 @@ public class NettyNetworkConnection implements NetworkConnection, ConversationCl
         Objects.requireNonNull(ci, "network listener can not be null");
         ErrorInformer errorInformer = ErrorInformer.of(new CasualConnectionException("network connection is gone"));
         errorInformer.addListener(networkListener);
-        EventLoopGroup workerGroup = EventLoopFactory.getInstance();
+        EventLoopGroup workerGroup = EventLoopFactory.getInstance(EventLoopClient.OUTBOUND);
         Correlator correlator = ci.getCorrelator();
         ConversationMessageStorage conversationMessageStorage = ConversationMessageStorageImpl.of();
         OnNetworkError onNetworkError = channel -> NetworkErrorHandler.notifyListenersIfNotConnected(channel, errorInformer);

--- a/casual/casual-network/src/test/groovy/se/laz/casual/network/EventLoopFactoryTest.groovy
+++ b/casual/casual-network/src/test/groovy/se/laz/casual/network/EventLoopFactoryTest.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
+package se.laz.casual.network
+
+import se.laz.casual.config.Configuration
+import spock.lang.Specification
+
+import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable
+
+class EventLoopFactoryTest extends Specification
+{
+   def 'correct instances are returned'()
+   {
+      given:
+      def outboundEventLoopGroup
+      def reverseEventLoopGroup
+      when:
+      withEnvironmentVariable( Configuration.UNMANAGED_ENV_VAR_NAME, "true" )
+              .execute( {
+                 outboundEventLoopGroup = EventLoopFactory.getInstance(EventLoopClient.OUTBOUND)
+                 reverseEventLoopGroup = EventLoopFactory.getInstance(EventLoopClient.REVERSE)
+              } )
+      then:
+      withEnvironmentVariable( Configuration.UNMANAGED_ENV_VAR_NAME, "true" )
+              .execute({
+                 outboundEventLoopGroup != reverseEventLoopGroup
+                 outboundEventLoopGroup == EventLoopFactory.getInstance(EventLoopClient.OUTBOUND)
+                 reverseEventLoopGroup == EventLoopFactory.getInstance(EventLoopClient.REVERSE)
+              })
+   }
+}

--- a/casual/casual-network/src/test/groovy/se/laz/casual/network/outbound/NettyConnectionInformationCreatorTest.groovy
+++ b/casual/casual-network/src/test/groovy/se/laz/casual/network/outbound/NettyConnectionInformationCreatorTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, The casual project. All rights reserved.
+ * Copyright (c) 2022 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -7,12 +7,12 @@
 package se.laz.casual.network.outbound
 
 import io.netty.channel.epoll.EpollSocketChannel
-import se.laz.casual.config.Outbound
-
-import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable
 import io.netty.channel.socket.nio.NioSocketChannel
+import se.laz.casual.config.Configuration
 import se.laz.casual.network.ProtocolVersion
 import spock.lang.Specification
+
+import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable
 
 class NettyConnectionInformationCreatorTest extends Specification
 {
@@ -34,7 +34,7 @@ class NettyConnectionInformationCreatorTest extends Specification
       ProtocolVersion protocolVersion = ProtocolVersion.VERSION_1_0
       when:
       NettyConnectionInformation ci
-      withEnvironmentVariable( Outbound.USE_EPOLL_ENV_VAR_NAME, "true" )
+      withEnvironmentVariable( Configuration.USE_EPOLL_ENV_VAR_NAME, "true" )
               .execute( {
                  ci = NettyConnectionInformationCreator.create(address, protocolVersion)
                  } )

--- a/configuration.md
+++ b/configuration.md
@@ -14,8 +14,8 @@ Casual supports the following configuration options which can be set using envir
 * `CASUAL_CONFIG_FILE` - Set path for casual configuration file. If not provided, default are used.
 * `CASUAL_INBOUND_STARTUP_MODE` - Set mode for inbound startup. Default `immediate`. Alternatives `trigger`, `discover`.
     See [Inbound Startup Configuration](inbound.md#startup-configuration) for more details.
-* `CASUAL_OUTBOUND_USE_EPOLL` - If set to true, Netty uses epoll instead of NIO - deprecated, please see `CASUAL_USE_EPOLL` instead.
-* `CASUAL_INBOUND_USE_EPOLL` - If set to true, Netty uses epoll instead of NIO - deprecated, please see `CASUAL_USE_EPOLL` instead.
+* `CASUAL_OUTBOUND_USE_EPOLL` - If set to true, Netty uses epoll instead of NIO - deprecated, please use `CASUAL_USE_EPOLL` instead.
+* `CASUAL_INBOUND_USE_EPOLL` - If set to true, Netty uses epoll instead of NIO - deprecated, please use `CASUAL_USE_EPOLL` instead.
 * `CASUAL_OUTBOUND_USE_EPOLL` - If set to true, Netty uses epoll instead of NIO, this goes for outbound, inbound and reverse inbound.
 * `CASUAL_INBOUND_STARTUP_INITIAL_DELAY_SECONDS` - Delay the startup of the inbound server. Default is no delay.
 * `CASUAL_UNMANAGED_SCHEDULED_EXECUTOR_SERVICE_POOL_SIZE` - The pool size of casual's scheduled executor service instance. Defaults to 10.

--- a/configuration.md
+++ b/configuration.md
@@ -16,7 +16,7 @@ Casual supports the following configuration options which can be set using envir
     See [Inbound Startup Configuration](inbound.md#startup-configuration) for more details.
 * `CASUAL_OUTBOUND_USE_EPOLL` - If set to true, Netty uses epoll instead of NIO - deprecated, please use `CASUAL_USE_EPOLL` instead.
 * `CASUAL_INBOUND_USE_EPOLL` - If set to true, Netty uses epoll instead of NIO - deprecated, please use `CASUAL_USE_EPOLL` instead.
-* `CASUAL_OUTBOUND_USE_EPOLL` - If set to true, Netty uses epoll instead of NIO, this goes for outbound, inbound and reverse inbound.
+* `CASUAL_USE_EPOLL` - If set to true, Netty uses epoll instead of NIO, this goes for outbound, inbound and reverse inbound.
 * `CASUAL_INBOUND_STARTUP_INITIAL_DELAY_SECONDS` - Delay the startup of the inbound server. Default is no delay.
 * `CASUAL_UNMANAGED_SCHEDULED_EXECUTOR_SERVICE_POOL_SIZE` - The pool size of casual's scheduled executor service instance. Defaults to 10.
 * `CASUAL_UNMANAGED` - If set to false, outbound and reverse inbound will use a managed executor service.

--- a/configuration.md
+++ b/configuration.md
@@ -14,10 +14,12 @@ Casual supports the following configuration options which can be set using envir
 * `CASUAL_CONFIG_FILE` - Set path for casual configuration file. If not provided, default are used.
 * `CASUAL_INBOUND_STARTUP_MODE` - Set mode for inbound startup. Default `immediate`. Alternatives `trigger`, `discover`.
     See [Inbound Startup Configuration](inbound.md#startup-configuration) for more details.
-* `CASUAL_OUTBOUND_USE_EPOLL` - If set to true, Netty uses epoll instead of NIO.
-* `CASUAL_INBOUND_USE_EPOLL` - If set to true, Netty uses epoll instead of NIO.
+* `CASUAL_OUTBOUND_USE_EPOLL` - If set to true, Netty uses epoll instead of NIO - deprecated, please see `CASUAL_OUTBOUND_USE_EPOLL` instead.
+* `CASUAL_INBOUND_USE_EPOLL` - If set to true, Netty uses epoll instead of NIO - deprecated, please see `CASUAL_OUTBOUND_USE_EPOLL` instead.
+* `CASUAL_OUTBOUND_USE_EPOLL` - If set to true, Netty uses epoll instead of NIO, this goes for outbound, inbound and reverse inbound.
 * `CASUAL_INBOUND_STARTUP_INITIAL_DELAY_SECONDS` - Delay the startup of the inbound server. Default is no delay.
 * `CASUAL_UNMANAGED_SCHEDULED_EXECUTOR_SERVICE_POOL_SIZE` - The pool size of casual's scheduled executor service instance. Defaults to 10.
+* `CASUAL_UNMANAGED` - If set to true, outbound and reverse inbound will use a managed executor service.
 
 NB - if a `CASUAL_CONFIG_FILE` is provided, it take precedence over the `CASUAL_INBOUND_STARTUP_MODE` setting.
 However, if some configuration is missing from the configuration file but has a setting via an environment variable then this will be used before any hardcoded default setting.
@@ -38,7 +40,6 @@ The available log levels are:
 Note, the level you set needs to be equal to or less than the level set to the package `io.netty`.
 For instance, with logging level for the package `io.netty` set to `DEBUG` and `CASUAL_OUTBOUND_NETTY_LOGGING_LEVEL` also set to `DEBUG`, that will work.
 Using level `INFO` will also work where as `TRACE` would not in this case.
-
 
 ## Casual Config File
 

--- a/configuration.md
+++ b/configuration.md
@@ -14,12 +14,12 @@ Casual supports the following configuration options which can be set using envir
 * `CASUAL_CONFIG_FILE` - Set path for casual configuration file. If not provided, default are used.
 * `CASUAL_INBOUND_STARTUP_MODE` - Set mode for inbound startup. Default `immediate`. Alternatives `trigger`, `discover`.
     See [Inbound Startup Configuration](inbound.md#startup-configuration) for more details.
-* `CASUAL_OUTBOUND_USE_EPOLL` - If set to true, Netty uses epoll instead of NIO - deprecated, please see `CASUAL_OUTBOUND_USE_EPOLL` instead.
-* `CASUAL_INBOUND_USE_EPOLL` - If set to true, Netty uses epoll instead of NIO - deprecated, please see `CASUAL_OUTBOUND_USE_EPOLL` instead.
+* `CASUAL_OUTBOUND_USE_EPOLL` - If set to true, Netty uses epoll instead of NIO - deprecated, please see `CASUAL_USE_EPOLL` instead.
+* `CASUAL_INBOUND_USE_EPOLL` - If set to true, Netty uses epoll instead of NIO - deprecated, please see `CASUAL_USE_EPOLL` instead.
 * `CASUAL_OUTBOUND_USE_EPOLL` - If set to true, Netty uses epoll instead of NIO, this goes for outbound, inbound and reverse inbound.
 * `CASUAL_INBOUND_STARTUP_INITIAL_DELAY_SECONDS` - Delay the startup of the inbound server. Default is no delay.
 * `CASUAL_UNMANAGED_SCHEDULED_EXECUTOR_SERVICE_POOL_SIZE` - The pool size of casual's scheduled executor service instance. Defaults to 10.
-* `CASUAL_UNMANAGED` - If set to true, outbound and reverse inbound will use a managed executor service.
+* `CASUAL_UNMANAGED` - If set to false, outbound and reverse inbound will use a managed executor service.
 
 NB - if a `CASUAL_CONFIG_FILE` is provided, it take precedence over the `CASUAL_INBOUND_STARTUP_MODE` setting.
 However, if some configuration is missing from the configuration file but has a setting via an environment variable then this will be used before any hardcoded default setting.

--- a/outbound.md
+++ b/outbound.md
@@ -27,6 +27,9 @@ Example configurations:
 }
 ```
 
+Note that the usage of both `unmanaged` and `useEpoll` in the outbound configuration section is `deprecated`.
+You should instead configure these properties at the root level of the configuration.
+
 See configuration(configuration.md) for more info regarding how configuration works in general.
 
 It is fine to only configure one attribute, the other one will then use the default value.

--- a/reverse-inbound.md
+++ b/reverse-inbound.md
@@ -27,6 +27,7 @@ On *casual-jca* startup, this configuration is read and for each configuration a
 host:port. If no size is specified then only one such connection is created per configuration.
 
 After the connection has succeeded, this connection now works as it was a normal *inbound* connection.
+It is still in fact a client though.
 
 ## Error handling
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '2.2.31'
+version = '2.2.32'
 
 def netty_version = '4.1.109.Final'
 def gson_version = '2.10.1'

--- a/versions.gradle
+++ b/versions.gradle
@@ -9,7 +9,7 @@
 group = 'se.laz.casual'
 version = '2.2.32'
 
-def netty_version = '4.1.109.Final'
+def netty_version = '4.1.110.Final'
 def gson_version = '2.10.1'
 
 ext.libs = [


### PR DESCRIPTION
* All reverse inbound clients now shares the same event loop group instead of creating a new per connection
  This works the same way as it currently does for outbound connections.
* New root property useEpoll - can also be set via env var CASUAL_USE_EPOLL
  If set to true, epoll is used for outbound, inbound and reverse inbound
* New root property unmanaged - can also be configured via env var CASUAL_UNMANAGED
  If set to true, outbound and reverse inbound runs using a managed executor ( only supported on jboss/wildfly currently)
* Netty version bump to 4.1.110.Final
* The deprecated configuration options re epoll and unmanaged will be removed in a future version
