### PR TITLE
trid unique per resource, not global

### DIFF
--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceManager.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceManager.java
@@ -8,6 +8,8 @@ package se.laz.casual.jca;
 
 
 import javax.transaction.xa.Xid;
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -17,38 +19,47 @@ import java.util.concurrent.atomic.AtomicInteger;
 public final class CasualResourceManager
 {
     private static final CasualResourceManager INSTANCE = new CasualResourceManager();
+    private static final Set<Xid> EMPTY_SET = Collections.emptySet();
     private final AtomicInteger currentRMId = new AtomicInteger(1);
-    private final ConcurrentMap<Xid, Boolean> pendingRequests = new ConcurrentHashMap<>();
+    private final ConcurrentMap<DomainId, Set<Xid>> pendingRequests = new ConcurrentHashMap<>();
     private CasualResourceManager()
     {}
 
-    public static final CasualResourceManager getInstance()
+    public static CasualResourceManager getInstance()
     {
         return INSTANCE;
     }
 
-    public final Integer getNextId()
+    public Integer getNextId()
     {
         return currentRMId.getAndIncrement();
     }
 
-    public void put(final Xid xid)
+    public void put(DomainId domainId, final Xid xid)
     {
-        if(pendingRequests.containsKey(xid))
+        if(pendingRequests.getOrDefault(domainId, EMPTY_SET).contains(xid))
         {
-            throw new CasualResourceAdapterException("xid: " + xid + " already stored");
+            throw new CasualResourceAdapterException("xid: " + xid + " already stored for domain: " + domainId);
         }
-        pendingRequests.put(xid, true);
+        pendingRequests.computeIfAbsent(domainId, k -> ConcurrentHashMap.newKeySet()).add(xid);
     }
 
-    public void remove(final Xid xid)
+    public synchronized void remove(DomainId domainId, final Xid xid)
     {
-        pendingRequests.remove(xid);
+        Set<Xid> inFlight = pendingRequests.get(domainId);
+        if(inFlight != null)
+        {
+            inFlight.remove(xid);
+            if(inFlight.isEmpty())
+            {
+                pendingRequests.remove(domainId);
+            }
+        }
     }
 
-    public boolean isPending(final Xid xid)
+    public boolean isPending(DomainId domainId, final Xid xid)
     {
-        return pendingRequests.containsKey(xid);
+        return pendingRequests.getOrDefault(domainId, EMPTY_SET).contains(xid);
     }
 
     @Override

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceManager.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceManager.java
@@ -35,7 +35,7 @@ public final class CasualResourceManager
         return currentRMId.getAndIncrement();
     }
 
-    public void put(DomainId domainId, final Xid xid)
+    public synchronized void put(DomainId domainId, final Xid xid)
     {
         if(pendingRequests.getOrDefault(domainId, EMPTY_SET).contains(xid))
         {

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualXAResource.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualXAResource.java
@@ -83,7 +83,7 @@ public class CasualXAResource implements XAResource
     public void end(Xid xid, int flag) throws XAException
     {
         LOG.finest(()-> String.format("end, xid: %s (%s) flag: %d, %s ", PrettyPrinter.casualStringify(xid), xid, flag, XAFlags.unmarshall(flag)));
-        CasualResourceManager.getInstance().remove(xid);
+        CasualResourceManager.getInstance().remove(domainId(), xid);
         disassociate();
         XAFlags f = XAFlags.unmarshall(flag);
         switch(f)
@@ -181,15 +181,15 @@ public class CasualXAResource implements XAResource
         LOG.finest(()-> String.format("start, xid: %s (%s) flag: %d, %s ", PrettyPrinter.casualStringify(xid), xid, i, XAFlags.unmarshall(i)));
         readOnly = false;
         if(!(XAFlags.TMJOIN.getValue() == i || XAFlags.TMRESUME.getValue() == i) &&
-            CasualResourceManager.getInstance().isPending(xid))
+            CasualResourceManager.getInstance().isPending(domainId(), xid))
         {
             LOG.finest(()->"throwing XAException.XAER_DUPID");
             throw new XAException(XAException.XAER_DUPID);
         }
         associate(xid);
-        if(!CasualResourceManager.getInstance().isPending(currentXid))
+        if(!CasualResourceManager.getInstance().isPending(domainId(), currentXid))
         {
-            CasualResourceManager.getInstance().put(currentXid);
+            CasualResourceManager.getInstance().put(domainId(), currentXid);
         }
     }
 
@@ -199,6 +199,11 @@ public class CasualXAResource implements XAResource
         return "CasualXAResource{" +
             "currentXid=" + currentXid +
             '}';
+    }
+
+    private DomainId domainId()
+    {
+        return casualManagedConnection.getDomainId();
     }
 
     private void associate(Xid xid)

