### PR TITLE
Feature/3.2/java 17 sonar fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,9 +12,8 @@ buildscript {
     }
 }
 
-
 plugins {
-  id("org.sonarqube") version "4.4.1.3373"
+  id "org.sonarqube" version "5.1.0.4882"
 }
 
 apply from: 'testsourcesets.gradle'

--- a/casual/casual-api/src/main/java/se/laz/casual/api/buffer/type/fielded/FieldedTypeBuffer.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/buffer/type/fielded/FieldedTypeBuffer.java
@@ -109,14 +109,12 @@ public final class FieldedTypeBuffer implements CasualBuffer
      * @param b the buffer to copy
      * @return a new buffer
      */
-    // java:S6204 - the resulting value list needs to be mutable
-    @SuppressWarnings("java:S6204")
     public static FieldedTypeBuffer of(FieldedTypeBuffer b)
     {
         Objects.requireNonNull(b, "buffer can not be null");
         FieldedTypeBuffer r = FieldedTypeBuffer.create();
         // shallow copy, keys and values are immutable
-        b.m.forEach((key, val) -> r.m.put(key, val.stream().collect(Collectors.toList())));
+        b.m.forEach((key, val) -> r.m.put(key, new ArrayList<>(val)));
         return r;
     }
 
@@ -364,8 +362,6 @@ public final class FieldedTypeBuffer implements CasualBuffer
      * @param remove true if the item should be removed ( destructive {@code readAll} )
      * @return the data or if name is not found, and empty list
      */
-    // java:S6204 - the resulting value list needs to be mutable
-    @SuppressWarnings("java:S6204")
     public List<FieldedData<?>> readAll(final String name, boolean remove)
     {
         List<FieldedData<?>> l = m.get(name);
@@ -377,7 +373,7 @@ public final class FieldedTypeBuffer implements CasualBuffer
         {
             m.remove(name);
         }
-        return l.stream().collect(Collectors.toList());
+        return new ArrayList<>(l);
     }
 
     private <T> FieldedTypeBuffer writeAll(final String name, final List<T> values)

--- a/casual/casual-api/src/main/java/se/laz/casual/api/buffer/type/fielded/FieldedTypeBuffer.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/buffer/type/fielded/FieldedTypeBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -109,6 +109,8 @@ public final class FieldedTypeBuffer implements CasualBuffer
      * @param b the buffer to copy
      * @return a new buffer
      */
