### PR TITLE
Feature/3.2/code needed for conversation support in casual caller

### DIFF
--- a/casual/casual-api/src/main/java/se/laz/casual/api/CasualConversationAPI.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/CasualConversationAPI.java
@@ -7,6 +7,7 @@
 package se.laz.casual.api;
 
 import se.laz.casual.api.buffer.CasualBuffer;
+import se.laz.casual.api.conversation.TpConnectReturn;
 import se.laz.casual.api.flags.AtmiFlags;
 import se.laz.casual.api.flags.Flag;
 
@@ -21,21 +22,27 @@ public interface CasualConversationAPI
      *
      * It signifies what state the caller will start out in
      * With AtmiFlags.TPSENDONLY the conversation caller is supposed to start sending data first, via tpsend.
-     * AtmiFlags.TPSENDONLY then means that the conversation caller will start receiving data, via tprecv
+     * AtmiFlags.TPRECVONLY then means that the conversation caller will start receiving data, via tprecv
      *
-     * @param serviceName name of service to which to connect.
-     * @param flags to send with the connection request.
-     * @return A conversation handle
+     * The conversation is only available if {@link TpConnectReturn#getErrorState()} equals to {@link se.laz.casual.api.flags.ErrorState#OK}
+     * - if not, you should fail the call with the provided error.
+     *
+     * Note:
+     * Always issue the call using try-with-resources to make sure that nothing leaks
+     *
+     * @param serviceName - the service name
+     * @param data - initial data to be sent
+     * @param flags - the flags
+     * @return A TpConnectReturn with a conversation if {@link TpConnectReturn#getErrorState()} equals to {@link se.laz.casual.api.flags.ErrorState#OK}
      */
-    Conversation tpconnect(String serviceName, Flag<AtmiFlags> flags);
+    TpConnectReturn tpconnect(String serviceName, CasualBuffer data, Flag<AtmiFlags> flags);
 
     /**
-     * As per {@link #tpconnect} though with additional data to be set during the connect request.
-     *
-     * @param serviceName name of service to which to connect.
-     * @param data to send during initial connection request.
-     * @param flags to send with the connection request.
-     * @return A conversation handle
+     * Same as tpconnect with data but no initial data is sent in this case
+     * @param serviceName - the service name
+     * @param flags - the flags
+     * @return A TpConnectReturn with a conversation if {@link TpConnectReturn#getErrorState()} equals to {@link se.laz.casual.api.flags.ErrorState#OK}
      */
-    Conversation tpconnect(String serviceName, CasualBuffer data, Flag<AtmiFlags> flags);
+    TpConnectReturn tpconnect(String serviceName, Flag<AtmiFlags> flags);
+
 }

--- a/casual/casual-api/src/main/java/se/laz/casual/api/CasualConversationApi.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/CasualConversationApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -14,7 +14,7 @@ import se.laz.casual.api.flags.Flag;
 /**
  * API to start a {@link Conversation}
  */
-public interface CasualConversationAPI
+public interface CasualConversationApi
 {
     /**
      * Flags have to be either:

--- a/casual/casual-api/src/main/java/se/laz/casual/api/CasualConversationApi.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/CasualConversationApi.java
@@ -27,6 +27,8 @@ public interface CasualConversationApi
      * The conversation is only available if {@link TpConnectReturn#getErrorState()} equals to {@link se.laz.casual.api.flags.ErrorState#OK}
      * - if not, you should fail the call with the provided error.
      *
+     * In the event of such things as IOExceptions, this can and will be thrown.
+     *
      * Note:
      * Always issue the call using try-with-resources to make sure that nothing leaks
      *

--- a/casual/casual-api/src/main/java/se/laz/casual/api/Conversation.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/Conversation.java
@@ -18,8 +18,13 @@ import se.laz.casual.api.buffer.ConversationReturn;
  *      try(CasualConnection connection = connectionFactory.getConnection())
  *      {
  *          OctetBuffer buffer = OctetBuffer.of("Initial payload\n".getBytes(StandardCharsets.UTF_8));
- *          try(Conversation conversation = connection.tpconnect("some_service", buffer, Flag.of(AtmiFlags.TPSENDONLY)))
+ *          try(TpConnectReturn tpConnectReturn = connection.tpconnect("some_service", buffer, Flag.of(AtmiFlags.TPSENDONLY)))
  *          {
+ *              if(tpConnectReturn.getErrorState() != ErrorState.OK)
+ *              {
+ *                  throw new TPConnectFailedException(tpConnectReturn.getErrorState());
+ *              }
+ *              Conversation conversation = tpConnectReturn.getConversation().orElseThrow(() -> new TPConnectFailedException("ErrorState.OK but no conversation!"));
  *              StringBuilder b = new StringBuilder("Payload:\n");
  *              buffer = OctetBuffer.of("Extra, extra, read all about it!\n".getBytes(StandardCharsets.UTF_8));
  *              // send buffer and hand over control
@@ -54,7 +59,7 @@ public interface Conversation extends AutoCloseable
     /**
      * Note, blocks until a message is available
      * Throws if called when tpsend is supposed to be called
-     * @return The received casual buffer.
+     * @return The result - {@link ConversationReturn<CasualBuffer>}
      */
     ConversationReturn<CasualBuffer> tprecv();
 
@@ -73,7 +78,7 @@ public interface Conversation extends AutoCloseable
     /**
      * Note: blocks until message has successfully been sent
      * Throws if called when tprecv is supposed to be called
-     * @param data to send.
+     * @param data
      * @param handOverControl - true if you are in control but want to hand over control and start receiving
      */
     void tpsend(CasualBuffer data, boolean handOverControl);

--- a/casual/casual-api/src/main/java/se/laz/casual/api/conversation/TpConnectReturn.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/conversation/TpConnectReturn.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2022, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+package se.laz.casual.api.conversation;
+
+import se.laz.casual.api.Conversation;
+import se.laz.casual.api.flags.ErrorState;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ *  The result from tpconnect
+ *  On return it either contains:
+ *  ErrorState.OK and a Conversation
+ *  or
+ *  !ErrorState.OK and no Conversation
+ *
+ *  Always use this with try with resources.
+ *  If you do not, any valid conversation will not be closed properly.
+ */
+
+public class TpConnectReturn implements AutoCloseable
+{
+    private final Conversation conversation;
+    private final ErrorState errorState;
+
+    private TpConnectReturn(Conversation conversation, ErrorState errorState)
+    {
+        this.conversation = conversation;
+        this.errorState = errorState;
+    }
+
+    public static TpConnectReturn of(Conversation conversation)
+    {
+        Objects.requireNonNull(conversation, "conversation can not be null");
+        return new TpConnectReturn(conversation, ErrorState.OK);
+    }
+
+    public static TpConnectReturn of(ErrorState errorState)
+    {
+        Objects.requireNonNull(errorState, "errorState can not be null");
+        return new TpConnectReturn(null, errorState);
+    }
+
+    public Optional<Conversation> getConversation()
+    {
+        return Optional.ofNullable(conversation);
+    }
+
+    public ErrorState getErrorState()
+    {
+        return errorState;
+    }
+
+    @Override
+    public void close()
+    {
+        getConversation().ifPresent(Conversation::close);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+        TpConnectReturn that = (TpConnectReturn) o;
+        return Objects.equals(getConversation(), that.getConversation()) && getErrorState() == that.getErrorState();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(getConversation(), getErrorState());
+    }
+
+    @Override
+    public String toString()
+    {
+        return "TpConnectReturn{" +
+                "conversation=" + conversation +
+                ", errorState=" + errorState +
+                '}';
+    }
+}

--- a/casual/casual-api/src/main/java/se/laz/casual/jca/CasualConnection.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/jca/CasualConnection.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2017 - 2023, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
 
 package se.laz.casual.jca;
 
-import se.laz.casual.api.CasualConversationAPI;
+import se.laz.casual.api.CasualConversationApi;
 import se.laz.casual.api.CasualDiscoveryApi;
 import se.laz.casual.api.CasualQueueApi;
 import se.laz.casual.api.CasualServiceApi;
@@ -16,7 +16,7 @@ import se.laz.casual.api.CasualServiceApi;
  *
  * @version $Revision: $
  */
-public interface CasualConnection extends CasualServiceApi, CasualQueueApi, CasualConversationAPI, CasualDiscoveryApi, AutoCloseable
+public interface CasualConnection extends CasualServiceApi, CasualQueueApi, CasualConversationApi, CasualDiscoveryApi, AutoCloseable
 {
     /**
      * Clean up the connection handle and close.

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualConnectionImpl.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualConnectionImpl.java
@@ -6,9 +6,9 @@
 
 package se.laz.casual.jca;
 
-import se.laz.casual.api.Conversation;
 import se.laz.casual.api.buffer.CasualBuffer;
 import se.laz.casual.api.buffer.ServiceReturn;
+import se.laz.casual.api.conversation.TpConnectReturn;
 import se.laz.casual.api.discovery.DiscoveryReturn;
 import se.laz.casual.api.flags.AtmiFlags;
 import se.laz.casual.api.flags.Flag;
@@ -185,7 +185,7 @@ public class CasualConnectionImpl implements CasualConnection
     }
 
     @Override
-    public Conversation tpconnect(String serviceName, Flag<AtmiFlags> flags)
+    public TpConnectReturn tpconnect(String serviceName, Flag<AtmiFlags> flags)
     {
         Objects.requireNonNull(serviceName,"serviceName can not be null");
         Objects.requireNonNull(flags, "flags can not be null");
@@ -193,7 +193,7 @@ public class CasualConnectionImpl implements CasualConnection
     }
 
     @Override
-    public Conversation tpconnect(String serviceName, CasualBuffer data, Flag<AtmiFlags> flags)
+    public TpConnectReturn tpconnect(String serviceName, CasualBuffer data, Flag<AtmiFlags> flags)
     {
         Objects.requireNonNull(serviceName,"serviceName can not be null");
         Objects.requireNonNull(data, "data can not be null");

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/conversation/ConversationConnectCaller.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/conversation/ConversationConnectCaller.java
@@ -7,10 +7,10 @@
 package se.laz.casual.jca.conversation;
 
 import se.laz.casual.api.CasualConversationAPI;
-import se.laz.casual.api.Conversation;
 import se.laz.casual.api.buffer.CasualBuffer;
 import se.laz.casual.api.buffer.type.ServiceBuffer;
 import se.laz.casual.api.conversation.Duplex;
+import se.laz.casual.api.conversation.TpConnectReturn;
 import se.laz.casual.api.flags.AtmiFlags;
 import se.laz.casual.api.flags.ErrorState;
 import se.laz.casual.api.flags.Flag;
@@ -46,13 +46,13 @@ public class ConversationConnectCaller implements CasualConversationAPI
     }
 
     @Override
-    public Conversation tpconnect(String serviceName, Flag<AtmiFlags> flags)
+    public TpConnectReturn tpconnect(String serviceName, Flag<AtmiFlags> flags)
     {
         return tpconnect(serviceName, null, flags);
     }
 
     @Override
-    public Conversation tpconnect(String serviceName, CasualBuffer data, Flag<AtmiFlags> flags)
+    public TpConnectReturn tpconnect(String serviceName, CasualBuffer data, Flag<AtmiFlags> flags)
     {
         Objects.requireNonNull(serviceName, "serviceName can not be null");
         Objects.requireNonNull(flags, "flags can not be null");
@@ -91,10 +91,10 @@ public class ConversationConnectCaller implements CasualConversationAPI
             ErrorState errorState = ErrorState.unmarshal(reply.getResultCode());
             if (errorState != ErrorState.OK)
             {
-                throw new ConversationConnectException("tpconnect failed with " + errorState + " for request: " + connectRequest);
+                return TpConnectReturn.of(errorState);
             }
         }
-        return CasualConversationImpl.of(managedConnection, conversationDirection, corrId, conversationExecution);
+        return TpConnectReturn.of(CasualConversationImpl.of(managedConnection, conversationDirection, corrId, conversationExecution));
     }
 
     private ConversationDirection getDirection(Flag<AtmiFlags> flags)

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/conversation/ConversationConnectCaller.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/conversation/ConversationConnectCaller.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2021, The casual project. All rights reserved.
+ * Copyright (c) 2021 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
 
 package se.laz.casual.jca.conversation;
 
-import se.laz.casual.api.CasualConversationAPI;
+import se.laz.casual.api.CasualConversationApi;
 import se.laz.casual.api.buffer.CasualBuffer;
 import se.laz.casual.api.buffer.type.ServiceBuffer;
 import se.laz.casual.api.conversation.Duplex;
@@ -28,7 +28,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Logger;
 
-public class ConversationConnectCaller implements CasualConversationAPI
+public class ConversationConnectCaller implements CasualConversationApi
 {
     private static final Logger LOG = Logger.getLogger(ConversationConnectCaller.class.getName());
     private static final int RESULT_CODE_UNKNOWN = -1;

--- a/casual/casual-jca/src/test/groovy/se/laz/casual/jca/conversation/ConversationConnectCallerTest.groovy
+++ b/casual/casual-jca/src/test/groovy/se/laz/casual/jca/conversation/ConversationConnectCallerTest.groovy
@@ -11,6 +11,7 @@ import se.laz.casual.api.Conversation
 import se.laz.casual.api.buffer.type.JsonBuffer
 import se.laz.casual.api.buffer.type.ServiceBuffer
 import se.laz.casual.api.conversation.Duplex
+import se.laz.casual.api.conversation.TpConnectReturn
 import se.laz.casual.api.flags.AtmiFlags
 import se.laz.casual.api.flags.ErrorState
 import se.laz.casual.api.flags.Flag
@@ -121,7 +122,11 @@ class ConversationConnectCallerTest extends Specification
             return CompletableFuture.completedFuture(connectReplyOK)
       }
       when:
-      Conversation conversation = instance.tpconnect(serviceName, message, Flag.of(AtmiFlags.TPSENDONLY))
+      TpConnectReturn connectReturn = instance.tpconnect(serviceName, message, Flag.of(AtmiFlags.TPSENDONLY))
+      then:
+      connectReturn.getErrorState() == ErrorState.OK
+      when:
+      Conversation conversation = connectReturn.getConversation().orElseThrow({ new RuntimeException('oopsie!')})
       then:
       conversation != null
       conversation.isSending()
@@ -142,7 +147,11 @@ class ConversationConnectCallerTest extends Specification
             return CompletableFuture.completedFuture(connectReplyOKUserCodeMissing)
       }
       when:
-      Conversation conversation = instance.tpconnect(serviceName, message, Flag.of(AtmiFlags.TPSENDONLY))
+      TpConnectReturn connectReturn = instance.tpconnect(serviceName, message, Flag.of(AtmiFlags.TPSENDONLY))
+      then:
+      connectReturn.getErrorState() == ErrorState.OK
+      when:
+      Conversation conversation = connectReturn.getConversation().orElseThrow({ new RuntimeException('oopsie!')})
       then:
       conversation != null
       conversation.isSending()

--- a/casual/casual-jca/src/test/groovy/se/laz/casual/jca/conversation/ConversationConnectCallerTest.groovy
+++ b/casual/casual-jca/src/test/groovy/se/laz/casual/jca/conversation/ConversationConnectCallerTest.groovy
@@ -176,4 +176,17 @@ class ConversationConnectCallerTest extends Specification
       thrown(CasualConnectionException)
    }
 
+   def 'tpconnect TPFAIL not ok errorstate'()
+   {
+      given:
+      1 * networkConnection.request( _ ) >> {
+         CasualNWMessageImpl<ConnectRequest> input ->
+            return CompletableFuture.completedFuture(connectReplyFail)
+      }
+      when:
+      TpConnectReturn connectReturn = instance.tpconnect(serviceName, message, Flag.of(AtmiFlags.TPSENDONLY))
+      then:
+      connectReturn.getErrorState() == ErrorState.unmarshal(connectReplyFail.getMessage().getResultCode())
+   }
+
 }

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '3.2.50'
+version = '3.2.51'
 
 def netty_version = '4.1.114.Final'
 def gson_version = '2.11.0'

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '3.2.51'
+version = '3.3.0'
 
 def netty_version = '4.1.114.Final'
 def gson_version = '2.11.0'


### PR DESCRIPTION
Instead of returning a Conversation we now return a TpConnectReturn which potentially wraps a conversation and a connection as well.
It is auto closable and should be used in a try with resources context.

This code will be used in casual caller to support conversation as well.