--- a/casual/casual-jca/src/test/groovy/se/laz/casual/jca/CasualResourceManagerTest.groovy
+++ b/casual/casual-jca/src/test/groovy/se/laz/casual/jca/CasualResourceManagerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -17,6 +17,7 @@ class CasualResourceManagerTest extends Specification
 {
     @Shared CasualResourceManager instance
     @Shared Xid xid1, xid2, xid3
+    @Shared DomainId domainOne, domainTwo
 
     def setup()
     {
@@ -24,13 +25,15 @@ class CasualResourceManagerTest extends Specification
         xid1 = XID.of( "123".getBytes(StandardCharsets.UTF_8), "321".getBytes(StandardCharsets.UTF_8), 0 )
         xid2 = XID.of("456".getBytes(StandardCharsets.UTF_8), "654".getBytes(StandardCharsets.UTF_8), 0 )
         xid3 = XID.of( xid1 )
+        domainOne = DomainId.of(UUID.randomUUID())
+        domainTwo = DomainId.of(UUID.randomUUID())
     }
 
     def cleanup()
     {
-        instance.remove( xid1 )
-        instance.remove( xid2 )
-        instance.remove( xid3 )
+        instance.remove(domainOne, xid1 )
+        instance.remove(domainOne, xid2 )
+        instance.remove(domainOne, xid3 )
     }
 
     def "Check xid constraints"()
@@ -53,41 +56,56 @@ class CasualResourceManagerTest extends Specification
         instance.is( second )
     }
 
-    def "XidPending persists in the queue."()
+    def "XidPending xid1."()
     {
         setup:
-        instance.put( xid1 )
+        instance.put( domainOne, xid1 )
 
         expect:
-        instance.isPending( xid1 )
-        !instance.isPending( xid2 )
-        instance.isPending( xid3 )
+        instance.isPending( domainOne, xid1 )
+        !instance.isPending( domainOne, xid2 )
+        instance.isPending( domainOne, xid3 )
     }
 
     def "RemoveResourceIdForXid"()
     {
         setup:
-        instance.put( xid1 )
-        instance.put( xid2 )
+        instance.put( domainOne, xid1 )
+        instance.put( domainOne, xid2 )
 
         when:
-        instance.remove( xid1 )
+        instance.remove( domainOne, xid1 )
 
         then:
-        !instance.isPending( xid1 )
-        instance.isPending( xid2 )
-        !instance.isPending( xid3 )
+        !instance.isPending( domainOne, xid1 )
+        instance.isPending( domainOne, xid2 )
+        !instance.isPending( domainOne, xid3 )
     }
 
     def 'add same xid twice'()
     {
         given:
-        instance.put( xid1 )
+        instance.put( domainOne, xid1 )
         when:
-        instance.put( xid1 )
+        instance.put( domainOne, xid1 )
         then:
         def e = thrown(CasualResourceAdapterException)
-        e.message == "xid: ${xid1} already stored"
+        e.message == "xid: ${xid1} already stored for domain: ${domainOne}"
+    }
+
+    def 'two resources, two domains'()
+    {
+       when:
+       instance.put(domainOne, xid1)
+       instance.put(domainTwo, xid1)
+       then:
+       instance.isPending(domainOne, xid1)
+       instance.isPending(domainTwo, xid1)
+       when:
+       instance.remove(domainOne, xid1)
+       then:
+       !instance.isPending(domainOne, xid1)
+       instance.isPending(domainTwo, xid1)
     }
 
     def "toString test."()

--- a/casual/casual-jca/src/test/groovy/se/laz/casual/jca/CasualXAResourceTest.groovy
+++ b/casual/casual-jca/src/test/groovy/se/laz/casual/jca/CasualXAResourceTest.groovy
@@ -1,11 +1,10 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
 
 package se.laz.casual.jca
-
 
 import se.laz.casual.api.flags.Flag
 import se.laz.casual.api.flags.XAFlags
@@ -13,7 +12,12 @@ import se.laz.casual.api.xa.XAReturnCode
 import se.laz.casual.api.xa.XID
 import se.laz.casual.internal.network.NetworkConnection
 import se.laz.casual.network.protocol.messages.CasualNWMessageImpl
