### PR TITLE
Let netty handle DNS-resolution

### DIFF
--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualManagedConnection.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualManagedConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -321,7 +321,7 @@ public class CasualManagedConnection implements ManagedConnection, NetworkListen
 
     private NetworkConnection createOneToOneManagedConnection()
     {
-        NettyConnectionInformation ci = NettyConnectionInformationCreator.create(new InetSocketAddress(mcf.getHostName(), mcf.getPortNumber()), mcf.getCasualProtocolVersion());
+        NettyConnectionInformation ci = NettyConnectionInformationCreator.create(InetSocketAddress.createUnresolved(mcf.getHostName(), mcf.getPortNumber()), mcf.getCasualProtocolVersion());
         NetworkConnection newNetworkConnection = NettyNetworkConnection.of(ci, this);
         log.finest(() -> "created new nw connection " + this);
         return newNetworkConnection;

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceAdapter.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceAdapter.java
@@ -108,7 +108,7 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
         for(ReverseInbound instance : reverseInbound)
         {
             startReverseInbound(ReverseInboundConnectionInformation.createBuilder()
-                                                                   .withAddress(new InetSocketAddress(instance.getAddress().getHost(), instance.getAddress().getPort()))
+                                                                   .withAddress(InetSocketAddress.createUnresolved(instance.getAddress().getHost(), instance.getAddress().getPort()))
                                                                    .withDomainId(configurationService.getConfiguration().getDomain().getId())
                                                                    .withDomainName(configurationService.getConfiguration().getDomain().getName())
                                                                    .withUseEpoll(configurationService.getConfiguration().getOutbound().getUseEpoll())
@@ -131,7 +131,8 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
                AutoConnect.of(connectionInformation, future::complete,this, () -> workManager);
                return future.join();
             };
-            Supplier<String> logMsg = () -> "casual reverse inbound connected to: " + connectionInformation.getAddress();
+            Supplier<String> logMsg = () -> "casual reverse inbound connected to: " +
+                    new InetSocketAddress(connectionInformation.getAddress().getHostName(), connectionInformation.getAddress().getPort());
             Work work = StartInboundServerWork.of(getInboundStartupServices(), logMsg, consumer, supplier);
             startWork(work, StartReverseInboundServerListener.of());
         }

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/pool/NetworkConnectionPool.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/pool/NetworkConnectionPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, The casual project. All rights reserved.
+ * Copyright (c) 2022 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -8,10 +8,10 @@ package se.laz.casual.jca.pool;
 import se.laz.casual.internal.network.NetworkConnection;
 import se.laz.casual.jca.Address;
 import se.laz.casual.jca.CasualResourceAdapterException;
-import se.laz.casual.network.outbound.NettyConnectionInformationCreator;
 import se.laz.casual.network.ProtocolVersion;
 import se.laz.casual.network.connection.CasualConnectionException;
 import se.laz.casual.network.outbound.NettyConnectionInformation;
+import se.laz.casual.network.outbound.NettyConnectionInformationCreator;
 import se.laz.casual.network.outbound.NettyNetworkConnection;
 import se.laz.casual.network.outbound.NetworkListener;
 
@@ -124,7 +124,7 @@ public class NetworkConnectionPool implements ReferenceCountedNetworkCloseListen
 
     private static ReferenceCountedNetworkConnection createNetworkConnection(Address address, ProtocolVersion protocolVersion, NetworkListener networkListener, ReferenceCountedNetworkCloseListener referenceCountedNetworkCloseListener, NetworkListener ownListener)
     {
-        NettyConnectionInformation ci = NettyConnectionInformationCreator.create(new InetSocketAddress(address.getHostName(), address.getPort()), protocolVersion);
+        NettyConnectionInformation ci = NettyConnectionInformationCreator.create(InetSocketAddress.createUnresolved(address.getHostName(), address.getPort()), protocolVersion);
         NetworkConnection networkConnection = NettyNetworkConnection.of(ci, ownListener);
         if (networkConnection instanceof NettyNetworkConnection)
         {

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/AutoConnect.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/AutoConnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, The casual project. All rights reserved.
+ * Copyright (c) 2022 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -36,10 +36,7 @@ public class AutoConnect
       Objects.requireNonNull(eventListener, "eventListener can not be null");
       Objects.requireNonNull(workManagerSupplier, "workManagerSupplier can not be null");
       Supplier<ReverseInboundServer> supplier = () -> ReverseInboundServerImpl.of(reverseInboundConnectionInformation, eventListener, workManagerSupplier);
-      Consumer<ReverseInboundServer> consumer = server -> {
-         connectListener.connected(server);
-         eventListener.connected(server);
-      };
+      Consumer<ReverseInboundServer> consumer = connectListener::connected;
       RepeatUntilSuccessTaskWork<ReverseInboundServer> task = RepeatUntilSuccessTaskWork.of(
               supplier,
               consumer,

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundConnectionInformation.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundConnectionInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, The casual project. All rights reserved.
+ * Copyright (c) 2022 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -53,7 +53,7 @@ public class ReverseInboundConnectionInformation
 
     public InetSocketAddress getAddress()
     {
-        return address;
+        return InetSocketAddress.createUnresolved(address.getHostName(), address.getPort());
     }
 
     public ProtocolVersion getProtocolVersion()

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundServerImpl.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundServerImpl.java
@@ -54,7 +54,7 @@ public class ReverseInboundServerImpl implements ReverseInboundServer
         Channel ch = init(reverseInboundConnectionInformation.getAddress(), messageHandler, ReverseInboundExceptionHandler.of(), reverseInboundConnectionInformation.isLogHandlerEnabled(), reverseInboundConnectionInformation.getChannelClass());
         ReverseInboundServerImpl server = new ReverseInboundServerImpl(ch, reverseInboundConnectionInformation.getAddress(), workManagerSupplier);
         ch.closeFuture().addListener(f -> server.onClose(reverseInboundConnectionInformation, eventListener));
-        LOG.info(() -> "reverse inbound connected to: " + reverseInboundConnectionInformation.getAddress());
+        LOG.info(() -> "reverse inbound connected to: " + server.getAddress());
         return server;
     }
 
@@ -91,7 +91,7 @@ public class ReverseInboundServerImpl implements ReverseInboundServer
     @Override
     public InetSocketAddress getAddress()
     {
-        return address;
+        return new InetSocketAddress(address.getHostName(), address.getPort());
     }
 
     @Override

--- a/casual/casual-network/src/main/java/se/laz/casual/network/outbound/BaseConnectionInformation.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/outbound/BaseConnectionInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -30,7 +30,7 @@ public abstract class BaseConnectionInformation
 
     public InetSocketAddress getAddress()
     {
-        return new InetSocketAddress(address.getAddress(), address.getPort());
+        return InetSocketAddress.createUnresolved(address.getHostName(), address.getPort());
     }
 
     public UUID getDomainId()

--- a/casual/casual-network/src/main/java/se/laz/casual/network/outbound/NettyNetworkConnection.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/outbound/NettyNetworkConnection.java
@@ -93,7 +93,7 @@ public class NettyNetworkConnection implements NetworkConnection, ConversationCl
         CasualMessageHandler messageHandler = CasualMessageHandler.of(correlator);
         Channel ch = init(ci.getAddress(), workerGroup, ci.getChannelClass(), messageHandler, conversationMessageHandler, ExceptionHandler.of(correlator, onNetworkError), ci.isLogHandlerEnabled());
         NettyNetworkConnection networkConnection = new NettyNetworkConnection(ci, correlator, ch, conversationMessageStorage, JEEConcurrencyFactory::getManagedExecutorService, errorInformer);
-        LOG.finest(() -> networkConnection + " connected to: " + ci.getAddress());
+        LOG.finest(() -> networkConnection + " connected to: " + new InetSocketAddress(ci.getAddress().getHostName(), ci.getAddress().getPort()));
         ch.closeFuture().addListener(f -> handleClose(networkConnection, errorInformer));
         DomainId id = networkConnection.throwIfProtocolVersionNotSupportedByEIS(ci.getDomainId(), ci.getDomainName());
         networkConnection.setDomainId(id);

--- a/casual/casual-network/src/test/groovy/se/laz/casual/network/inbound/reverse/ReverseInboundConnectionInformationTest.groovy
+++ b/casual/casual-network/src/test/groovy/se/laz/casual/network/inbound/reverse/ReverseInboundConnectionInformationTest.groovy
@@ -1,20 +1,30 @@
+/*
+ * Copyright (c) 2024, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
 package se.laz.casual.network.inbound.reverse
 
 import io.netty.channel.Channel
-import io.netty.channel.epoll.EpollSocketChannel;
-import io.netty.channel.socket.nio.NioSocketChannel;
-import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable
-import javax.resource.spi.XATerminator
-import javax.resource.spi.endpoint.MessageEndpointFactory
-import javax.resource.spi.work.WorkManager
+import io.netty.channel.epoll.EpollSocketChannel
+import io.netty.channel.socket.nio.NioSocketChannel
 import se.laz.casual.network.ProtocolVersion
 import se.laz.casual.network.outbound.Correlator
 import spock.lang.Specification
 
-class ReverseInboundConnectionInformationTest extends Specification {
-   def "test ReverseInboundConnectionInformation, with useEpoll"() {
+import javax.resource.spi.XATerminator
+import javax.resource.spi.endpoint.MessageEndpointFactory
+import javax.resource.spi.work.WorkManager
+
+import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable
+
+class ReverseInboundConnectionInformationTest extends Specification
+{
+   def "test ReverseInboundConnectionInformation, with useEpoll"()
+   {
       setup:
-      InetSocketAddress address = new InetSocketAddress("localhost", 8080)
+      InetSocketAddress address = InetSocketAddress.createUnresolved("localhost", 8080)
       ProtocolVersion protocolVersion = ProtocolVersion.VERSION_1_0
       Correlator correlator = Mock(Correlator)
       MessageEndpointFactory factory = Mock(MessageEndpointFactory)
@@ -58,9 +68,10 @@ class ReverseInboundConnectionInformationTest extends Specification {
       connectionInfo.isLogHandlerEnabled() == isLogHandlerEnabled
    }
 
-   def "test ReverseInboundConnectionInformation, no useEpoll"() {
+   def "test ReverseInboundConnectionInformation, no useEpoll"()
+   {
       setup:
-      InetSocketAddress address = new InetSocketAddress("localhost", 8080)
+      InetSocketAddress address = InetSocketAddress.createUnresolved("localhost", 8080)
       ProtocolVersion protocolVersion = ProtocolVersion.VERSION_1_0
       Correlator correlator = Mock(Correlator)
       MessageEndpointFactory factory = Mock(MessageEndpointFactory)

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,9 +7,9 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '2.2.32'
+version = '2.2.33'
 
-def netty_version = '4.1.110.Final'
+def netty_version = '4.1.113.Final'
 def gson_version = '2.10.1'
 
 ext.libs = [


### PR DESCRIPTION
Let netty handle DNS-resolution

This fixes a bug where we would cache a resolved InetSocketAddress.

The intention is now clear, we never hand over a resolved InetSocketAddress to netty.