+    // java:S6204 - the resulting value list needs to be mutable
+    @SuppressWarnings("java:S6204")
     public static FieldedTypeBuffer of(FieldedTypeBuffer b)
     {
         Objects.requireNonNull(b, "buffer can not be null");
@@ -156,7 +158,8 @@ public final class FieldedTypeBuffer implements CasualBuffer
      * @return the same buffer but containing the new data
      */
     // squid:S1612 - sonar hates lambdas
-    @SuppressWarnings("squid:S1612")
+    // java:S6204 - the resulting value list needs to be mutable
+    @SuppressWarnings({"squid:S1612", "java:S6204"})
     public FieldedTypeBuffer replace(final Map<String, List<FieldedData<?>>> d)
     {
         m = new HashMap<>();
@@ -361,6 +364,8 @@ public final class FieldedTypeBuffer implements CasualBuffer
      * @param remove true if the item should be removed ( destructive {@code readAll} )
      * @return the data or if name is not found, and empty list
      */
+    // java:S6204 - the resulting value list needs to be mutable
+    @SuppressWarnings("java:S6204")
     public List<FieldedData<?>> readAll(final String name, boolean remove)
     {
         List<FieldedData<?>> l = m.get(name);

--- a/casual/casual-api/src/main/java/se/laz/casual/api/buffer/type/fielded/json/CasualFieldedLookup.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/buffer/type/fielded/json/CasualFieldedLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 /**
  * Data structure containing the canonical representation
@@ -86,7 +85,7 @@ public final class CasualFieldedLookup
      */
     public static List<String> getNames()
     {
-        return stringToField.keySet().stream().collect(Collectors.toList());
+        return stringToField.keySet().stream().toList();
     }
 
     private static CasualFielded slurpJSON(final URL resource)

--- a/casual/casual-api/src/main/java/se/laz/casual/api/buffer/type/fielded/marshalling/details/CommonDetails.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/buffer/type/fielded/marshalling/details/CommonDetails.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * A collection of helper methods for marshalling/unmarshalling
@@ -69,7 +68,7 @@ public final class CommonDetails
     {
         return Arrays.stream(c.getDeclaredFields())
                      .filter(CommonDetails::hasCasualFieldAnnotation)
-                     .collect(Collectors.toList());
+                     .toList();
     }
 
     /**
@@ -82,7 +81,7 @@ public final class CommonDetails
     {
         return Arrays.stream(c.getMethods())
                      .filter(CommonDetails::hasCasualFieldAnnotation)
-                     .collect(Collectors.toList());
+                     .toList();
     }
 
     /**
@@ -94,7 +93,7 @@ public final class CommonDetails
     public static Map<Method, List<ParameterInfo>> getParameterInfo(final Class<?> c)
     {
         List<Method> methods = Arrays.stream(c.getMethods())
-                                     .collect(Collectors.toList());
+                                     .toList();
         Map<Method, List<ParameterInfo>> map = new HashMap<>();
         for(Method m : methods)
         {
@@ -115,7 +114,7 @@ public final class CommonDetails
      */
     public static List<ParameterInfo> getParameterInfo(final Method m)
     {
-        List<Type> genericParameterTypes = Arrays.stream(m.getGenericParameterTypes()).collect(Collectors.toList());
+        List<Type> genericParameterTypes = Arrays.stream(m.getGenericParameterTypes()).toList();
         List<ParameterInfo> parameterInfo = new ArrayList<>();
         Parameter[] parameters = m.getParameters();
         for(int i = 0; i < m.getParameterCount(); ++i)

--- a/casual/casual-api/src/main/java/se/laz/casual/api/buffer/type/fielded/marshalling/details/Marshaller.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/buffer/type/fielded/marshalling/details/Marshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -45,7 +45,8 @@ public final class Marshaller
         return writeMethodReturnValues(o, methods, b, mode);
     }
 
-    @SuppressWarnings("deprecation")
+    // java:S3011 - we need to change accessibility
+    @SuppressWarnings({"deprecation", "java:S3011"})
     private static FieldedTypeBuffer writeMethodReturnValues(Object o, List<Method> methods, FieldedTypeBuffer b, FieldedTypeBufferProcessorMode mode)
     {
         // For methods we get the return value and store it
@@ -78,7 +79,8 @@ public final class Marshaller
         return b;
     }
 
-    @SuppressWarnings("deprecation")
+    // java:S3011 - we need to change accessibility
+    @SuppressWarnings({"deprecation", "java:S3011"})
     private static FieldedTypeBuffer writeFields(final Object o, final List<Field> fields, FieldedTypeBuffer b, FieldedTypeBufferProcessorMode mode)
     {
         for (Field f : fields)

--- a/casual/casual-api/src/main/java/se/laz/casual/api/buffer/type/fielded/marshalling/details/Unmarshaller.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/buffer/type/fielded/marshalling/details/Unmarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -116,9 +116,8 @@ public final class Unmarshaller
         {
             final int finalIndex = i;
             final ParameterInfo p = parameterInfo.get(i);
-            if(p instanceof AnnotatedParameterInfo)
+            if(p instanceof AnnotatedParameterInfo info)
             {
-                AnnotatedParameterInfo info = (AnnotatedParameterInfo)p;
                 readValue(context, info.getAnnotation(), (Object v) -> l[finalIndex] = v, info.getType(), info::getParameterizedType);
             }
             else
@@ -129,6 +128,8 @@ public final class Unmarshaller
         return l;
     }
 
+    // java:S3011 - we need to change accessibility
+    @SuppressWarnings("java:S3011")
     private static <T> boolean readFields(UnmarshallerContext<T> context)
     {
         AtomicBoolean fieldedValueUnmarshalled = new AtomicBoolean(false);
@@ -178,6 +179,7 @@ public final class Unmarshaller
         }
     }
 
+    @SuppressWarnings("java:S3011")
     private static void setField(final Object instance, final Field f, final Object v, final AtomicBoolean fieldedValueUnmarshalled )
     {
         try

--- a/casual/casual-api/src/main/java/se/laz/casual/api/buffer/type/fielded/marshalling/details/UnmarshallerContextImpl.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/buffer/type/fielded/marshalling/details/UnmarshallerContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, The casual project. All rights reserved.
+ * Copyright (c) 2022 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -144,6 +144,7 @@ public final class UnmarshallerContextImpl<T> implements UnmarshallerContext<T>
         return CommonDetails.getCasuallyAnnotatedFields(getInstance().getClass());
     }
 
+    @SuppressWarnings("java:S3011")
     private T createInstance(Class<T> clazz)
     {
         try

--- a/casual/casual-api/src/main/java/se/laz/casual/api/util/PrettyPrinter.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/util/PrettyPrinter.java
@@ -30,12 +30,12 @@ public final class PrettyPrinter
 
     public static String format(UUID correlationId, UUID execution)
     {
-        return String.format("correlation: %s, execution: %s\n", PrettyPrinter.casualStringify(correlationId), PrettyPrinter.casualStringify(execution));
+        return String.format("correlation: %s, execution: %s%n", PrettyPrinter.casualStringify(correlationId), PrettyPrinter.casualStringify(execution));
     }
 
     public static String format(UUID correlationId, UUID execution, Xid xid)
     {
-        return String.format("correlation: %s, execution: %s, xid: %s\n", PrettyPrinter.casualStringify(correlationId), PrettyPrinter.casualStringify(execution), PrettyPrinter.casualStringify(xid));
+        return String.format("correlation: %s, execution: %s, xid: %s%n", PrettyPrinter.casualStringify(correlationId), PrettyPrinter.casualStringify(execution), PrettyPrinter.casualStringify(xid));
     }
 
     private static String toHex(byte[] bytes)

--- a/casual/casual-api/src/main/java/se/laz/casual/network/ProtocolVersion.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/network/ProtocolVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, The casual project. All rights reserved.
+ * Copyright (c) 2022 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -9,7 +9,6 @@ import se.laz.casual.network.connection.CasualConnectionException;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public enum ProtocolVersion
 {
@@ -79,7 +78,7 @@ public enum ProtocolVersion
     {
         return supportedVersionNumbers().stream()
                                         .map(version -> unmarshall(version).getVersionAsString())
-                                        .collect(Collectors.toList());
+                                        .toList();
     }
 
 }

--- a/casual/casual-api/src/test/groovy/se/laz/casual/api/testdata/LuckyPhoneBookService.java
+++ b/casual/casual-api/src/test/groovy/se/laz/casual/api/testdata/LuckyPhoneBookService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -10,7 +10,6 @@ import se.laz.casual.api.buffer.type.fielded.annotation.CasualFieldElement;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 public class LuckyPhoneBookService
 {
@@ -36,7 +35,7 @@ public class LuckyPhoneBookService
         Objects.requireNonNull(name);
         Objects.requireNonNull(phoneNumbers);
         Objects.requireNonNull(luckyNumbers);
-        return new LuckyPhoneBookService(age, name, phoneNumbers.stream().collect(Collectors.toList()), luckyNumbers.stream().collect(Collectors.toList()));
+        return new LuckyPhoneBookService(age, name, phoneNumbers.stream().toList(), luckyNumbers.stream().toList());
     }
 
     public static LuckyPhoneBookService of()
@@ -56,7 +55,7 @@ public class LuckyPhoneBookService
 
     public void setPhoneNumbers(@CasualFieldElement(name = "FLD_STRING2") List<String> l)
     {
-        this.phoneNumbers = l.stream().collect(Collectors.toList());
+        this.phoneNumbers = l.stream().toList();
     }
 
     public void setLuckyNumbers(@CasualFieldElement(name = "FLD_LONG2", lengthName = "FLD_LONG4") List<Integer> numbers)

--- a/casual/casual-api/src/test/groovy/se/laz/casual/api/testdata/PojoWithAnnotatedMethods.java
+++ b/casual/casual-api/src/test/groovy/se/laz/casual/api/testdata/PojoWithAnnotatedMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -9,9 +9,9 @@ package se.laz.casual.api.testdata;
 import se.laz.casual.api.buffer.type.fielded.annotation.CasualFieldElement;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 public final class PojoWithAnnotatedMethods implements Serializable
 {
@@ -36,7 +36,7 @@ public final class PojoWithAnnotatedMethods implements Serializable
     {
         Objects.requireNonNull(name);
         Objects.requireNonNull(phoneNumbers);
-        return new PojoWithAnnotatedMethods(age, name, phoneNumbers.stream().collect(Collectors.toList()), luckyNumbers.stream().collect(Collectors.toList()));
+        return new PojoWithAnnotatedMethods(age, name, new ArrayList<>(phoneNumbers), new ArrayList<>(luckyNumbers));
     }
 
     @CasualFieldElement(name = "FLD_LONG1")
@@ -68,7 +68,7 @@ public final class PojoWithAnnotatedMethods implements Serializable
     }
     public void setPhoneNumbers(@CasualFieldElement(name = "FLD_STRING2") List<String> l)
     {
-        this.phoneNumbers = l.stream().collect(Collectors.toList());
+        this.phoneNumbers = l.stream().toList();
     }
 
     @CasualFieldElement(name = "FLD_LONG2", lengthName = "FLD_LONG4")

--- a/casual/casual-api/src/test/groovy/se/laz/casual/api/testdata/PojoWithMappableFieldList.java
+++ b/casual/casual-api/src/test/groovy/se/laz/casual/api/testdata/PojoWithMappableFieldList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -13,7 +13,6 @@ import java.io.Serializable;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 public final class PojoWithMappableFieldList implements Serializable
 {
@@ -37,7 +36,7 @@ public final class PojoWithMappableFieldList implements Serializable
 
     public List<LocalDate> getDates()
     {
-        return dates.stream().collect(Collectors.toList());
+        return dates.stream().toList();
     }
 
     @Override

--- a/casual/casual-api/src/test/groovy/se/laz/casual/api/testdata/PojoWithMappableParamList.java
+++ b/casual/casual-api/src/test/groovy/se/laz/casual/api/testdata/PojoWithMappableParamList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -11,9 +11,9 @@ import se.laz.casual.api.buffer.type.fielded.mapper.LocalDateMapper;
 
 import java.io.Serializable;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 public final class PojoWithMappableParamList implements Serializable
 {
@@ -29,19 +29,19 @@ public final class PojoWithMappableParamList implements Serializable
     public static PojoWithMappableParamList of(final List<LocalDate> dates)
     {
         Objects.requireNonNull(dates);
-        return new PojoWithMappableParamList(dates.stream().collect(Collectors.toList()));
+        return new PojoWithMappableParamList(new ArrayList<>(dates));
     }
 
     @CasualFieldElement(name ="FLD_STRING1", mapper = LocalDateMapper.class)
     public List<LocalDate> getDates()
     {
-        return dates.stream().collect(Collectors.toList());
+        return new ArrayList<>(dates);
     }
 
     public PojoWithMappableParamList setDates(@CasualFieldElement(name ="FLD_STRING1", mapper = LocalDateMapper.class)
                                               final List<LocalDate> dates)
     {
-        this.dates = dates.stream().collect(Collectors.toList());
+        this.dates = new ArrayList<>(dates);
         return this;
     }
 

--- a/casual/casual-api/src/test/groovy/se/laz/casual/api/testdata/SimpleListPojo.java
+++ b/casual/casual-api/src/test/groovy/se/laz/casual/api/testdata/SimpleListPojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -9,9 +9,9 @@ package se.laz.casual.api.testdata;
 import se.laz.casual.api.buffer.type.fielded.annotation.CasualFieldElement;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 public class SimpleListPojo implements Serializable
 {
@@ -35,17 +35,17 @@ public class SimpleListPojo implements Serializable
     public static SimpleListPojo of(final List<String> l, final List<Integer> numbers)
     {
         Objects.requireNonNull(l);
-        return new SimpleListPojo(l.stream().collect(Collectors.toList()), numbers.stream().collect(Collectors.toList()));
+        return new SimpleListPojo(new ArrayList<>(l), new ArrayList<>(numbers));
     }
 
     public List<String> getStrings()
     {
-        return strings.stream().collect(Collectors.toList());
+        return strings.stream().toList();
     }
 
     public List<Integer> getNumbers()
     {
-        return numbers.stream().collect(Collectors.toList());
+        return numbers.stream().toList();
     }
 
     @Override

--- a/casual/casual-api/src/test/groovy/se/laz/casual/api/testdata/WrappedListPojo.java
+++ b/casual/casual-api/src/test/groovy/se/laz/casual/api/testdata/WrappedListPojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -9,9 +9,9 @@ package se.laz.casual.api.testdata;
 import se.laz.casual.api.buffer.type.fielded.annotation.CasualFieldElement;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 public final class WrappedListPojo implements Serializable
 {
@@ -30,7 +30,7 @@ public final class WrappedListPojo implements Serializable
     public static WrappedListPojo of(final List<SimplePojo> simplePojos)
     {
         Objects.requireNonNull(simplePojos);
-        return new WrappedListPojo(simplePojos.stream().collect(Collectors.toList()));
+        return new WrappedListPojo(new ArrayList<>(simplePojos));
     }
     public List<SimplePojo> getSimplePojos()
     {

--- a/casual/casual-api/src/test/groovy/se/laz/casual/api/testdata/WrappedListPojoWithAnnotatedMethods.java
+++ b/casual/casual-api/src/test/groovy/se/laz/casual/api/testdata/WrappedListPojoWithAnnotatedMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -9,9 +9,9 @@ package se.laz.casual.api.testdata;
 import se.laz.casual.api.buffer.type.fielded.annotation.CasualFieldElement;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 public final class WrappedListPojoWithAnnotatedMethods implements Serializable
 {
@@ -27,7 +27,7 @@ public final class WrappedListPojoWithAnnotatedMethods implements Serializable
     public static WrappedListPojoWithAnnotatedMethods of(final List<SimplePojo> simplePojos)
     {
         Objects.requireNonNull(simplePojos);
-        return new WrappedListPojoWithAnnotatedMethods(simplePojos.stream().collect(Collectors.toList()));
+        return new WrappedListPojoWithAnnotatedMethods(new ArrayList<>(simplePojos));
     }
     @CasualFieldElement
     public List<SimplePojo> getSimplePojos()

--- a/casual/casual-api/src/test/groovy/se/laz/casual/api/testdata/WrappedPojo.java
+++ b/casual/casual-api/src/test/groovy/se/laz/casual/api/testdata/WrappedPojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -21,6 +21,8 @@ public class WrappedPojo implements Serializable
     @CasualFieldElement(name = "FLD_STRING1")
     private final String symbol;
 
+    // java:S1068 - serves a purpose in the test code
+    @SuppressWarnings("java:S1068")
     // non fielded field
     private final String sneakyField = "sneaky";
     private WrappedPojo(final SimplePojo sp, String symbol)

--- a/casual/casual-event-client/src/main/java/se/laz/casual/event/client/messages/ConnectionMessage.java
+++ b/casual/casual-event-client/src/main/java/se/laz/casual/event/client/messages/ConnectionMessage.java
@@ -5,6 +5,8 @@
  */
 package se.laz.casual.event.client.messages;
 
+// java:S6548 - yes it is intentional
+@SuppressWarnings("java:S6548")
 public class ConnectionMessage
 {
     private static final String CONNECTION_MESSAGE = "{\"message\":\"HELLO\"}";

--- a/casual/casual-fielded-annotations/src/main/java/se/laz/casual/api/buffer/type/fielded/annotation/CasualFieldElement.java
+++ b/casual/casual-fielded-annotations/src/main/java/se/laz/casual/api/buffer/type/fielded/annotation/CasualFieldElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -137,6 +137,7 @@ public @interface CasualFieldElement
      * That is, if no other mapper is supplied - no mapping will take place
      * @return mapper.
      */
+    @SuppressWarnings("java:S1452")
     Class<? extends CasualObjectMapper<? extends Object, ? extends Object>> mapper() default PassThroughMapper.class;
 
 }

--- a/casual/casual-inbound-handler-api/src/main/java/se/laz/casual/jca/inbound/handler/buffer/PassThroughBufferHandler.java
+++ b/casual/casual-inbound-handler-api/src/main/java/se/laz/casual/jca/inbound/handler/buffer/PassThroughBufferHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -51,9 +51,9 @@ public class PassThroughBufferHandler implements BufferHandler
     @Override
     public InboundResponse toResponse(ServiceCallInfo info, Object result)
     {
-        if( result instanceof InboundResponse )
+        if( result instanceof InboundResponse response )
         {
-            return (InboundResponse) result;
+            return response;
         }
         return InboundResponse.createBuilder().buffer( (CasualBuffer)result).build();
     }

--- a/casual/casual-inbound-handler-casual-service/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/discovery/JndiMatcher.java
+++ b/casual/casual-inbound-handler-casual-service/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/discovery/JndiMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -7,7 +7,6 @@
 package se.laz.casual.jca.inbound.handler.service.casual.discovery;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 
 /**
@@ -22,7 +21,7 @@ public class JndiMatcher
     {}
     public static String findMatch(String implementationType, String ejbName, String interfaceType, List<String> jndiUrls )
     {
-        List<String> found = jndiUrls.stream().filter( jndiUrl -> matches( implementationType, ejbName, interfaceType, jndiUrl ) ).collect(Collectors.toList());
+        List<String> found = jndiUrls.stream().filter( jndiUrl -> matches( implementationType, ejbName, interfaceType, jndiUrl ) ).toList();
 
         return found.size() == 1? found.get( 0 ) : null;
     }

--- a/casual/casual-inbound-handler-casual-service/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/discovery/JndiUtil.java
+++ b/casual/casual-inbound-handler-casual-service/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/discovery/JndiUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -90,13 +90,13 @@ public class JndiUtil
             try
             {
                 Object tmp = ctx.lookup(name);
-                if (tmp instanceof Context)
+                if (tmp instanceof Context context)
                 {
-                    results.putAll(findAllProxyInstance((Context) tmp, childPath));
+                    results.putAll(findAllProxyInstance(context, childPath));
                 }
-                else if (tmp instanceof Proxy)
+                else if (tmp instanceof Proxy proxy)
                 {
-                    results.put(childPath, (Proxy) tmp);
+                    results.put(childPath, proxy);
                 }
             }
             catch(NamingException e)

--- a/casual/casual-inbound-handler-casual-service/src/test/java/se/laz/casual/jca/inbound/handler/service/casual/ClassAndMethodBasedTransactionAnnotation.java
+++ b/casual/casual-inbound-handler-casual-service/src/test/java/se/laz/casual/jca/inbound/handler/service/casual/ClassAndMethodBasedTransactionAnnotation.java
@@ -1,16 +1,17 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
 
 package se.laz.casual.jca.inbound.handler.service.casual;
 
-import se.laz.casual.api.service.CasualService;
-
 import jakarta.ejb.TransactionAttribute;
 import jakarta.ejb.TransactionAttributeType;
+import se.laz.casual.api.service.CasualService;
 
+// java:S1186 - test code
+@SuppressWarnings("java:S1186")
 @TransactionAttribute(TransactionAttributeType.SUPPORTS)
 public class ClassAndMethodBasedTransactionAnnotation implements SomeInterface
 {

--- a/casual/casual-inbound-handler-casual-service/src/test/java/se/laz/casual/jca/inbound/handler/service/casual/ClassBasedTransactionAnnotation.java
+++ b/casual/casual-inbound-handler-casual-service/src/test/java/se/laz/casual/jca/inbound/handler/service/casual/ClassBasedTransactionAnnotation.java
@@ -1,16 +1,17 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
 
 package se.laz.casual.jca.inbound.handler.service.casual;
 
-import se.laz.casual.api.service.CasualService;
-
 import jakarta.ejb.TransactionAttribute;
 import jakarta.ejb.TransactionAttributeType;
+import se.laz.casual.api.service.CasualService;
 
+// java:S1186 - test code
+@SuppressWarnings("java:S1186")
 @TransactionAttribute(TransactionAttributeType.NEVER)
 public class ClassBasedTransactionAnnotation implements SomeInterface
 {

--- a/casual/casual-inbound-handler-casual-service/src/test/java/se/laz/casual/jca/inbound/handler/service/casual/MethodBasedTransactionAnnotation.java
+++ b/casual/casual-inbound-handler-casual-service/src/test/java/se/laz/casual/jca/inbound/handler/service/casual/MethodBasedTransactionAnnotation.java
@@ -1,16 +1,17 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
 
 package se.laz.casual.jca.inbound.handler.service.casual;
 
-import se.laz.casual.api.service.CasualService;
-
 import jakarta.ejb.TransactionAttribute;
 import jakarta.ejb.TransactionAttributeType;
+import se.laz.casual.api.service.CasualService;
 
+// java:S1186 - test code
+@SuppressWarnings("java:S1186")
 public class MethodBasedTransactionAnnotation implements SomeInterface
 {
     @CasualService(name="someMethod" )

--- a/casual/casual-inbound-handler-casual-service/src/test/java/se/laz/casual/jca/inbound/handler/service/casual/NoAnnotation.java
+++ b/casual/casual-inbound-handler-casual-service/src/test/java/se/laz/casual/jca/inbound/handler/service/casual/NoAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -8,6 +8,8 @@ package se.laz.casual.jca.inbound.handler.service.casual;
 
 import se.laz.casual.api.service.CasualService;
 
+// java:S1186 - test code
+@SuppressWarnings("java:S1186")
 public class NoAnnotation implements SomeInterface
 {
     @CasualService(name="someMethod" )

--- a/casual/casual-inbound-handler-fielded-buffer/src/main/java/se/laz/casual/jca/inbound/handler/buffer/fielded/FieldedBufferHandler.java
+++ b/casual/casual-inbound-handler-fielded-buffer/src/main/java/se/laz/casual/jca/inbound/handler/buffer/fielded/FieldedBufferHandler.java
@@ -59,9 +59,9 @@ public class FieldedBufferHandler implements BufferHandler
         FieldedTypeBuffer buffer = FieldedTypeBuffer.create();
         if( result != null )
         {
-            if( result instanceof InboundResponse )
+            if( result instanceof InboundResponse response)
             {
-                return (InboundResponse) result;
+                return response;
             }
 
             buffer = FieldedTypeBufferProcessor.marshall(result);

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualManagedConnection.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualManagedConnection.java
@@ -264,9 +264,9 @@ public class CasualManagedConnection implements ManagedConnection, NetworkListen
     public WorkManager getWorkManager()
     {
         ResourceAdapter ra = mcf.getResourceAdapter();
-        if(ra instanceof CasualResourceAdapter)
+        if(ra instanceof CasualResourceAdapter resourceAdapter)
         {
-            return ((CasualResourceAdapter) ra).getWorkManager();
+            return resourceAdapter.getWorkManager();
         }
         throw new CasualResourceAdapterException("resource adapter should be a casual resource adapter");
     }

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceAdapter.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceAdapter.java
@@ -64,6 +64,8 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
     private static Logger log = Logger.getLogger(CasualResourceAdapter.class.getName());
     private ConcurrentHashMap<Integer, CasualActivationSpec> activations = new ConcurrentHashMap<>();
     private List<ReverseInboundServer> reverseInbounds = new ArrayList<>();
+    // it is not really unused, it should never ever be gc:ed, thus it is part of this class
+    @SuppressWarnings("java:S1068")
     private EventServer eventServer;
 
     private WorkManager workManager;

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceManager.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -12,6 +12,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
+// java:S6548 - yes it is intentional
+@SuppressWarnings("java:S6548")
 public final class CasualResourceManager
 {
     private static final CasualResourceManager INSTANCE = new CasualResourceManager();

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualXAResource.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualXAResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -78,6 +78,8 @@ public class CasualXAResource implements XAResource
      * @throws XAException if end fails.
      */
     @Override
+    // java:S1301 - opinionated and, in this case - wrong
+    @SuppressWarnings("java:S1301")
     public void end(Xid xid, int flag) throws XAException
     {
         LOG.finest(()-> String.format("end, xid: %s (%s) flag: %d, %s ", PrettyPrinter.casualStringify(xid), xid, flag, XAFlags.unmarshall(flag)));
@@ -86,10 +88,7 @@ public class CasualXAResource implements XAResource
         XAFlags f = XAFlags.unmarshall(flag);
         switch(f)
         {
-            // note: we want to fallthrough here
-            case TMSUCCESS:
-            case TMFAIL:
-            case TMSUSPEND:
+            case TMSUCCESS, TMFAIL, TMSUSPEND:
                 break;
             default:
                 LOG.finest(()->"throwing XAException.XAER_RMFAIL");
@@ -119,9 +118,8 @@ public class CasualXAResource implements XAResource
     @Override
     public boolean isSameRM(XAResource xaResource) throws XAException
     {
-        if(xaResource instanceof CasualXAResource)
+        if(xaResource instanceof CasualXAResource casualXAResource)
         {
-            CasualXAResource casualXAResource = (CasualXAResource) xaResource;
             return casualXAResource.casualManagedConnection.getDomainId().equals(casualManagedConnection.getDomainId());
         }
         return false;
@@ -223,12 +221,13 @@ public class CasualXAResource implements XAResource
         return readOnly;
     }
 
+    // java:S1301 - opinionated and, in this case - wrong
+    @SuppressWarnings("java:S1301")
     private void throwWhenTransactionErrorCode(final XAReturnCode transactionReturnCode) throws XAException
     {
         switch( transactionReturnCode )
         {
-            case XA_OK:
-            case XA_RDONLY:
+            case XA_OK, XA_RDONLY:
                 break;
             default:
                 LOG.finest(()->"throwing XAException for XAReturnCode: " + transactionReturnCode);

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/jmx/Casual.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/jmx/Casual.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2024, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
 package se.laz.casual.jca.jmx;
 
 import se.laz.casual.jca.pool.NetworkConnectionPool;
@@ -5,7 +11,6 @@ import se.laz.casual.jca.pool.NetworkPoolHandler;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class Casual implements CasualMBean
 {
@@ -16,7 +21,7 @@ public class Casual implements CasualMBean
       Map<String, NetworkConnectionPool> pools = NetworkPoolHandler.getInstance().getPools();
       return pools.keySet().stream()
                   .map(key -> key + "=" + pools.get(key))
-                  .collect(Collectors.toList());
+                  .toList();
    }
 
    @Override

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/jmx/JMXStartup.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/jmx/JMXStartup.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2024, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
 package se.laz.casual.jca.jmx;
 
 import javax.management.InstanceAlreadyExistsException;
@@ -10,6 +16,8 @@ import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
 import java.util.logging.Logger;
 
+// yes it is intentional
+@SuppressWarnings("java:S6548")
 public class JMXStartup
 {
    private static final Logger LOG = Logger.getLogger(JMXStartup.class.getName());

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/pool/NetworkConnectionPool.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/pool/NetworkConnectionPool.java
@@ -126,9 +126,8 @@ public class NetworkConnectionPool implements ReferenceCountedNetworkCloseListen
     {
         NettyConnectionInformation ci = NettyConnectionInformationCreator.create(InetSocketAddress.createUnresolved(address.getHostName(), address.getPort()), protocolVersion);
         NetworkConnection networkConnection = NettyNetworkConnection.of(ci, ownListener);
-        if (networkConnection instanceof NettyNetworkConnection)
+        if (networkConnection instanceof NettyNetworkConnection impl)
         {
-            NettyNetworkConnection impl = (NettyNetworkConnection) networkConnection;
             impl.addListener(networkListener);
             LOG.finest(() -> "created network connection: " + networkConnection);
             return ReferenceCountedNetworkConnection.of(impl, referenceCountedNetworkCloseListener);

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/pool/NetworkPoolHandler.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/pool/NetworkPoolHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, The casual project. All rights reserved.
+ * Copyright (c) 2022 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -16,6 +16,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
+// yes it is intentional
+@SuppressWarnings("java:S6548")
 public class NetworkPoolHandler
 {
     private static final Logger log = Logger.getLogger(NetworkPoolHandler.class.getName());

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/queue/Transformer.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/queue/Transformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -10,7 +10,6 @@ import se.laz.casual.api.queue.QueueMessage;
 import se.laz.casual.network.protocol.messages.queue.DequeueMessage;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 public final class Transformer
 {
@@ -20,7 +19,7 @@ public final class Transformer
     {
         return l.stream()
                 .map(Transformer::transformMessage)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private static QueueMessage transformMessage(final DequeueMessage msg)

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartInboundServerWork.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartInboundServerWork.java
@@ -1,16 +1,16 @@
 /*
- * Copyright (c) 2021-2023, The casual project. All rights reserved.
+ * Copyright (c) 2021 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
 
 package se.laz.casual.jca.work;
 
+import jakarta.resource.spi.work.Work;
 import se.laz.casual.config.ConfigurationService;
 import se.laz.casual.jca.InboundStartupException;
 import se.laz.casual.jca.inbound.handler.service.casual.CasualServiceRegistry;
 
-import jakarta.resource.spi.work.Work;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -52,9 +52,7 @@ public final class StartInboundServerWork<T> implements Work
         Objects.requireNonNull(startupServices, "Startup Services is null.");
         Objects.requireNonNull(consumer, "Consumer is null.");
         Objects.requireNonNull(supplier, "supplier is null");
-        // note: only needed to make the compiler, java 8, not spew out warnings
-        StartInboundServerWork<T> work = new StartInboundServerWork<>(startupServices, logMessage, consumer, supplier, delay);
-        return work;
+        return new StartInboundServerWork<>(startupServices, logMessage, consumer, supplier, delay);
     }
 
     @Override

--- a/casual/casual-jca/src/test/groovy/se/laz/casual/test/matchers/CasualDequeueRequestMessageMatcher.java
+++ b/casual/casual-jca/src/test/groovy/se/laz/casual/test/matchers/CasualDequeueRequestMessageMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -27,6 +27,7 @@ public class CasualDequeueRequestMessageMatcher
             @Override
             public void describeTo(Description description)
             {
+                description.appendText("message with queue name " + expected.getQueueName());
             }
 
             @Override

--- a/casual/casual-jca/src/test/groovy/se/laz/casual/test/matchers/CasualDomainDiscoveryRequestMessageMatcher.java
+++ b/casual/casual-jca/src/test/groovy/se/laz/casual/test/matchers/CasualDomainDiscoveryRequestMessageMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -31,6 +31,7 @@ public final class CasualDomainDiscoveryRequestMessageMatcher
             @Override
             public void describeTo(Description description)
             {
+                description.appendText("servicenames and queuenames were not matching");
             }
 
             @Override

--- a/casual/casual-jca/src/test/groovy/se/laz/casual/test/matchers/CasualEnqueueRequestMessageMatcher.java
+++ b/casual/casual-jca/src/test/groovy/se/laz/casual/test/matchers/CasualEnqueueRequestMessageMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -31,6 +31,7 @@ public class CasualEnqueueRequestMessageMatcher
             @Override
             public void describeTo(Description description)
             {
+                description.appendText("enqueue request message does not match ").appendValue(expected);
             }
 
             @Override

--- a/casual/casual-jca/src/test/groovy/se/laz/casual/test/matchers/CasualServiceCallRequestMessageMatcher.java
+++ b/casual/casual-jca/src/test/groovy/se/laz/casual/test/matchers/CasualServiceCallRequestMessageMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -52,6 +52,7 @@ public final class CasualServiceCallRequestMessageMatcher
             @Override
             public void describeTo(Description description)
             {
+                description.appendText("service call request message does not match ").appendText( expected.getServiceName() );
             }
 
             @Override

--- a/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/domain/CasualDomainConnectRequestMessage.java
+++ b/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/domain/CasualDomainConnectRequestMessage.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 public class CasualDomainConnectRequestMessage implements CasualNetworkTransmittable
 {
@@ -118,7 +117,7 @@ public class CasualDomainConnectRequestMessage implements CasualNetworkTransmitt
 
     public List<Long> getProtocols()
     {
-        return protocols.stream().collect(Collectors.toList());
+        return protocols.stream().toList();
     }
 
     public static Builder createBuilder()

--- a/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/domain/CasualDomainDiscoveryRequestMessage.java
+++ b/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/domain/CasualDomainDiscoveryRequestMessage.java
@@ -56,10 +56,10 @@ public class CasualDomainDiscoveryRequestMessage implements CasualNetworkTransmi
         final byte[] domainNameBytes = domainName.getBytes(StandardCharsets.UTF_8);
         final List<byte[]> serviceNameBytes = serviceNames.stream()
                                                           .map(s -> s.getBytes(StandardCharsets.UTF_8))
-                                                          .collect(Collectors.toList());
+                                                          .toList();
         final List<byte[]> queueNameBytes  = queueNames.stream()
-                                                          .map(s -> s.getBytes(StandardCharsets.UTF_8))
-                                                          .collect(Collectors.toList());
+                                                       .map(s -> s.getBytes(StandardCharsets.UTF_8))
+                                                       .toList();
         final long messageSize = DiscoveryRequestSizes.EXECUTION.getNetworkSize() + DiscoveryRequestSizes.DOMAIN_ID.getNetworkSize() +
                                  DiscoveryRequestSizes.DOMAIN_NAME_SIZE.getNetworkSize() + domainNameBytes.length +
                                  DiscoveryRequestSizes.SERVICES_SIZE.getNetworkSize() +
@@ -138,6 +138,8 @@ public class CasualDomainDiscoveryRequestMessage implements CasualNetworkTransmi
         return this;
     }
 
+    // internal representation, fine to be mutable
+    @SuppressWarnings("java:S6204")
     private CasualDomainDiscoveryRequestMessage setServiceNames(List<String> serviceNames)
     {
         this.serviceNames = serviceNames.stream()
@@ -147,6 +149,8 @@ public class CasualDomainDiscoveryRequestMessage implements CasualNetworkTransmi
         return this;
     }
 
+    // internal representation, fine to be mutable
+    @SuppressWarnings("java:S6204")
     private CasualDomainDiscoveryRequestMessage setQueueNames(List<String> queueNames)
     {
         this.queueNames = queueNames.stream()

--- a/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/queue/CasualDequeueReplyMessage.java
+++ b/casual/casual-network-protocol/src/main/java/se/laz/casual/network/protocol/messages/queue/CasualDequeueReplyMessage.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 public class CasualDequeueReplyMessage implements CasualNetworkTransmittable
 {
@@ -93,7 +92,7 @@ public class CasualDequeueReplyMessage implements CasualNetworkTransmittable
 
     public List<DequeueMessage> getMessages()
     {
-        return messages.stream().collect(Collectors.toList());
+        return messages.stream().toList();
     }
 
     public static final class Builder
@@ -121,7 +120,7 @@ public class CasualDequeueReplyMessage implements CasualNetworkTransmittable
         {
             Objects.requireNonNull(execution, "execution is not allowed to be null");
             Objects.requireNonNull(messages, "messages is not allowed to be null, can be empty though");
-            return new CasualDequeueReplyMessage(execution, messages.stream().collect(Collectors.toList()));
+            return new CasualDequeueReplyMessage(execution, new ArrayList<>(messages));
         }
     }
 }

--- a/casual/casual-network/src/main/java/se/laz/casual/network/outbound/CorrelatorImpl.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/outbound/CorrelatorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -16,7 +16,6 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 public final class CorrelatorImpl implements Correlator
 {
@@ -67,8 +66,7 @@ public final class CorrelatorImpl implements Correlator
     @Override
     public void completeAllExceptionally(Exception e)
     {
-        completeExceptionally(requests.keySet().stream()
-                                      .collect(Collectors.toList()), e);
+        completeExceptionally(requests.keySet().stream().toList(), e);
     }
 
     @Override

--- a/casual/casual-network/src/main/java/se/laz/casual/network/outbound/ExceptionHandler.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/outbound/ExceptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -68,9 +68,9 @@ public class ExceptionHandler extends ChannelInboundHandlerAdapter
         Throwable result = t;
         while(null != (cause = result.getCause()) && (result != cause))
         {
-            if(result instanceof  CasualDecoderException)
+            if(result instanceof  CasualDecoderException exception)
             {
-                return Optional.of((CasualDecoderException)result);
+                return Optional.of(exception);
             }
             result = cause;
         }

--- a/casual/casual-network/src/main/java/se/laz/casual/network/outbound/NettyNetworkConnection.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/outbound/NettyNetworkConnection.java
@@ -411,9 +411,8 @@ public class NettyNetworkConnection implements NetworkConnection, ConversationCl
     {
         LOG.finest(() -> "message: " + LogTool.asLogEntry(message));
         final T msg = message.getMessage();
-        if(msg instanceof DomainDisconnectRequestMessage)
+        if(msg instanceof DomainDisconnectRequestMessage requestMessage)
         {
-            DomainDisconnectRequestMessage requestMessage = (DomainDisconnectRequestMessage) msg;
             domainDisconnectHandler.domainDisconnected(DomainDisconnectReplyInfo.of(message.getCorrelationId(), requestMessage.getExecution()));
         }
         else if(msg instanceof DomainDiscoveryTopologyUpdateMessage)

--- a/casual/casual-service-discovery-extension/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/CasualServiceRegistry.java
+++ b/casual/casual-service-discovery-extension/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/CasualServiceRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -9,11 +9,12 @@ package se.laz.casual.jca.inbound.handler.service.casual;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 /**
  * Internal Registry for discovered EJB endpoints with CasualService annotation to allow inbound requests to be dispatched.
  */
+// yes it is intentional
+@SuppressWarnings("java:S6548")
 public final class CasualServiceRegistry
 {
     private final Map<String,CasualServiceMetaData> serviceMetaData;
@@ -74,7 +75,7 @@ public final class CasualServiceRegistry
 
     public List<CasualServiceMetaData> getUnresolvedServices()
     {
-        return serviceMetaData.values().stream().filter(CasualServiceMetaData::isUnresolved).collect(Collectors.toList());
+        return serviceMetaData.values().stream().filter(CasualServiceMetaData::isUnresolved).toList();
     }
 
     public void clear()

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '3.2.44'
+version = '3.2.45'
 
 def netty_version = '4.1.113.Final'
 def gson_version = '2.10.1'


### PR DESCRIPTION
Java 17 sonar fixes.
There are still 2 issues found, that ServiceReturn and CasualFielded should be made into records.
That is correct, however they live in the API and we would need to do a major release to fix that.

Thus they should remain as issues, no supression, until we make a major release can convert them into records.