-import se.laz.casual.network.protocol.messages.transaction.*
+import se.laz.casual.network.protocol.messages.transaction.CasualTransactionResourceCommitReplyMessage
+import se.laz.casual.network.protocol.messages.transaction.CasualTransactionResourceCommitRequestMessage
+import se.laz.casual.network.protocol.messages.transaction.CasualTransactionResourcePrepareReplyMessage
+import se.laz.casual.network.protocol.messages.transaction.CasualTransactionResourcePrepareRequestMessage
+import se.laz.casual.network.protocol.messages.transaction.CasualTransactionResourceRollbackReplyMessage
+import se.laz.casual.network.protocol.messages.transaction.CasualTransactionResourceRollbackRequestMessage
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -30,6 +34,7 @@ class CasualXAResourceTest extends Specification
     @Shared CasualXAResource instance
     @Shared CasualManagedConnection managedConnection
     @Shared NetworkConnection networkConnection
+    @Shared DomainId domainOne = DomainId.of(UUID.randomUUID())
     @Shared Xid xid1, xid2
     @Shared CasualNWMessageImpl<CasualTransactionResourcePrepareRequestMessage> expectedPrepareRequestMessage
     @Shared CasualNWMessageImpl<CasualTransactionResourcePrepareRequestMessage> actualPrepareRequestMessage
@@ -49,7 +54,9 @@ class CasualXAResourceTest extends Specification
         mcf.getResourceId() >> {
             resourceId
         }
-        networkConnection = Mock(NetworkConnection)
+        networkConnection = Mock(NetworkConnection){
+           getDomainId() >> domainOne
+        }
         managedConnection = new CasualManagedConnection( Mock(CasualManagedConnectionFactory) )
         managedConnection.networkConnection = networkConnection
         instance = new CasualXAResource( managedConnection, mcf.getResourceId() )
@@ -65,8 +72,8 @@ class CasualXAResourceTest extends Specification
 
     def cleanup()
     {
-        transactionResources.remove( xid1 )
-        transactionResources.remove( xid2 )
+        transactionResources.remove( domainOne, xid1 )
+        transactionResources.remove( domainOne, xid2 )
     }
 
     def initialiseExpectedRequests()
