### PR TITLE
Feature/3.2/initialise fieled on startup

### DIFF
--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceAdapter.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceAdapter.java
@@ -84,11 +84,28 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
         //It is also not possible to inject with CDI on wildfly only ConfigProperty annotations.
 
         log.info( ConfigurationService.log() );
+        initialiseFielded();
+        startEventServer();
+    }
+
+    /**
+     * Initialise fielded if there is a field table configured.
+     * This is to ensure json parsing required to populate static maps
+     * from within RA where `casual-api-spi-impl` is available.
+     * Therefore, other apps don't need to include casual-api-spi-impl in
+     * their own deployments too.
+     * Statics are unique per classloader.
+     * This only works due to the casual-api being available in a global module,
+     * meaning that the classloader is shared by all deployments.
+     * Any deployment utilising fielded is expected to have casual-jca deployed first.
+     */
+    private void initialiseFielded()
+    {
         if( ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_FIELD_TABLE ) != null )
         {
-            log.info( ()-> "CasualFieldedLookup Vomit: " + CasualFieldedLookup.getURL() );
+
+            log.finest( ()-> "CasualFieldedLookup static initialisation: " + CasualFieldedLookup.getURL() );
         }
-        startEventServer();
     }
 
     private void startEventServer()

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceAdapter.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceAdapter.java
@@ -19,6 +19,7 @@ import jakarta.resource.spi.work.Work;
 import jakarta.resource.spi.work.WorkException;
 import jakarta.resource.spi.work.WorkListener;
 import jakarta.resource.spi.work.WorkManager;
+import se.laz.casual.api.buffer.type.fielded.json.CasualFieldedLookup;
 import se.laz.casual.config.ConfigurationOptions;
 import se.laz.casual.config.ConfigurationService;
 import se.laz.casual.config.ReverseInbound;
@@ -83,6 +84,10 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
         //It is also not possible to inject with CDI on wildfly only ConfigProperty annotations.
 
         log.info( ConfigurationService.log() );
+        if( ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_FIELD_TABLE ) != null )
+        {
+            log.info( ()-> "CasualFieldedLookup Vomit: " + CasualFieldedLookup.getURL() );
+        }
         startEventServer();
     }
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '3.2.50-SNAPSHOT'
+version = '3.2.50'
 
 def netty_version = '4.1.114.Final'
 def gson_version = '2.11.0'

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '3.2.49'
+version = '3.2.50-SNAPSHOT'
 
 def netty_version = '4.1.114.Final'
 def gson_version = '2.11.0'


### PR DESCRIPTION
Fix to ensure fielded is eagerly loaded if the user has provided a configuration for the casual fielded table file.
Without this, the test application failed to perform marshalling of fielded as it did not have jsonprovider available, which was moved out of casual-api into casual-api-spi-impl in the previous release.