### PR TITLE
Bugfix/3.2/inbound discovery with custom service handlers

### DIFF
--- a/casual/casual-inbound-handler-api/src/main/java/se/laz/casual/jca/inbound/handler/service/ServiceHandler.java
+++ b/casual/casual-inbound-handler-api/src/main/java/se/laz/casual/jca/inbound/handler/service/ServiceHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -18,7 +18,7 @@ public interface ServiceHandler extends Prioritisable
      * service of this name.
      *
      * Differs from {@link #isServiceAvailable} in that a
-     * service could be registered  but unavailable,
+     * service could be registered and possible to handle but unavailable,
      * in which case this method would return true,
      * but {@link #isServiceAvailable} would return false.
      *
@@ -28,8 +28,15 @@ public interface ServiceHandler extends Prioritisable
     boolean canHandleService( String serviceName );
 
     /**
-     * Determine if the provided service is available
-     * in this handler.
+     * Determine if the provided service is available to receive requests
+     * through this handler.
+     *
+     * Differs from {@link #canHandleService} in that a
+     * service may not yet be available/ready to receive requests, but
+     * this handler can handle the service when it is available.
+     * In which case this method would return false,
+     * but {@link #canHandleService} would return true.
+     *
      * @param serviceName name
      * @return if the service is available.
      */

--- a/casual/casual-jca/build.gradle
+++ b/casual/casual-jca/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -41,6 +41,7 @@ dependencies {
     implementation project(':casual:casual-network-protocol')
     implementation project(':casual:casual-event-api')
     implementation project(':casual:casual-event-server')
+    compileOnly project(':casual:casual-inbound-handler-api')
     implementation libs.netty
     compileOnly libs.javaee_api
     compileOnly libs.gson
@@ -53,6 +54,8 @@ dependencies {
 
     testImplementation libs.javaee_api
     testImplementation libs.hamcrest_all
+    testImplementation project(':casual:casual-inbound-handler-api')
+    //testImplementation project(':casual:casual-inbound-handler-casual-service')
     // for spock
     testImplementation platform(libs.groovy_bom)
     testImplementation libs.groovy

--- a/casual/casual-jca/build.gradle
+++ b/casual/casual-jca/build.gradle
@@ -55,7 +55,6 @@ dependencies {
     testImplementation libs.javaee_api
     testImplementation libs.hamcrest_all
     testImplementation project(':casual:casual-inbound-handler-api')
-    //testImplementation project(':casual:casual-inbound-handler-casual-service')
     // for spock
     testImplementation platform(libs.groovy_bom)
     testImplementation libs.groovy

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartInboundServerWork.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartInboundServerWork.java
@@ -10,11 +10,12 @@ import jakarta.resource.spi.work.Work;
 import se.laz.casual.config.ConfigurationOptions;
 import se.laz.casual.config.ConfigurationService;
 import se.laz.casual.jca.InboundStartupException;
-import se.laz.casual.jca.inbound.handler.service.casual.CasualServiceRegistry;
+import se.laz.casual.jca.inbound.handler.service.ServiceHandler;
+import se.laz.casual.jca.inbound.handler.service.ServiceHandlerFactory;
+import se.laz.casual.jca.inbound.handler.service.ServiceHandlerNotFoundException;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -113,14 +114,25 @@ public final class StartInboundServerWork<T> implements Work
 
     private Set<String> checkRemainingServices( Set<String> remaining )
     {
-        CasualServiceRegistry registry = CasualServiceRegistry.getInstance();
-        Map<Boolean,Set<String>> found = remaining.stream()
-                .collect( Collectors.partitioningBy( registry::hasServiceEntry, Collectors.toSet() ) );
-        for( String foundService: found.get( true ) )
+        Set<String> notFound = new HashSet<>( remaining );
+        for( String find: remaining )
         {
-            log.info( ()-> "Startup service registered: " + foundService );
+            try
+            {
+                ServiceHandler handler = ServiceHandlerFactory.getHandler( find );
+                if( handler.isServiceAvailable( find ) )
+                {
+                    notFound.remove( find );
+                    log.info( () -> "Startup service registered: " + find );
+                }
+
+            }
+            catch( ServiceHandlerNotFoundException e )
+            {
+                //Service not registered.
+            }
         }
-        return found.get( false );
+        return notFound;
     }
 
     private void maybeDelay()

--- a/casual/casual-jca/src/test/groovy/se/laz/casual/jca/work/StartInboundServerWorkTest.groovy
+++ b/casual/casual-jca/src/test/groovy/se/laz/casual/jca/work/StartInboundServerWorkTest.groovy
@@ -153,22 +153,4 @@ class StartInboundServerWorkTest extends Specification
         then:
         server.isActive(  )
     }
-
-//    CasualServiceEntry prepareRegistry( String serviceName )
-//    {
-//        CasualService service = new CasualServiceLiteral( serviceName, "" )
-//        Class<?> serviceClass = String.class
-//        Method serviceMethod = String.class.getMethod( "toString" )
-//
-//        CasualServiceMetaData metaData = CasualServiceMetaData.newBuilder(  )
-//                .service( service )
-//                .implementationClass( serviceClass )
-//                .serviceMethod( serviceMethod )
-//                .build(  )
-//
-//        registry.register( metaData )
-//
-//        return CasualServiceEntry.of( serviceName, "", null, null )
-//    }
-
 }

--- a/casual/casual-jca/src/test/groovy/se/laz/casual/jca/work/StartInboundServerWorkTest.groovy
+++ b/casual/casual-jca/src/test/groovy/se/laz/casual/jca/work/StartInboundServerWorkTest.groovy
@@ -10,19 +10,15 @@ import jakarta.resource.spi.XATerminator
 import jakarta.resource.spi.endpoint.MessageEndpointFactory
 import jakarta.resource.spi.work.Work
 import jakarta.resource.spi.work.WorkManager
-import se.laz.casual.api.service.CasualService
 import se.laz.casual.config.Mode
 import se.laz.casual.jca.InboundStartupException
-import se.laz.casual.jca.inbound.handler.service.casual.CasualServiceEntry
-import se.laz.casual.jca.inbound.handler.service.casual.CasualServiceLiteral
-import se.laz.casual.jca.inbound.handler.service.casual.CasualServiceMetaData
-import se.laz.casual.jca.inbound.handler.service.casual.CasualServiceRegistry
+import se.laz.casual.jca.inbound.handler.service.ServiceHandlerFactory
+import se.laz.casual.jca.inbound.handler.test.TestServiceHandler
 import se.laz.casual.network.inbound.CasualServer
 import se.laz.casual.network.inbound.ConnectionInformation
 import spock.lang.Shared
 import spock.lang.Specification
 
-import java.lang.reflect.Method
 import java.util.concurrent.CompletionService
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.ExecutorCompletionService
@@ -41,7 +37,10 @@ class StartInboundServerWorkTest extends Specification
     Work instance
     ConnectionInformation ci
 
-    CasualServiceRegistry registry = CasualServiceRegistry.getInstance()
+    TestServiceHandler testHandler = (TestServiceHandler) ServiceHandlerFactory.getHandlers(  ).stream(  )
+            .filter {  it instanceof TestServiceHandler }
+            .findFirst(  )
+            .orElseThrow( ()-> new RuntimeException( "pop" ))
 
     CasualServer server
 
@@ -60,7 +59,7 @@ class StartInboundServerWorkTest extends Specification
 
     def cleanup()
     {
-        registry.clear(  )
+        testHandler.clear(  )
         if( server != null )
         {
             server.close(  )
@@ -85,14 +84,14 @@ class StartInboundServerWorkTest extends Specification
     {
         given:
         String serviceName1 = Mode.Constants.TRIGGER_SERVICE
-        CasualServiceEntry entry = prepareRegistry( serviceName1 )
+        testHandler.registerService( serviceName1 )
 
         instance = StartInboundServerWork.of( [serviceName1], {"inbound started"},{s -> server = s}, {CasualServer.of(ci)})
 
         when:
         completionService.submit( { instance.run(  ) } )
         completionService.submit( {
-            registry.register( entry )
+            testHandler.makeServiceAvailable( serviceName1 )
         } )
 
         completionService.take(  ).get( 5, TimeUnit.SECONDS )
@@ -106,7 +105,7 @@ class StartInboundServerWorkTest extends Specification
     {
         given:
         String serviceName1 = Mode.Constants.TRIGGER_SERVICE
-        prepareRegistry( serviceName1 )
+        testHandler.registerService( serviceName1 )
 
         instance = StartInboundServerWork.of( [serviceName1], {"inbound started"}, {s -> server = s}, {CasualServer.of(ci)} )
 
@@ -131,10 +130,9 @@ class StartInboundServerWorkTest extends Specification
     {
         given:
         List<String> serviceNames = ["service1","service2"]
-        List<CasualServiceEntry> entries = []
         for( String serviceName: serviceNames )
         {
-            entries.add( prepareRegistry( serviceName ) )
+            testHandler.registerService( serviceName )
         }
 
         instance = StartInboundServerWork.of( serviceNames, {"inbound started"},{s -> server = s}, {CasualServer.of(ci)})
@@ -142,9 +140,9 @@ class StartInboundServerWorkTest extends Specification
         when:
         completionService.submit( { instance.run(  ) } )
         completionService.submit( {
-            for( CasualServiceEntry entry: entries )
+            for( String service: serviceNames )
             {
-                registry.register( entry )
+                testHandler.makeServiceAvailable( service )
                 Thread.sleep( 1010 )
             }
         } )
@@ -156,21 +154,21 @@ class StartInboundServerWorkTest extends Specification
         server.isActive(  )
     }
 
-    CasualServiceEntry prepareRegistry( String serviceName )
-    {
-        CasualService service = new CasualServiceLiteral( serviceName, "" )
-        Class<?> serviceClass = String.class
-        Method serviceMethod = String.class.getMethod( "toString" )
-
-        CasualServiceMetaData metaData = CasualServiceMetaData.newBuilder(  )
-                .service( service )
-                .implementationClass( serviceClass )
-                .serviceMethod( serviceMethod )
-                .build(  )
-
-        registry.register( metaData )
-
-        return CasualServiceEntry.of( serviceName, "", null, null )
-    }
+//    CasualServiceEntry prepareRegistry( String serviceName )
+//    {
+//        CasualService service = new CasualServiceLiteral( serviceName, "" )
+//        Class<?> serviceClass = String.class
+//        Method serviceMethod = String.class.getMethod( "toString" )
+//
+//        CasualServiceMetaData metaData = CasualServiceMetaData.newBuilder(  )
+//                .service( service )
+//                .implementationClass( serviceClass )
+//                .serviceMethod( serviceMethod )
+//                .build(  )
+//
+//        registry.register( metaData )
+//
+//        return CasualServiceEntry.of( serviceName, "", null, null )
+//    }
 
 }

--- a/casual/casual-jca/src/test/java/se/laz/casual/jca/inbound/handler/test/TestServiceHandler.java
+++ b/casual/casual-jca/src/test/java/se/laz/casual/jca/inbound/handler/test/TestServiceHandler.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+package se.laz.casual.jca.inbound.handler.test;
+
+import se.laz.casual.api.service.ServiceInfo;
+import se.laz.casual.jca.inbound.handler.InboundRequest;
+import se.laz.casual.jca.inbound.handler.InboundResponse;
+import se.laz.casual.jca.inbound.handler.service.ServiceHandler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TestServiceHandler implements ServiceHandler
+{
+    private static final Map<String, Boolean> services = new HashMap<>();
+
+    public void registerService( String name )
+    {
+        services.put( name, false );
+    }
+
+    public void makeServiceAvailable( String name )
+    {
+        services.put( name, true );
+    }
+
+    public void clear( )
+    {
+        services.clear();
+    }
+
+    @Override
+    public boolean canHandleService( String serviceName )
+    {
+        return services.containsKey( serviceName );
+    }
+
+    @Override
+    public boolean isServiceAvailable( String serviceName )
+    {
+        return services.getOrDefault( serviceName, false );
+    }
+
+    @Override
+    public InboundResponse invokeService( InboundRequest request )
+    {
+        return null;
+    }
+
+    @Override
+    public ServiceInfo getServiceInfo( String serviceName )
+    {
+        return null;
+    }
+}

--- a/casual/casual-jca/src/test/resources/META-INF/services/se.laz.casual.jca.inbound.handler.service.ServiceHandler
+++ b/casual/casual-jca/src/test/resources/META-INF/services/se.laz.casual.jca.inbound.handler.service.ServiceHandler
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2017 - 2024, The casual project. All rights reserved.
+#
+# This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+#
+
+se.laz.casual.jca.inbound.handler.test.TestServiceHandler #Fielded Casual Handler.

--- a/inbound.md
+++ b/inbound.md
@@ -41,7 +41,7 @@ It is therefore the responsibility of the `ServiceHandler` implementations to en
 dispatch incoming requests to the appropriate deployed application.
 
 As new applications containing casual inbound services are deployed, the domain discovery requests must respond accordingly. Therefore all
-`ServiceHandler` implementations must monitor the deployment of applications containing Casual Services over time.
+`ServiceHandler` implementations must monitor the deployment of applications containing "their services" over time.
 
 ### CasualServiceHandler implementation
 

--- a/inbound.md
+++ b/inbound.md
@@ -13,9 +13,9 @@ There are currently two types of services which are supported by Casual JCA.
 * Casual Services
 * JavaEE Services - (testing purpose only)
 
-### Casual Service Registration
+### Casual Service Discovery
 
-In order to register inbound services, applications can for example use the `@CasualService` annotation upon their
+In order to make inbound services discoverable, applications can for example use the `@CasualService` annotation upon their
 method of a `@Remote` Java bean.
 In the following example you can see how a service called `echo` is defined.
 
@@ -34,16 +34,25 @@ public class EchoServiceImpl implements EchoService
                 .build();
     }
 }
-``` 
-During application deployment Casual JCA application will `@Observe` the deployment of the `@CasualService` and 
+```
+
+All available `ServiceHandler` implementation are used to respond to domain discovery requests by calling the`isServiceAvailable` method. 
+It is therefore the responsibility of the `ServiceHandler` implementations to ensure it responds correctly to these domain discovery requests and
+dispatch incoming requests to the appropriate deployed application.
+
+As new applications containing casual inbound services are deployed, the domain discovery requests must respond accordingly. Therefore all
+`ServiceHandler` implementations must monitor the deployment of applications containing Casual Services over time.
+
+### CasualServiceHandler implementation
+
+Internally the `CasualServiceHandler` implementation of `ServiceHandler` uses a private CasualServiceRegistry which
+determines whether a service can be handled and or is available to be called.
+
+During application deployment Casual JCA application will `@Observe` the deployment of the `@CasualService` and
 register them as inbound services, allowing clients to make requests against these services.
 This applies to all applications that are deployed throughout the runtime of the application server.
 
-The resulting inbound service registry is used to respond to domain discovery requests. As well as to dispatch incoming
-request to the appropriate deployed application. As new applications containing casual inbound services are deployed, 
-the domain discovery requests will respond accordingly.
-
-NB - undeployment of an application currently does not remove the associated casual services from the registry.
+NB - undeployment of an application currently does not remove the associated casual services from the private internal registry.
 
 ### Extending Casual Service Handler
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '3.2.47'
+version = '3.2.48'
 
 def netty_version = '4.1.114.Final'
 def gson_version = '2.10.1'


### PR DESCRIPTION
Utilise all available service handlers to determine when services are available on startup with mode DISCOVER.
This is to ensure that custom service handlers are not ignored, as it currently the case.