@@ -153,7 +160,7 @@ class CasualXAResourceTest extends Specification
     def "GetCurrentXid returns value given during start."()
     {
         when:
-        transactionResources.remove( xid1 )
+        transactionResources.remove( domainOne, xid1 )
         instance.start( xid1, 0 )
 
         then:
@@ -163,7 +170,7 @@ class CasualXAResourceTest extends Specification
     def "GetCurrentXid returns null xid after end has been called."()
     {
         when:
-        transactionResources.remove( xid1 )
+        transactionResources.remove( domainOne, xid1 )
         instance.start( xid1, 0 )
         instance.end(xid1, XAFlags.TMSUCCESS.getValue())
         then:

--- a/casual/casual-jca/src/test/groovy/se/laz/casual/jca/conversation/CasualConversationImplTest.groovy
+++ b/casual/casual-jca/src/test/groovy/se/laz/casual/jca/conversation/CasualConversationImplTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, The casual project. All rights reserved.
+ * Copyright (c) 2021 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -21,6 +21,7 @@ import se.laz.casual.jca.CasualManagedConnection
 import se.laz.casual.jca.CasualManagedConnectionFactory
 import se.laz.casual.jca.CasualResourceAdapter
 import se.laz.casual.jca.CasualResourceManager
+import se.laz.casual.jca.DomainId
 import se.laz.casual.network.protocol.messages.CasualNWMessageImpl
 import se.laz.casual.network.protocol.messages.conversation.Request
 import spock.lang.Shared
@@ -36,6 +37,7 @@ class CasualConversationImplTest extends Specification
    @Shared NetworkConnection networkConnection
    @Shared UUID corrId
    @Shared UUID conversationExecution
+   @Shared DomainId domainOne = DomainId.of(UUID.randomUUID())
    @Shared String serviceName
    @Shared JsonBuffer message
    @Shared JsonBuffer replyMsg
@@ -55,14 +57,16 @@ class CasualConversationImplTest extends Specification
       ra = new CasualResourceAdapter()
       ra.workManager = workManager
       mcf = Mock(CasualManagedConnectionFactory)
-      networkConnection = Mock(NetworkConnection)
+      networkConnection = Mock(NetworkConnection){
+         getDomainId() >> domainOne
+      }
 
       connection = new CasualManagedConnection( mcf )
       connection.networkConnection =  networkConnection
 
-      CasualResourceManager.getInstance().remove(XID.NULL_XID)
+      CasualResourceManager.getInstance().remove(domainOne, XID.NULL_XID)
       connection.getXAResource().start( XID.NULL_XID, 0 )
-      CasualResourceManager.getInstance().remove(XID.NULL_XID)
+      CasualResourceManager.getInstance().remove(domainOne, XID.NULL_XID)
 
       conversationConnectCaller = ConversationConnectCaller.of(connection)
       instance = CasualConversationImpl.of(connection, conversationDirection, corrId, conversationExecution)

--- a/casual/casual-jca/src/test/groovy/se/laz/casual/jca/conversation/ConversationConnectCallerTest.groovy
+++ b/casual/casual-jca/src/test/groovy/se/laz/casual/jca/conversation/ConversationConnectCallerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, The casual project. All rights reserved.
+ * Copyright (c) 2021 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -20,6 +20,7 @@ import se.laz.casual.jca.CasualManagedConnection
 import se.laz.casual.jca.CasualManagedConnectionFactory
 import se.laz.casual.jca.CasualResourceAdapter
 import se.laz.casual.jca.CasualResourceManager
+import se.laz.casual.jca.DomainId
 import se.laz.casual.network.connection.CasualConnectionException
 import se.laz.casual.network.protocol.messages.CasualNWMessageImpl
 import se.laz.casual.network.protocol.messages.conversation.ConnectReply
@@ -36,6 +37,7 @@ class ConversationConnectCallerTest extends Specification
    @Shared NetworkConnection networkConnection
    @Shared UUID executionId
    @Shared UUID corrId
+   @Shared DomainId domainOne = DomainId.of(UUID.randomUUID())
    @Shared String serviceName
    @Shared JsonBuffer message
    @Shared CasualNWMessageImpl<ConnectRequest> expectedConnectRequest
@@ -54,14 +56,16 @@ class ConversationConnectCallerTest extends Specification
       ra = new CasualResourceAdapter()
       ra.workManager = workManager
       mcf = Mock(CasualManagedConnectionFactory)
-      networkConnection = Mock(NetworkConnection)
+      networkConnection = Mock(NetworkConnection){
+         getDomainId() >> domainOne
+      }
 
       connection = new CasualManagedConnection( mcf )
       connection.networkConnection =  networkConnection
 
-      CasualResourceManager.getInstance().remove(XID.NULL_XID)
+      CasualResourceManager.getInstance().remove(domainOne, XID.NULL_XID)
       connection.getXAResource().start( XID.NULL_XID, 0 )
-      CasualResourceManager.getInstance().remove(XID.NULL_XID)
+      CasualResourceManager.getInstance().remove(domainOne, XID.NULL_XID)
 
       instance = ConversationConnectCaller.of( connection )
 

--- a/casual/casual-jca/src/test/groovy/se/laz/casual/jca/queue/CasualQueueCallerTest.groovy
+++ b/casual/casual-jca/src/test/groovy/se/laz/casual/jca/queue/CasualQueueCallerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -7,19 +7,29 @@
 package se.laz.casual.jca.queue
 
 import se.laz.casual.api.buffer.type.JsonBuffer
-import se.laz.casual.api.queue.*
+import se.laz.casual.api.queue.DequeueReturn
+import se.laz.casual.api.queue.EnqueueReturn
+import se.laz.casual.api.queue.MessageSelector
+import se.laz.casual.api.queue.QueueInfo
+import se.laz.casual.api.queue.QueueMessage
 import se.laz.casual.api.xa.XID
 import se.laz.casual.config.Domain
 import se.laz.casual.internal.network.NetworkConnection
 import se.laz.casual.jca.CasualManagedConnection
 import se.laz.casual.jca.CasualManagedConnectionFactory
 import se.laz.casual.jca.CasualResourceManager
+import se.laz.casual.jca.DomainId
 import se.laz.casual.network.connection.CasualConnectionException
 import se.laz.casual.network.protocol.messages.CasualNWMessageImpl
 import se.laz.casual.network.protocol.messages.domain.CasualDomainDiscoveryReplyMessage
 import se.laz.casual.network.protocol.messages.domain.CasualDomainDiscoveryRequestMessage
 import se.laz.casual.network.protocol.messages.domain.Queue
-import se.laz.casual.network.protocol.messages.queue.*
+import se.laz.casual.network.protocol.messages.queue.CasualDequeueReplyMessage
+import se.laz.casual.network.protocol.messages.queue.CasualDequeueRequestMessage
+import se.laz.casual.network.protocol.messages.queue.CasualEnqueueReplyMessage
+import se.laz.casual.network.protocol.messages.queue.CasualEnqueueRequestMessage
+import se.laz.casual.network.protocol.messages.queue.DequeueMessage
+import se.laz.casual.network.protocol.messages.queue.EnqueueMessage
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -36,6 +46,7 @@ class CasualQueueCallerTest extends Specification
     @Shared NetworkConnection networkConnection
     @Shared UUID executionId
     @Shared UUID domainId
+    @Shared DomainId domainOne = DomainId.of(UUID.randomUUID())
     @Shared UUID enqueueReplyId
     @Shared def domainName
     @Shared def queueName
@@ -60,13 +71,15 @@ class CasualQueueCallerTest extends Specification
         mcf.getResourceId() >> {
             resourceId
         }
-        networkConnection = Mock(NetworkConnection)
+        networkConnection = Mock(NetworkConnection){
+           getDomainId() >> domainOne
+        }
         connection = new CasualManagedConnection( mcf )
         connection.networkConnection =  networkConnection
 
-        CasualResourceManager.getInstance().remove(XID.NULL_XID)
+        CasualResourceManager.getInstance().remove(domainOne, XID.NULL_XID)
         connection.getXAResource().start( XID.NULL_XID, 0 )
-        CasualResourceManager.getInstance().remove(XID.NULL_XID)
+        CasualResourceManager.getInstance().remove(domainOne,XID.NULL_XID)
 
         instance = CasualQueueCaller.of( connection )
 

--- a/casual/casual-jca/src/test/groovy/se/laz/casual/jca/service/CasualServiceCallerTest.groovy
+++ b/casual/casual-jca/src/test/groovy/se/laz/casual/jca/service/CasualServiceCallerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2023, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -11,7 +11,11 @@ import se.laz.casual.api.buffer.CasualBuffer
 import se.laz.casual.api.buffer.ServiceReturn
 import se.laz.casual.api.buffer.type.JsonBuffer
 import se.laz.casual.api.buffer.type.ServiceBuffer
-import se.laz.casual.api.flags.*
+import se.laz.casual.api.flags.AtmiFlags
+import se.laz.casual.api.flags.ErrorState
+import se.laz.casual.api.flags.Flag
+import se.laz.casual.api.flags.ServiceReturnState
+import se.laz.casual.api.flags.TransactionState
 import se.laz.casual.api.network.protocol.messages.exception.CasualProtocolException
 import se.laz.casual.api.xa.XID
 import se.laz.casual.config.Domain
@@ -23,6 +27,7 @@ import se.laz.casual.jca.CasualManagedConnection
 import se.laz.casual.jca.CasualManagedConnectionFactory
 import se.laz.casual.jca.CasualResourceAdapter
 import se.laz.casual.jca.CasualResourceManager
+import se.laz.casual.jca.DomainId
 import se.laz.casual.network.connection.CasualConnectionException
 import se.laz.casual.network.messages.domain.TransactionType
 import se.laz.casual.network.protocol.messages.CasualNWMessageImpl
@@ -46,6 +51,7 @@ class CasualServiceCallerTest extends Specification
     @Shared NetworkConnection networkConnection
     @Shared UUID executionId
     @Shared UUID domainId
+    @Shared DomainId domainOne = DomainId.of(UUID.randomUUID())
     @Shared String domainName
     @Shared String serviceName
     @Shared JsonBuffer message
@@ -67,13 +73,15 @@ class CasualServiceCallerTest extends Specification
         workManager = Mock(WorkManager)
         ra.workManager = workManager
         mcf = Mock(CasualManagedConnectionFactory)
-        networkConnection = Mock(NetworkConnection)
+        networkConnection = Mock(NetworkConnection){
+           getDomainId() >> domainOne
+        }
         connection = new CasualManagedConnection( mcf )
         connection.networkConnection =  networkConnection
 
-        CasualResourceManager.getInstance().remove(XID.NULL_XID)
+        CasualResourceManager.getInstance().remove(domainOne, XID.NULL_XID)
         connection.getXAResource().start( XID.NULL_XID, 0 )
-        CasualResourceManager.getInstance().remove(XID.NULL_XID)
+        CasualResourceManager.getInstance().remove(domainOne, XID.NULL_XID)
 
         instance = CasualServiceCaller.of( connection )
         serviceCallEventPublisher = Mock(ServiceCallEventPublisher)

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,9 +7,9 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '3.2.45'
+version = '3.2.46'
 
-def netty_version = '4.1.113.Final'
+def netty_version = '4.1.114.Final'
 def gson_version = '2.10.1'
 
 ext.libs = [


### PR DESCRIPTION
For wildfly, the trid should be unique per resource - not global as it is for wls as wls handles it differently.
