### PR TITLE
feat: handle graceful shutdown

### DIFF
--- a/casual/casual-api/src/main/java/se/laz/casual/jca/RuntimeInformation.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/jca/RuntimeInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, The casual project. All rights reserved.
+ * Copyright (c) 2023 - 2025, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -8,11 +8,13 @@ package se.laz.casual.jca;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
 
 public class RuntimeInformation
 {
     private static final String INBOUND_SERVER_STARTED = "INBOUND_SERVER_STARTED";
     private static final String EVENT_SERVER_STARTED = "EVENT_SERVER_STARTED";
+    private static final String DOMAIN_IS_BEING_SHUTDOWN = "DOMAIN_IS_BEING_SHUTDOWN";
     private static final Map<String, Boolean> CACHE = new ConcurrentHashMap<>();
 
     private RuntimeInformation()
@@ -36,5 +38,16 @@ public class RuntimeInformation
     public static void setEventServerStarted(boolean started)
     {
         CACHE.put(EVENT_SERVER_STARTED, started);
+    }
+
+    public static void setDomainIsBeingShutdown(boolean beingShutdown)
+    {
+        CACHE.put(DOMAIN_IS_BEING_SHUTDOWN, beingShutdown);
+    }
+
+    public static boolean isDomainBeingShutdown()
+    {
+        Logger.getLogger(RuntimeInformation.class.getName()).info(() -> "isDomainBeingShutdown?" + Optional.ofNullable(CACHE.get(DOMAIN_IS_BEING_SHUTDOWN)).orElse(false));
+        return Optional.ofNullable(CACHE.get(DOMAIN_IS_BEING_SHUTDOWN)).orElse(false);
     }
 }

--- a/casual/casual-api/src/main/java/se/laz/casual/jca/RuntimeInformation.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/jca/RuntimeInformation.java
@@ -8,7 +8,6 @@ package se.laz.casual.jca;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Logger;
 
 public class RuntimeInformation
 {
@@ -47,7 +46,6 @@ public class RuntimeInformation
 
     public static boolean isDomainBeingShutdown()
     {
-        Logger.getLogger(RuntimeInformation.class.getName()).info(() -> "isDomainBeingShutdown?" + Optional.ofNullable(CACHE.get(DOMAIN_IS_BEING_SHUTDOWN)).orElse(false));
         return Optional.ofNullable(CACHE.get(DOMAIN_IS_BEING_SHUTDOWN)).orElse(false);
     }
 }

--- a/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/CasualInboundTransactionRegistry.java
+++ b/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/CasualInboundTransactionRegistry.java
@@ -30,12 +30,10 @@ public class CasualInboundTransactionRegistry
         Objects.requireNonNull(key, "key can not be null");
         Objects.requireNonNull(channelId, "channelId can not be null");
         log.finest(() -> "Removing transaction " + key + " from transaction registry");
-        Set<XidKey> ids = transactions.get(channelId);
-        ids.remove(key);
-        if(ids.isEmpty())
-        {
-            transactions.remove(channelId);
-        }
+        transactions.computeIfPresent(channelId, (id, set) ->{
+           set.remove(key);
+           return set.isEmpty() ? null : set;
+        });
     }
 
     public void remove(ChannelId channelId)

--- a/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/CasualInboundTransactionRegistry.java
+++ b/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/CasualInboundTransactionRegistry.java
@@ -17,18 +17,20 @@ import java.util.logging.Logger;
 public class CasualInboundTransactionRegistry
 {
     private static final Logger log = Logger.getLogger(CasualInboundTransactionRegistry.class.getName());
+    private static final String CHANNEL_ID_CAN_NOT_BE_NULL = "channelId can not be null";
     private final Map<ChannelId, Set<XidKey>> transactions = new ConcurrentHashMap<>();
 
     public void add(ChannelId channelId, XidKey key)
     {
+        Objects.requireNonNull(channelId, CHANNEL_ID_CAN_NOT_BE_NULL);
         Objects.requireNonNull(key, "key can not be null");
         log.finest(() -> "Adding transaction " + key + " to inbound transaction registry");
         transactions.computeIfAbsent(channelId, id -> ConcurrentHashMap.newKeySet()).add(key);
     }
     public void remove(ChannelId channelId, XidKey key)
     {
+        Objects.requireNonNull(channelId, CHANNEL_ID_CAN_NOT_BE_NULL);
         Objects.requireNonNull(key, "key can not be null");
-        Objects.requireNonNull(channelId, "channelId can not be null");
         log.finest(() -> "Removing transaction " + key + " from transaction registry");
         transactions.computeIfPresent(channelId, (id, set) ->{
            set.remove(key);
@@ -38,7 +40,7 @@ public class CasualInboundTransactionRegistry
 
     public void remove(ChannelId channelId)
     {
-        Objects.requireNonNull(channelId, "channelId can not be null");
+        Objects.requireNonNull(channelId, CHANNEL_ID_CAN_NOT_BE_NULL);
         log.finest(() -> "Removing all pending transactions for " + channelId + " from transaction registry");
         transactions.remove(channelId);
     }

--- a/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/CasualInboundTransactionRegistry.java
+++ b/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/CasualInboundTransactionRegistry.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
+package se.laz.casual.jca.inflow;
+
+import io.netty.channel.ChannelId;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
+
+public class CasualInboundTransactionRegistry
+{
+    private static final Logger log = Logger.getLogger(CasualInboundTransactionRegistry.class.getName());
+    private final Map<ChannelId, Set<XidKey>> transactions = new ConcurrentHashMap<>();
+
+    public void add(ChannelId channelId, XidKey key)
+    {
+        Objects.requireNonNull(key, "key can not be null");
+        log.finest(() -> "Adding transaction " + key + " to inbound transaction registry");
+        transactions.computeIfAbsent(channelId, id -> ConcurrentHashMap.newKeySet()).add(key);
+    }
+    public void remove(ChannelId channelId, XidKey key)
+    {
+        Objects.requireNonNull(key, "key can not be null");
+        Objects.requireNonNull(channelId, "channelId can not be null");
+        log.finest(() -> "Removing transaction " + key + " from transaction registry");
+        Set<XidKey> ids = transactions.get(channelId);
+        ids.remove(key);
+        if(ids.isEmpty())
+        {
+            transactions.remove(channelId);
+        }
+    }
+
+    public void remove(ChannelId channelId)
+    {
+        Objects.requireNonNull(channelId, "channelId can not be null");
+        log.finest(() -> "Removing all pending transactions for " + channelId + " from transaction registry");
+        transactions.remove(channelId);
+    }
+
+    public boolean hasPending()
+    {
+        log.finest(() -> "# of inbound pending: " + transactions.size());
+        return !transactions.isEmpty();
+    }
+}

--- a/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/CasualInboundTransactionRegistry.java
+++ b/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/CasualInboundTransactionRegistry.java
@@ -24,14 +24,14 @@ public class CasualInboundTransactionRegistry
     {
         Objects.requireNonNull(channelId, CHANNEL_ID_CAN_NOT_BE_NULL);
         Objects.requireNonNull(key, "key can not be null");
-        log.finest(() -> "Adding transaction " + key + " to inbound transaction registry");
+        log.finest(() -> "adding transaction " + key + " for channel id: " + channelId + " to inbound transaction registry");
         transactions.computeIfAbsent(channelId, id -> ConcurrentHashMap.newKeySet()).add(key);
     }
     public void remove(ChannelId channelId, XidKey key)
     {
         Objects.requireNonNull(channelId, CHANNEL_ID_CAN_NOT_BE_NULL);
         Objects.requireNonNull(key, "key can not be null");
-        log.finest(() -> "Removing transaction " + key + " from transaction registry");
+        log.finest(() -> "removing transaction " + key + "for channel id: " + channelId +" from transaction registry");
         transactions.computeIfPresent(channelId, (id, set) ->{
            set.remove(key);
            return set.isEmpty() ? null : set;

--- a/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/CasualMessageListener.java
+++ b/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/CasualMessageListener.java
@@ -55,7 +55,7 @@ public interface CasualMessageListener
     * @param message                    received.
     * @param channel                    for the response.
     * @param workManager                for managing long running execution.
-    * @param inboundTransactionRegistry
+    * @param inboundTransactionRegistry the inbound transaction registry
     */
    void serviceCallRequest(CasualNWMessage<CasualServiceCallRequestMessage> message, Channel channel, WorkManager workManager, CasualInboundTransactionRegistry inboundTransactionRegistry);
 
@@ -65,7 +65,7 @@ public interface CasualMessageListener
     * @param message                    received.
     * @param channel                    for the response.
     * @param xaTerminator               for controlling transaction.
-    * @param inboundTransactionRegistry
+    * @param inboundTransactionRegistry the inbound transaction registry
     */
    void prepareRequest(CasualNWMessage<CasualTransactionResourcePrepareRequestMessage> message, Channel channel, XATerminator xaTerminator, CasualInboundTransactionRegistry inboundTransactionRegistry);
 
@@ -75,7 +75,7 @@ public interface CasualMessageListener
     * @param message                    received.
     * @param channel                    for the response.
     * @param xaTerminator               for controlling transaction.
-    * @param inboundTransactionRegistry
+    * @param inboundTransactionRegistry the inbound transaction registry
     */
    void commitRequest(CasualNWMessage<CasualTransactionResourceCommitRequestMessage> message, Channel channel, XATerminator xaTerminator, CasualInboundTransactionRegistry inboundTransactionRegistry);
 
@@ -85,7 +85,7 @@ public interface CasualMessageListener
     * @param message                    received.
     * @param channel                    for the response.
     * @param xaTerminator               for controlling transaction.
-    * @param inboundTransactionRegistry
+    * @param inboundTransactionRegistry the inbound transaction registry
     */
    void requestRollback(CasualNWMessage<CasualTransactionResourceRollbackRequestMessage> message, Channel channel, XATerminator xaTerminator, CasualInboundTransactionRegistry inboundTransactionRegistry);
 }

--- a/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/CasualMessageListener.java
+++ b/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/CasualMessageListener.java
@@ -52,36 +52,40 @@ public interface CasualMessageListener
     * Process the Service Call request making use of the provided {@link WorkManager} to handle long running executions.
     * Write the resulting response to the provided {@link Channel}.
     *
-    * @param message received.
-    * @param channel for the response.
-    * @param workManager for managing long running execution.
+    * @param message                    received.
+    * @param channel                    for the response.
+    * @param workManager                for managing long running execution.
+    * @param inboundTransactionRegistry
     */
-   void serviceCallRequest(CasualNWMessage<CasualServiceCallRequestMessage> message, Channel channel, WorkManager workManager );
+   void serviceCallRequest(CasualNWMessage<CasualServiceCallRequestMessage> message, Channel channel, WorkManager workManager, CasualInboundTransactionRegistry inboundTransactionRegistry);
 
    /**
     * Process the transaction Prepare request utilising the provided {@link XATerminator}.
     *
-    * @param message received.
-    * @param channel for the response.
-    * @param xaTerminator for controlling transaction.
+    * @param message                    received.
+    * @param channel                    for the response.
+    * @param xaTerminator               for controlling transaction.
+    * @param inboundTransactionRegistry
     */
-   void prepareRequest(CasualNWMessage<CasualTransactionResourcePrepareRequestMessage> message, Channel channel, XATerminator xaTerminator);
+   void prepareRequest(CasualNWMessage<CasualTransactionResourcePrepareRequestMessage> message, Channel channel, XATerminator xaTerminator, CasualInboundTransactionRegistry inboundTransactionRegistry);
 
    /**
     * Process the transaction Commit request utilising the provided {@link XATerminator}.
     *
-    * @param message received.
-    * @param channel for the response.
-    * @param xaTerminator for controlling transaction.
+    * @param message                    received.
+    * @param channel                    for the response.
+    * @param xaTerminator               for controlling transaction.
+    * @param inboundTransactionRegistry
     */
-   void commitRequest(CasualNWMessage<CasualTransactionResourceCommitRequestMessage> message, Channel channel, XATerminator xaTerminator);
+   void commitRequest(CasualNWMessage<CasualTransactionResourceCommitRequestMessage> message, Channel channel, XATerminator xaTerminator, CasualInboundTransactionRegistry inboundTransactionRegistry);
 
    /**
     * Process the transaction Rollbacak request utilising the providded {@link XATerminator}.
     *
-    * @param message received.
-    * @param channel for the response.
-    * @param xaTerminator for controlling transaction.
+    * @param message                    received.
+    * @param channel                    for the response.
+    * @param xaTerminator               for controlling transaction.
+    * @param inboundTransactionRegistry
     */
-   void requestRollback(CasualNWMessage<CasualTransactionResourceRollbackRequestMessage> message, Channel channel, XATerminator xaTerminator);
+   void requestRollback(CasualNWMessage<CasualTransactionResourceRollbackRequestMessage> message, Channel channel, XATerminator xaTerminator, CasualInboundTransactionRegistry inboundTransactionRegistry);
 }

--- a/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/XidKey.java
+++ b/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/XidKey.java
@@ -16,7 +16,7 @@ public class XidKey
     private final byte[] bqual;
     private final int formatId;
 
-    public XidKey(byte[] gtrid, byte[] bqual, int formatId)
+    private XidKey(byte[] gtrid, byte[] bqual, int formatId)
     {
         this.gtrid = gtrid;
         this.bqual = bqual;

--- a/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/XidKey.java
+++ b/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/XidKey.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
+package se.laz.casual.jca.inflow;
+
+import javax.transaction.xa.Xid;
+import java.util.Arrays;
+import java.util.Objects;
+
+public class XidKey
+{
+    private final byte[] gtrid;
+    private final byte[] bqual;
+    private final int formatId;
+
+    public XidKey(byte[] gtrid, byte[] bqual, int formatId)
+    {
+        this.gtrid = gtrid;
+        this.bqual = bqual;
+        this.formatId = formatId;
+    }
+
+    public static XidKey of(Xid xid)
+    {
+        Objects.requireNonNull(xid, "xid must not be null");
+        byte[] gtrid = Arrays.copyOfRange(xid.getGlobalTransactionId(), 0, xid.getGlobalTransactionId().length);
+        byte[] bqual = Arrays.copyOfRange(xid.getBranchQualifier(), 0, xid.getBranchQualifier().length);
+        int formatId = xid.getFormatId();
+        return new XidKey(gtrid, bqual, formatId);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (!(o instanceof XidKey xidKey))
+        {
+            return false;
+        }
+        return formatId == xidKey.formatId && Arrays.equals(gtrid, xidKey.gtrid) && Arrays.equals(bqual, xidKey.bqual);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(Arrays.hashCode(gtrid), Arrays.hashCode(bqual), formatId);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "XidKey{" +
+                "gtrid=" + Arrays.toString(gtrid) +
+                ", bqual=" + Arrays.toString(bqual) +
+                ", formatId=" + formatId +
+                '}';
+    }
+}

--- a/casual/casual-inbound-api/src/test/groovy/se/laz/casual/jca/inflow/CasualInboundTransactionRegistryTest.groovy
+++ b/casual/casual-inbound-api/src/test/groovy/se/laz/casual/jca/inflow/CasualInboundTransactionRegistryTest.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
+package se.laz.casual.jca.inflow
+
+import io.netty.channel.ChannelId
+import se.laz.casual.api.xa.XID
+import spock.lang.Specification
+
+import javax.transaction.xa.Xid
+
+class CasualInboundTransactionRegistryTest extends Specification
+{
+   CasualInboundTransactionRegistry instance
+
+   def setup()
+   {
+      instance = new CasualInboundTransactionRegistry()
+   }
+
+   def 'add, remove, pending test'()
+   {
+      given:
+      byte[] gtridData = (0..XID.MAX_XID_DATA_SIZE/2 -1) as byte[]
+      byte[] bqualData = (0..XID.MAX_XID_DATA_SIZE/2 -1) as byte[]
+      def formatTypeOne = 42L
+      def formatTypeTwo = 99L
+      ChannelId idOne = Mock(ChannelId)
+      Xid xidOne = XID.of(gtridData, bqualData, formatTypeOne)
+      XidKey keyOne = XidKey.of(xidOne)
+      ChannelId idTwo = Mock(ChannelId)
+      Xid xidTwo = XID.of(gtridData, bqualData, formatTypeTwo)
+      XidKey keyTwo = XidKey.of(xidTwo)
+      when:
+      instance.add(idOne, keyOne)
+      instance.add(idOne, keyTwo)
+      then:
+      instance.hasPending()
+      when:
+      instance.remove(idOne, keyOne)
+      then:
+      instance.hasPending()
+      when:
+      instance.remove(idOne, keyTwo)
+      then:
+      !instance.hasPending()
+      when:
+      instance.add(idOne, keyOne)
+      instance.add(idTwo, keyTwo)
+      then:
+      instance.hasPending()
+      when:
+      instance.remove(idOne)
+      then:
+      instance.hasPending()
+      when:
+      instance.remove(idTwo)
+      then:
+      !instance.hasPending()
+   }
+}

--- a/casual/casual-inbound-api/src/test/groovy/se/laz/casual/jca/inflow/XidKeyTest.groovy
+++ b/casual/casual-inbound-api/src/test/groovy/se/laz/casual/jca/inflow/XidKeyTest.groovy
@@ -23,11 +23,14 @@ class XidKeyTest extends Specification
       when:
       Xid xidOne = XID.of(gtridData, bqualData, formatTypeOne)
       XidKey keyOne = XidKey.of(xidOne)
+      XidKey equalToKeyOne = XidKey.of(xidOne)
       Xid xidTwo = XID.of(gtridData, bqualData, formatTypeTwo)
       XidKey keyTwo = XidKey.of(xidTwo)
       then:
       keyOne == keyOne
       keyOne.hashCode() == keyOne.hashCode()
+      keyOne == equalToKeyOne
+      keyOne.hashCode() == equalToKeyOne.hashCode()
       keyTwo == keyTwo
       keyTwo.hashCode() == keyTwo.hashCode()
       keyOne != keyTwo

--- a/casual/casual-inbound-api/src/test/groovy/se/laz/casual/jca/inflow/XidKeyTest.groovy
+++ b/casual/casual-inbound-api/src/test/groovy/se/laz/casual/jca/inflow/XidKeyTest.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
+package se.laz.casual.jca.inflow
+
+import se.laz.casual.api.xa.XID
+import spock.lang.Specification
+
+import javax.transaction.xa.Xid
+
+class XidKeyTest extends Specification
+{
+   def 'equality/hashcode'()
+   {
+      given:
+      byte[] gtridData = (0..XID.MAX_XID_DATA_SIZE / 2 - 1) as byte[]
+      byte[] bqualData = (0..XID.MAX_XID_DATA_SIZE / 2 - 1) as byte[]
+      def formatTypeOne = 42L
+      def formatTypeTwo = 99L
+      when:
+      Xid xidOne = XID.of(gtridData, bqualData, formatTypeOne)
+      XidKey keyOne = XidKey.of(xidOne)
+      Xid xidTwo = XID.of(gtridData, bqualData, formatTypeTwo)
+      XidKey keyTwo = XidKey.of(xidTwo)
+      then:
+      keyOne == keyOne
+      keyOne.hashCode() == keyOne.hashCode()
+      keyTwo == keyTwo
+      keyTwo.hashCode() == keyTwo.hashCode()
+      keyOne != keyTwo
+      keyOne.hashCode() != keyTwo.hashCode()
+   }
+}

--- a/casual/casual-inbound/src/main/java/se/laz/casual/jca/inflow/CasualMessageListenerImpl.java
+++ b/casual/casual-inbound/src/main/java/se/laz/casual/jca/inflow/CasualMessageListenerImpl.java
@@ -251,7 +251,6 @@ public class CasualMessageListenerImpl implements CasualMessageListener
     {
         log.finest(() -> "commitRequest(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution(), message.getMessage().getXid()) + message);
         Xid xid = message.getMessage().getXid();
-        inboundTransactionRegistry.remove(channel.id(), XidKey.of(xid));
         boolean onePhase = message.getMessage().getFlags().isSet( XAFlags.TMONEPHASE );
 
         int status = -1;
@@ -266,6 +265,7 @@ public class CasualMessageListenerImpl implements CasualMessageListener
         }
         finally
         {
+            inboundTransactionRegistry.remove(channel.id(), XidKey.of(xid));
             CasualTransactionResourceCommitReplyMessage reply =
                     CasualTransactionResourceCommitReplyMessage.of(
                             message.getMessage().getExecution(),
@@ -284,7 +284,6 @@ public class CasualMessageListenerImpl implements CasualMessageListener
         log.finest(() -> "requestRollback(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution(), message.getMessage().getXid()) + message );
 
         Xid xid = message.getMessage().getXid();
-        inboundTransactionRegistry.remove(channel.id(), XidKey.of(xid));
         int status = -1;
         try
         {
@@ -297,6 +296,7 @@ public class CasualMessageListenerImpl implements CasualMessageListener
         }
         finally
         {
+            inboundTransactionRegistry.remove(channel.id(), XidKey.of(xid));
             CasualTransactionResourceRollbackReplyMessage reply =
                     CasualTransactionResourceRollbackReplyMessage.of(
                             message.getMessage().getExecution(),

--- a/casual/casual-inbound/src/main/java/se/laz/casual/jca/inflow/CasualMessageListenerImpl.java
+++ b/casual/casual-inbound/src/main/java/se/laz/casual/jca/inflow/CasualMessageListenerImpl.java
@@ -107,7 +107,7 @@ public class CasualMessageListenerImpl implements CasualMessageListener
     @Override
     public void domainDisconnectReply(CasualNWMessage<DomainDisconnectReplyMessage> message)
     {
-        log.info(() -> "domainDisconnectReply(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution()) + message );
+        log.finest(() -> "domainDisconnectReply(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution()) + message );
     }
 
     @Override
@@ -144,7 +144,7 @@ public class CasualMessageListenerImpl implements CasualMessageListener
     @Override
     public void serviceCallRequest(CasualNWMessage<CasualServiceCallRequestMessage> message, Channel channel, WorkManager workManager, CasualInboundTransactionRegistry inboundTransactionRegistry)
     {
-        log.info(() -> "serviceCallRequest(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution(), message.getMessage().getXid()) + message);
+        log.finest(() -> "serviceCallRequest(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution(), message.getMessage().getXid()) + message);
 
         Xid xid = message.getMessage().getXid();
         if(tpNoReplyOutOfProtocol( message, isServiceCallTransactional( xid )))
@@ -213,7 +213,7 @@ public class CasualMessageListenerImpl implements CasualMessageListener
     @Override
     public void prepareRequest(CasualNWMessage<CasualTransactionResourcePrepareRequestMessage> message, Channel channel, XATerminator xaTerminator, CasualInboundTransactionRegistry inboundTransactionRegistry)
     {
-        log.info(() ->  "prepareRequest(). " + PrettyPrinter.format(message.getCorrelationId(),
+        log.finest(() ->  "prepareRequest(). " + PrettyPrinter.format(message.getCorrelationId(),
                 message.getMessage().getExecution(), message.getMessage().getXid()) + "flags:" + message.getMessage().getFlags() + " " + message);
         Xid xid = message.getMessage().getXid();
         int status = -1;
@@ -249,7 +249,7 @@ public class CasualMessageListenerImpl implements CasualMessageListener
     @Override
     public void commitRequest(CasualNWMessage<CasualTransactionResourceCommitRequestMessage> message, Channel channel, XATerminator xaTerminator, CasualInboundTransactionRegistry inboundTransactionRegistry)
     {
-        log.info(() -> "commitRequest(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution(), message.getMessage().getXid()) + message);
+        log.finest(() -> "commitRequest(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution(), message.getMessage().getXid()) + message);
         Xid xid = message.getMessage().getXid();
         inboundTransactionRegistry.remove(channel.id(), XidKey.of(xid));
         boolean onePhase = message.getMessage().getFlags().isSet( XAFlags.TMONEPHASE );
@@ -281,7 +281,7 @@ public class CasualMessageListenerImpl implements CasualMessageListener
     @Override
     public void requestRollback(CasualNWMessage<CasualTransactionResourceRollbackRequestMessage> message, Channel channel, XATerminator xaTerminator, CasualInboundTransactionRegistry inboundTransactionRegistry)
     {
-        log.info(() -> "requestRollback(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution(), message.getMessage().getXid()) + message );
+        log.finest(() -> "requestRollback(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution(), message.getMessage().getXid()) + message );
 
         Xid xid = message.getMessage().getXid();
         inboundTransactionRegistry.remove(channel.id(), XidKey.of(xid));

--- a/casual/casual-inbound/src/main/java/se/laz/casual/jca/inflow/CasualMessageListenerImpl.java
+++ b/casual/casual-inbound/src/main/java/se/laz/casual/jca/inflow/CasualMessageListenerImpl.java
@@ -107,7 +107,7 @@ public class CasualMessageListenerImpl implements CasualMessageListener
     @Override
     public void domainDisconnectReply(CasualNWMessage<DomainDisconnectReplyMessage> message)
     {
-        log.finest(() -> "domainDisconnectReply(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution()) + message );
+        log.info(() -> "domainDisconnectReply(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution()) + message );
     }
 
     @Override
@@ -142,9 +142,9 @@ public class CasualMessageListenerImpl implements CasualMessageListener
     }
 
     @Override
-    public void serviceCallRequest(CasualNWMessage<CasualServiceCallRequestMessage> message, Channel channel, WorkManager workManager )
+    public void serviceCallRequest(CasualNWMessage<CasualServiceCallRequestMessage> message, Channel channel, WorkManager workManager, CasualInboundTransactionRegistry inboundTransactionRegistry)
     {
-        log.finest(() -> "serviceCallRequest(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution(), message.getMessage().getXid()) + message);
+        log.info(() -> "serviceCallRequest(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution(), message.getMessage().getXid()) + message);
 
         Xid xid = message.getMessage().getXid();
         if(tpNoReplyOutOfProtocol( message, isServiceCallTransactional( xid )))
@@ -162,6 +162,7 @@ public class CasualMessageListenerImpl implements CasualMessageListener
         {
             if(!isTpNoReply && isServiceCallTransactional( xid ) )
             {
+                inboundTransactionRegistry.add(channel.id(), XidKey.of(xid));
                 workManager.scheduleWork(work, WorkManager.INDEFINITE, createTransactionContext(xid, message.getMessage().getTimeout()), new ServiceCallWorkListener(channel, message.getMessage()));
             }
             else
@@ -171,6 +172,10 @@ public class CasualMessageListenerImpl implements CasualMessageListener
         }
         catch (WorkException e)
         {
+            if(!isTpNoReply && isServiceCallTransactional( xid ) )
+            {
+                inboundTransactionRegistry.remove(channel.id(), XidKey.of(xid));
+            }
             throw new CasualResourceAdapterException( "Error starting work.", e );
         }
     }
@@ -206,11 +211,10 @@ public class CasualMessageListenerImpl implements CasualMessageListener
     }
 
     @Override
-    public void prepareRequest(CasualNWMessage<CasualTransactionResourcePrepareRequestMessage> message, Channel channel, XATerminator xaTerminator)
+    public void prepareRequest(CasualNWMessage<CasualTransactionResourcePrepareRequestMessage> message, Channel channel, XATerminator xaTerminator, CasualInboundTransactionRegistry inboundTransactionRegistry)
     {
-        log.finest(() ->  "prepareRequest(). " + PrettyPrinter.format(message.getCorrelationId(),
+        log.info(() ->  "prepareRequest(). " + PrettyPrinter.format(message.getCorrelationId(),
                 message.getMessage().getExecution(), message.getMessage().getXid()) + "flags:" + message.getMessage().getFlags() + " " + message);
-
         Xid xid = message.getMessage().getXid();
         int status = -1;
         try
@@ -225,7 +229,11 @@ public class CasualMessageListenerImpl implements CasualMessageListener
         }
         finally
         {
-
+            if(status == XAReturnCode.XA_RDONLY.getId())
+            {
+                // XA_RDONLY, no commit/rollback will be called
+                inboundTransactionRegistry.remove(channel.id(), XidKey.of(xid));
+            }
             CasualTransactionResourcePrepareReplyMessage reply =
                     CasualTransactionResourcePrepareReplyMessage.of(
                             message.getMessage().getExecution(),
@@ -239,11 +247,11 @@ public class CasualMessageListenerImpl implements CasualMessageListener
     }
 
     @Override
-    public void commitRequest(CasualNWMessage<CasualTransactionResourceCommitRequestMessage> message, Channel channel, XATerminator xaTerminator)
+    public void commitRequest(CasualNWMessage<CasualTransactionResourceCommitRequestMessage> message, Channel channel, XATerminator xaTerminator, CasualInboundTransactionRegistry inboundTransactionRegistry)
     {
-        log.finest(() -> "commitRequest(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution(), message.getMessage().getXid()) + message);
-
+        log.info(() -> "commitRequest(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution(), message.getMessage().getXid()) + message);
         Xid xid = message.getMessage().getXid();
+        inboundTransactionRegistry.remove(channel.id(), XidKey.of(xid));
         boolean onePhase = message.getMessage().getFlags().isSet( XAFlags.TMONEPHASE );
 
         int status = -1;
@@ -271,12 +279,12 @@ public class CasualMessageListenerImpl implements CasualMessageListener
     }
 
     @Override
-    public void requestRollback(CasualNWMessage<CasualTransactionResourceRollbackRequestMessage> message, Channel channel, XATerminator xaTerminator)
+    public void requestRollback(CasualNWMessage<CasualTransactionResourceRollbackRequestMessage> message, Channel channel, XATerminator xaTerminator, CasualInboundTransactionRegistry inboundTransactionRegistry)
     {
-        log.finest(() -> "requestRollback(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution(), message.getMessage().getXid()) + message );
+        log.info(() -> "requestRollback(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution(), message.getMessage().getXid()) + message );
 
         Xid xid = message.getMessage().getXid();
-
+        inboundTransactionRegistry.remove(channel.id(), XidKey.of(xid));
         int status = -1;
         try
         {

--- a/casual/casual-inbound/src/test/groovy/se/laz/casual/jca/inflow/CasualMessageListenerImplTest.groovy
+++ b/casual/casual-inbound/src/test/groovy/se/laz/casual/jca/inflow/CasualMessageListenerImplTest.groovy
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2025, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
 
 package se.laz.casual.jca.inflow
+
 
 import io.netty.channel.embedded.EmbeddedChannel
 import jakarta.resource.spi.XATerminator
@@ -180,10 +181,9 @@ class CasualMessageListenerImplTest extends Specification
                         .setTimeout( timeoutDuration.toNanos() )
                         .build()
         )
-
+        CasualInboundTransactionRegistry inboundTransactionRegistry = new CasualInboundTransactionRegistry()
         when:
-        instance.serviceCallRequest( message, channel, workManager )
-
+        instance.serviceCallRequest(message, channel, workManager, inboundTransactionRegistry)
         then:
         1 * workManager.scheduleWork( _,_,_,_ ) >> {
             CasualServiceCallWork work, long startTimeout, ExecutionContext executionContext, WorkListener workListener ->
@@ -202,6 +202,8 @@ class CasualMessageListenerImplTest extends Specification
         actualExecutionContext.getXid() == xid
         actualExecutionContext.getTransactionTimeout() == timeout
         actualWorkListener != null
+
+        inboundTransactionRegistry.hasPending()
     }
 
     def "ServiceCallRequest with null xid calls service work without transaction context."()
@@ -220,9 +222,9 @@ class CasualMessageListenerImplTest extends Specification
                         .setXatmiFlags( Flag.of())
                         .build()
         )
-
+        CasualInboundTransactionRegistry inboundTransactionRegistry = new CasualInboundTransactionRegistry()
         when:
-        instance.serviceCallRequest( message, channel, workManager )
+        instance.serviceCallRequest(message, channel, workManager, inboundTransactionRegistry)
 
         then:
         1 * workManager.scheduleWork(_, _, _, _) >> {
@@ -235,6 +237,7 @@ class CasualMessageListenerImplTest extends Specification
 
         actualWork != null
         actualWork.getCorrelationId() == correlationId
+        !inboundTransactionRegistry.hasPending()
     }
 
     def "ServiceCallRequest TPNOREPLY, non transactional"()
@@ -257,9 +260,9 @@ class CasualMessageListenerImplTest extends Specification
                       .setTimeout( timeoutDuration.toNanos() )
                       .build()
        )
-
+       CasualInboundTransactionRegistry inboundTransactionRegistry = new CasualInboundTransactionRegistry()
        when:
-       instance.serviceCallRequest( message, channel, workManager )
+       instance.serviceCallRequest(message, channel, workManager, inboundTransactionRegistry)
 
        then:
        1 * workManager.scheduleWork( _,_,_,_ ) >> {
@@ -277,6 +280,7 @@ class CasualMessageListenerImplTest extends Specification
        actualStartTimeout == WorkManager.INDEFINITE
        actualExecutionContext == null
        actualWorkListener != null
+       !inboundTransactionRegistry.hasPending()
     }
 
     def "ServiceCallRequest TPNOREPLY, transactional - out of protocol, call will be issued but non transactional"()
@@ -299,9 +303,9 @@ class CasualMessageListenerImplTest extends Specification
                        .setTimeout( timeoutDuration.toNanos() )
                        .build()
        )
-
+       CasualInboundTransactionRegistry inboundTransactionRegistry = new CasualInboundTransactionRegistry()
        when:
-       instance.serviceCallRequest( message, channel, workManager )
+       instance.serviceCallRequest(message, channel, workManager, inboundTransactionRegistry)
 
        then:
        1 * workManager.scheduleWork( _,_,_,_ ) >> {
@@ -319,6 +323,7 @@ class CasualMessageListenerImplTest extends Specification
        actualStartTimeout == WorkManager.INDEFINITE
        actualExecutionContext == null
        actualWorkListener != null
+       !inboundTransactionRegistry.hasPending()
     }
 
     def "ServiceCallRequest startWork throws exception, wrapped and thrown."()
@@ -334,9 +339,9 @@ class CasualMessageListenerImplTest extends Specification
                         .setXatmiFlags( Flag.of())
                         .build()
         )
-
+        CasualInboundTransactionRegistry inboundTransactionRegistry = new CasualInboundTransactionRegistry()
         when:
-        instance.serviceCallRequest( message, channel, workManager )
+        instance.serviceCallRequest(message, channel, workManager, inboundTransactionRegistry)
 
         then:
         1 * workManager.scheduleWork( _,_,_,_ ) >> {
@@ -344,6 +349,7 @@ class CasualMessageListenerImplTest extends Specification
         }
 
         thrown CasualResourceAdapterException
+        !inboundTransactionRegistry.hasPending()
     }
 
     def "PrepareRequest"()
@@ -359,9 +365,10 @@ class CasualMessageListenerImplTest extends Specification
                         flag
                 )
         )
-
+        CasualInboundTransactionRegistry inboundTransactionRegistry = new CasualInboundTransactionRegistry()
+        inboundTransactionRegistry.add(channel.id(), XidKey.of(xid))
         when:
-        instance.prepareRequest( message, channel, xaTerminator )
+        instance.prepareRequest(message, channel, xaTerminator, inboundTransactionRegistry)
         channel.writeInbound(channel.outboundMessages().element())
         CasualNWMessage<CasualTransactionResourcePrepareReplyMessage> reply = inboundHandler.getMsg()
 
@@ -375,38 +382,74 @@ class CasualMessageListenerImplTest extends Specification
         reply.getCorrelationId() == correlationId
         reply.getMessage().getExecution() == execution
         reply.getMessage().getTransactionReturnCode() == XAReturnCode.XA_OK
+        inboundTransactionRegistry.hasPending()
     }
 
-    def "PrepareRequest return code failure."()
+    def "PrepareRequest XA_RDONLY"()
     {
-        given:
-        int resource = 1
-        Flag<XAFlags> flag = Flag.of()
-        CasualNWMessageImpl<CasualTransactionResourcePrepareRequestMessage> message = CasualNWMessageImpl.of(correlationId,
-                CasualTransactionResourcePrepareRequestMessage.of(
-                        execution,
-                        xid,
-                        resource,
-                        flag
-                )
-        )
+       given:
+       int resource = 1
+       Flag<XAFlags> flag = Flag.of()
+       CasualNWMessageImpl<CasualTransactionResourcePrepareRequestMessage> message = CasualNWMessageImpl.of(correlationId,
+               CasualTransactionResourcePrepareRequestMessage.of(
+                       execution,
+                       xid,
+                       resource,
+                       flag
+               )
+       )
+       CasualInboundTransactionRegistry inboundTransactionRegistry = new CasualInboundTransactionRegistry()
+       inboundTransactionRegistry.add(channel.id(), XidKey.of(xid))
+       when:
+       instance.prepareRequest(message, channel, xaTerminator, inboundTransactionRegistry)
+       channel.writeInbound(channel.outboundMessages().element())
+       CasualNWMessage<CasualTransactionResourcePrepareReplyMessage> reply = inboundHandler.getMsg()
 
-        when:
-        instance.prepareRequest( message, channel, xaTerminator )
-        channel.writeInbound(channel.outboundMessages().element())
-        CasualNWMessage<CasualTransactionResourcePrepareReplyMessage> reply = inboundHandler.getMsg()
+       then:
+       1 * xaTerminator.prepare( xid ) >> {
+          return XAReturnCode.XA_RDONLY.getId()
+       }
 
-        then:
-        1 * xaTerminator.prepare( xid ) >> {
-            return XAReturnCode.XAER_RMERR.getId()
-        }
-
-        reply != null
-        reply.getType() == CasualNWMessageType.PREPARE_REQUEST_REPLY
-        reply.getCorrelationId() == correlationId
-        reply.getMessage().getExecution() == execution
-        reply.getMessage().getTransactionReturnCode() == XAReturnCode.XAER_RMERR
+       reply != null
+       reply.getType() == CasualNWMessageType.PREPARE_REQUEST_REPLY
+       reply.getCorrelationId() == correlationId
+       reply.getMessage().getExecution() == execution
+       reply.getMessage().getTransactionReturnCode() == XAReturnCode.XA_RDONLY
+       !inboundTransactionRegistry.hasPending()
     }
+
+   def "PrepareRequest return code failure."()
+   {
+      given:
+      int resource = 1
+      Flag<XAFlags> flag = Flag.of()
+      CasualNWMessageImpl<CasualTransactionResourcePrepareRequestMessage> message = CasualNWMessageImpl.of(correlationId,
+              CasualTransactionResourcePrepareRequestMessage.of(
+                      execution,
+                      xid,
+                      resource,
+                      flag
+              )
+      )
+      CasualInboundTransactionRegistry inboundTransactionRegistry = new CasualInboundTransactionRegistry()
+      inboundTransactionRegistry.add(channel.id(), XidKey.of(xid))
+      when:
+      instance.prepareRequest(message, channel, xaTerminator, inboundTransactionRegistry)
+      channel.writeInbound(channel.outboundMessages().element())
+      CasualNWMessage<CasualTransactionResourcePrepareReplyMessage> reply = inboundHandler.getMsg()
+
+      then:
+      1 * xaTerminator.prepare( xid ) >> {
+         return XAReturnCode.XAER_RMERR.getId()
+      }
+
+      reply != null
+      reply.getType() == CasualNWMessageType.PREPARE_REQUEST_REPLY
+      reply.getCorrelationId() == correlationId
+      reply.getMessage().getExecution() == execution
+      reply.getMessage().getTransactionReturnCode() == XAReturnCode.XAER_RMERR
+      inboundTransactionRegistry.hasPending()
+   }
 
     def "PrepareRequest prepare throws exception, returns exception error code."()
     {
@@ -421,9 +464,10 @@ class CasualMessageListenerImplTest extends Specification
                         flag
                 )
         )
-
+        CasualInboundTransactionRegistry inboundTransactionRegistry = new CasualInboundTransactionRegistry()
+        inboundTransactionRegistry.add(channel.id(), XidKey.of(xid))
         when:
-        instance.prepareRequest( message, channel, xaTerminator )
+        instance.prepareRequest(message, channel, xaTerminator, inboundTransactionRegistry)
         channel.writeInbound(channel.outboundMessages().element())
         CasualNWMessage<CasualTransactionResourcePrepareReplyMessage> reply = inboundHandler.getMsg()
 
@@ -437,6 +481,7 @@ class CasualMessageListenerImplTest extends Specification
         reply.getCorrelationId() == correlationId
         reply.getMessage().getExecution() == execution
         reply.getMessage().getTransactionReturnCode() == XAReturnCode.XAER_RMERR
+        inboundTransactionRegistry.hasPending()
     }
 
     def "CommitRequest"()
@@ -452,9 +497,10 @@ class CasualMessageListenerImplTest extends Specification
                         flag
                 )
         )
-
+        CasualInboundTransactionRegistry inboundTransactionRegistry = new CasualInboundTransactionRegistry()
+        inboundTransactionRegistry.add(channel.id(), XidKey.of(xid))
         when:
-        instance.commitRequest( message, channel, xaTerminator )
+        instance.commitRequest(message, channel, xaTerminator, inboundTransactionRegistry)
         channel.writeInbound(channel.outboundMessages().element())
         CasualNWMessage<CasualTransactionResourceCommitReplyMessage> reply = inboundHandler.getMsg()
 
@@ -466,6 +512,7 @@ class CasualMessageListenerImplTest extends Specification
         reply.getCorrelationId() == correlationId
         reply.getMessage().getExecution() == execution
         reply.getMessage().getTransactionReturnCode() == XAReturnCode.XA_OK
+        !inboundTransactionRegistry.hasPending()
     }
 
     def "CommitRequest one phase true"()
@@ -481,9 +528,10 @@ class CasualMessageListenerImplTest extends Specification
                         flag
                 )
         )
-
+        CasualInboundTransactionRegistry inboundTransactionRegistry = new CasualInboundTransactionRegistry()
+        inboundTransactionRegistry.add(channel.id(), XidKey.of(xid))
         when:
-        instance.commitRequest( message, channel, xaTerminator )
+        instance.commitRequest(message, channel, xaTerminator, inboundTransactionRegistry)
         channel.writeInbound(channel.outboundMessages().element())
         CasualNWMessage<CasualTransactionResourceCommitReplyMessage> reply = inboundHandler.getMsg()
 
@@ -495,6 +543,7 @@ class CasualMessageListenerImplTest extends Specification
         reply.getCorrelationId() == correlationId
         reply.getMessage().getExecution() == execution
         reply.getMessage().getTransactionReturnCode() == XAReturnCode.XA_OK
+        !inboundTransactionRegistry.hasPending()
     }
 
     def "CommitRequest commit throws exception, returns exception error code."()
@@ -510,9 +559,10 @@ class CasualMessageListenerImplTest extends Specification
                         flag
                 )
         )
-
+        CasualInboundTransactionRegistry inboundTransactionRegistry = new CasualInboundTransactionRegistry()
+        inboundTransactionRegistry.add(channel.id(), XidKey.of(xid))
         when:
-        instance.commitRequest( message, channel, xaTerminator )
+        instance.commitRequest(message, channel, xaTerminator, inboundTransactionRegistry)
         channel.writeInbound(channel.outboundMessages().element())
         CasualNWMessage<CasualTransactionResourceCommitReplyMessage> reply = inboundHandler.getMsg()
 
@@ -526,6 +576,7 @@ class CasualMessageListenerImplTest extends Specification
         reply.getCorrelationId() == correlationId
         reply.getMessage().getExecution() == execution
         reply.getMessage().getTransactionReturnCode() == XAReturnCode.XAER_RMERR
+        !inboundTransactionRegistry.hasPending()
     }
 
     def "RollbackRequest"()
@@ -541,9 +592,10 @@ class CasualMessageListenerImplTest extends Specification
                         flag
                 )
         )
-
+        CasualInboundTransactionRegistry inboundTransactionRegistry = new CasualInboundTransactionRegistry()
+        inboundTransactionRegistry.add(channel.id(), XidKey.of(xid))
         when:
-        instance.requestRollback( message, channel, xaTerminator )
+        instance.requestRollback(message, channel, xaTerminator, inboundTransactionRegistry)
         channel.writeInbound(channel.outboundMessages().element())
         CasualNWMessage<CasualTransactionResourceRollbackReplyMessage> reply = inboundHandler.getMsg()
 
@@ -555,6 +607,7 @@ class CasualMessageListenerImplTest extends Specification
         reply.getCorrelationId() == correlationId
         reply.getMessage().getExecution() == execution
         reply.getMessage().getTransactionReturnCode() == XAReturnCode.XA_OK
+        !inboundTransactionRegistry.hasPending()
     }
 
     def "RollbackRequest rollback throws exception, returns exception error code."()
@@ -570,9 +623,10 @@ class CasualMessageListenerImplTest extends Specification
                         flag
                 )
         )
-
+        CasualInboundTransactionRegistry inboundTransactionRegistry = new CasualInboundTransactionRegistry()
+        inboundTransactionRegistry.add(channel.id(), XidKey.of(xid))
         when:
-        instance.requestRollback( message, channel, xaTerminator )
+        instance.requestRollback(message, channel, xaTerminator, inboundTransactionRegistry)
         channel.writeInbound(channel.outboundMessages().element())
         CasualNWMessage<CasualTransactionResourceRollbackReplyMessage> reply = inboundHandler.getMsg()
 
@@ -586,6 +640,7 @@ class CasualMessageListenerImplTest extends Specification
         reply.getCorrelationId() == correlationId
         reply.getMessage().getExecution() == execution
         reply.getMessage().getTransactionReturnCode() == XAReturnCode.XAER_RMERR
+        !inboundTransactionRegistry.hasPending()
     }
 
     class TestCasualService implements CasualService{

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceAdapter.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceAdapter.java
@@ -231,10 +231,8 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
         InboundDeactivatedContext.clear();
         InboundTopologyUpdateContext.clear();
         Predicate predicate = () -> inboundTransactionRegistry.hasPending() || CasualResourceManager.getInstance().hasPending();
-        long sleepTime = 20L;
-        // TODO: should the timeout be configurable with a default value?
-        long timeout = 15L * 1000L; // 15s
-        ShutdownBarrier shutdownBarrier = ShutdownBarrier.of(sleepTime, timeout, predicate);
+        long sleepTimeMilliseconds = 20L;
+        ShutdownBarrier shutdownBarrier = ShutdownBarrier.of(sleepTimeMilliseconds, predicate);
         shutdownBarrier.intermittentSleep();
         if( server != null )
         {

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceAdapter.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceAdapter.java
@@ -225,15 +225,15 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
     public void endpointDeactivation(MessageEndpointFactory endpointFactory,
                                      ActivationSpec spec)
     {
-        log.info(()->"endpointDeactivation() - sending domain disconnect messages");
+        log.info(()->"endpointDeactivation() ");
         RuntimeInformation.setDomainIsBeingShutdown(true);
         InboundDeactivatedContext.domainDisconnect();
         InboundDeactivatedContext.clear();
         InboundTopologyUpdateContext.clear();
         Predicate predicate = () -> inboundTransactionRegistry.hasPending() || CasualResourceManager.getInstance().hasPending();
-        long sleepTime = 20;
+        long sleepTime = 20L;
         // TODO: should the timeout be configurable with a default value?
-        long timeout = 15 * 1000; // 15s
+        long timeout = 15L * 1000L; // 15s
         ShutdownBarrier shutdownBarrier = ShutdownBarrier.of(sleepTime, timeout, predicate);
         shutdownBarrier.intermittentSleep();
         if( server != null )
@@ -249,7 +249,7 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
     public void start(BootstrapContext ctx)
             throws ResourceAdapterInternalException
     {
-        log.info(()->"start()");
+        log.finest(()->"start()");
         workManager = ctx.getWorkManager();
         xaTerminator = ctx.getXATerminator();
         JMXStartup.getInstance().initJMX();

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceAdapter.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceAdapter.java
@@ -26,6 +26,7 @@ import se.laz.casual.config.ReverseInbound;
 import se.laz.casual.event.server.EventServer;
 import se.laz.casual.event.server.EventServerConnectionInformation;
 import se.laz.casual.jca.inflow.CasualActivationSpec;
+import se.laz.casual.jca.inflow.CasualInboundTransactionRegistry;
 import se.laz.casual.jca.jmx.JMXStartup;
 import se.laz.casual.jca.work.StartInboundServerListener;
 import se.laz.casual.jca.work.StartInboundServerWork;
@@ -68,6 +69,7 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
     private static Logger log = Logger.getLogger(CasualResourceAdapter.class.getName());
     private ConcurrentHashMap<Integer, CasualActivationSpec> activations = new ConcurrentHashMap<>();
     private List<ReverseInboundServer> reverseInbounds = new ArrayList<>();
+    private CasualInboundTransactionRegistry inboundTransactionRegistry;
     // it is not really unused, it should never ever be gc:ed, thus it is part of this class
     @SuppressWarnings("java:S1068")
     private EventServer eventServer;
@@ -133,6 +135,8 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
                                    ActivationSpec spec) throws ResourceException
     {
         log.info(()->"start endpointActivation() ");
+        inboundTransactionRegistry = new CasualInboundTransactionRegistry();
+        RuntimeInformation.setDomainIsBeingShutdown(false);
         CasualActivationSpec as = (CasualActivationSpec) spec;
         as.setPort( getInboundServerPort() );
         ConnectionInformation ci = ConnectionInformation.createBuilder()
@@ -141,6 +145,7 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
                 .withWorkManager(workManager)
                 .withXaTerminator(xaTerminator)
                 .withUseEpoll( ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_INBOUND_USE_EPOLL ) )
+                .withInboundTransactionRegistry(inboundTransactionRegistry)
                 .build();
         activations.put(as.getPort(), as);
         log.info(() -> "start casual inbound server" );
@@ -164,6 +169,7 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
                                                                    .withXaTerminator(xaTerminator)
                                                                    .withProtocolVersion(ProtocolVersion.VERSION_1_0)
                                                                    .withMaxBackoffMillils(instance.getMaxConnectionBackoffMillis())
+                                                                   .withInboundTransactionRegistry(inboundTransactionRegistry)
                                                                    .build(), instance.getSize());
         }
     }
@@ -219,10 +225,17 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
     public void endpointDeactivation(MessageEndpointFactory endpointFactory,
                                      ActivationSpec spec)
     {
-        log.finest(()->"endpointDeactivation()");
+        log.info(()->"endpointDeactivation() - sending domain disconnect messages");
+        RuntimeInformation.setDomainIsBeingShutdown(true);
         InboundDeactivatedContext.domainDisconnect();
         InboundDeactivatedContext.clear();
         InboundTopologyUpdateContext.clear();
+        Predicate predicate = () -> inboundTransactionRegistry.hasPending() || CasualResourceManager.getInstance().hasPending();
+        long sleepTime = 20;
+        // TODO: should the timeout be configurable with a default value?
+        long timeout = 15 * 1000; // 15s
+        ShutdownBarrier shutdownBarrier = ShutdownBarrier.of(sleepTime, timeout, predicate);
+        shutdownBarrier.intermittentSleep();
         if( server != null )
         {
             server.close();
@@ -236,7 +249,7 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
     public void start(BootstrapContext ctx)
             throws ResourceAdapterInternalException
     {
-        log.finest(()->"start()");
+        log.info(()->"start()");
         workManager = ctx.getWorkManager();
         xaTerminator = ctx.getXATerminator();
         JMXStartup.getInstance().initJMX();
@@ -245,7 +258,7 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
     @Override
     public void stop()
     {
-        log.finest(()->"stop()");
+        log.info(()->"stop()");
     }
 
     //Return empty array not null. But specification says to return null if we don't support this feature, so ignoring.

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceAdapter.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceAdapter.java
@@ -258,7 +258,7 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
     @Override
     public void stop()
     {
-        log.info(()->"stop()");
+        log.finest(()->"stop()");
     }
 
     //Return empty array not null. But specification says to return null if we don't support this feature, so ignoring.

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceManager.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2025, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -42,6 +42,11 @@ public final class CasualResourceManager
             throw new CasualResourceAdapterException("xid: " + xid + " already stored for domain: " + domainId);
         }
         pendingRequests.computeIfAbsent(domainId, k -> ConcurrentHashMap.newKeySet()).add(xid);
+    }
+
+    public synchronized boolean hasPending()
+    {
+        return !pendingRequests.isEmpty();
     }
 
     public synchronized void remove(DomainId domainId, final Xid xid)

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/Predicate.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/Predicate.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
+package se.laz.casual.jca;
+
+@FunctionalInterface
+public interface Predicate
+{
+    boolean eval();
+}

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/ShutdownBarrier.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/ShutdownBarrier.java
@@ -28,7 +28,7 @@ public class ShutdownBarrier
      * @param sleepTime How long current thread should sleep, in milliseconds
      * @param timeout Timeout, in milliseconds - if accumulated sleep > timeout, the spin lock returns
      * @param predicate Predicate, intermittent wait will happen until predicate returns true or, if timeout is set and triggered
-     * @return
+     * @return the shutdown barrier
      */
     public static ShutdownBarrier of(long sleepTime, long timeout, Predicate predicate)
     {

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/ShutdownBarrier.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/ShutdownBarrier.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
+package se.laz.casual.jca;
+
+import java.util.Objects;
+import java.util.logging.Logger;
+
+public class ShutdownBarrier
+{
+    private static final Logger log = Logger.getLogger(ShutdownBarrier.class.getName());
+    private static final long NO_TIMEOUT = -1;
+    private final long sleepTime;
+    private long timeout;
+    private final Predicate predicate;
+
+    public ShutdownBarrier(long sleepTime, long timeout, Predicate predicate)
+    {
+        this.sleepTime = sleepTime;
+        this.timeout = timeout;
+        this.predicate = predicate;
+    }
+
+    /**
+     * @param sleepTime How long current thread should sleep, in milliseconds
+     * @param timeout Timeout, in milliseconds - if accumulated sleep > timeout, the spin lock returns
+     * @param predicate Predicate, intermittent wait will happen until predicate returns true or, if timeout is set and triggered
+     * @return
+     */
+    public static ShutdownBarrier of(long sleepTime, long timeout, Predicate predicate)
+    {
+        Objects.requireNonNull(predicate, "predicate must not be null");
+        return new ShutdownBarrier(sleepTime, timeout, predicate);
+    }
+
+    public static ShutdownBarrier of(long sleepTime, Predicate predicate)
+    {
+        Objects.requireNonNull(predicate, "predicate must not be null");
+        return new ShutdownBarrier(sleepTime, NO_TIMEOUT, predicate);
+    }
+
+    public void intermittentSleep()
+    {
+        boolean doCheckTimeout = timeout != NO_TIMEOUT;
+        while (predicate.eval() && !hasTimedOut(doCheckTimeout))
+        {
+            try
+            {
+                Thread.sleep(sleepTime);
+                if(doCheckTimeout)
+                {
+                    timeout -= sleepTime;
+                }
+            }
+            catch (InterruptedException e)
+            {
+                Thread.currentThread().interrupt();
+                // we are not allowed to throw here, so we log it
+                log.warning(() -> "thread interrupted during spinlock");
+            }
+        }
+    }
+
+    private boolean hasTimedOut(boolean doCheckTimeout)
+    {
+        return doCheckTimeout && timeout < 0;
+    }
+
+}

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/ShutdownBarrier.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/ShutdownBarrier.java
@@ -17,7 +17,7 @@ public class ShutdownBarrier
     private long timeout;
     private final Predicate predicate;
 
-    public ShutdownBarrier(long sleepTime, long timeout, Predicate predicate)
+    private ShutdownBarrier(long sleepTime, long timeout, Predicate predicate)
     {
         this.sleepTime = sleepTime;
         this.timeout = timeout;
@@ -39,7 +39,6 @@ public class ShutdownBarrier
 
     public static ShutdownBarrier of(long sleepTime, Predicate predicate)
     {
-        Objects.requireNonNull(predicate, "predicate must not be null");
         return new ShutdownBarrier(sleepTime, NO_TIMEOUT, predicate);
     }
 

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/ShutdownBarrier.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/ShutdownBarrier.java
@@ -45,7 +45,7 @@ public class ShutdownBarrier
             {
                 Thread.currentThread().interrupt();
                 // we are not allowed to throw here, so we log it
-                log.warning(() -> "thread interrupted during spinlock");
+                log.warning(() -> "shutdown barrier thread interrupted during sleep");
             }
         }
     }

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/ShutdownBarrier.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/ShutdownBarrier.java
@@ -25,6 +25,7 @@ public class ShutdownBarrier
     }
 
     /**
+     * Note: Shutdown barrier is not allowed to throw
      * @param sleepTime How long current thread should sleep, in milliseconds
      * @param timeout Timeout, in milliseconds - if accumulated sleep > timeout, the spin lock returns
      * @param predicate Predicate, intermittent wait will happen until predicate returns true or, if timeout is set and triggered

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/ShutdownBarrier.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/ShutdownBarrier.java
@@ -12,48 +12,34 @@ import java.util.logging.Logger;
 public class ShutdownBarrier
 {
     private static final Logger log = Logger.getLogger(ShutdownBarrier.class.getName());
-    private static final long NO_TIMEOUT = -1;
     private final long sleepTime;
-    private long timeout;
     private final Predicate predicate;
 
-    private ShutdownBarrier(long sleepTime, long timeout, Predicate predicate)
+    private ShutdownBarrier(long sleepTime, Predicate predicate)
     {
         this.sleepTime = sleepTime;
-        this.timeout = timeout;
         this.predicate = predicate;
     }
 
     /**
      * Note: Shutdown barrier is not allowed to throw
      * @param sleepTime How long current thread should sleep, in milliseconds
-     * @param timeout Timeout, in milliseconds - if accumulated sleep > timeout, the spin lock returns
-     * @param predicate Predicate, intermittent wait will happen until predicate returns true or, if timeout is set and triggered
+     * @param predicate Predicate, intermittent sleep will happen until predicate returns true
      * @return the shutdown barrier
      */
-    public static ShutdownBarrier of(long sleepTime, long timeout, Predicate predicate)
-    {
-        Objects.requireNonNull(predicate, "predicate must not be null");
-        return new ShutdownBarrier(sleepTime, timeout, predicate);
-    }
-
     public static ShutdownBarrier of(long sleepTime, Predicate predicate)
     {
-        return new ShutdownBarrier(sleepTime, NO_TIMEOUT, predicate);
+        Objects.requireNonNull(predicate, "predicate must not be null");
+        return new ShutdownBarrier(sleepTime, predicate);
     }
 
     public void intermittentSleep()
     {
-        boolean doCheckTimeout = timeout != NO_TIMEOUT;
-        while (predicate.eval() && !hasTimedOut(doCheckTimeout))
+        while (predicate.eval())
         {
             try
             {
                 Thread.sleep(sleepTime);
-                if(doCheckTimeout)
-                {
-                    timeout -= sleepTime;
-                }
             }
             catch (InterruptedException e)
             {
@@ -63,10 +49,4 @@ public class ShutdownBarrier
             }
         }
     }
-
-    private boolean hasTimedOut(boolean doCheckTimeout)
-    {
-        return doCheckTimeout && timeout < 0;
-    }
-
 }

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/service/CasualServiceCaller.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/service/CasualServiceCaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2025, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -9,6 +9,7 @@ package se.laz.casual.jca.service;
 import se.laz.casual.api.CasualServiceApi;
 import se.laz.casual.api.buffer.CasualBuffer;
 import se.laz.casual.api.buffer.ServiceReturn;
+import se.laz.casual.api.buffer.type.CStringBuffer;
 import se.laz.casual.api.buffer.type.ServiceBuffer;
 import se.laz.casual.api.flags.AtmiFlags;
 import se.laz.casual.api.flags.ErrorState;
@@ -25,6 +26,7 @@ import se.laz.casual.event.ServiceCallEvent;
 import se.laz.casual.event.ServiceCallEventPublisher;
 import se.laz.casual.event.ServiceCallEventStoreFactory;
 import se.laz.casual.jca.CasualManagedConnection;
+import se.laz.casual.jca.RuntimeInformation;
 import se.laz.casual.network.connection.CasualConnectionException;
 import se.laz.casual.network.protocol.messages.CasualNWMessageImpl;
 import se.laz.casual.network.protocol.messages.domain.CasualDomainDiscoveryReplyMessage;
@@ -73,6 +75,10 @@ public class CasualServiceCaller implements CasualServiceApi
         try
         {
             throwIfTpCallFlagsInvalid(serviceName, flags);
+            if(RuntimeInformation.isDomainBeingShutdown())
+            {
+                return tpenoent();
+            }
             return issueAsyncCall(serviceName, data, flags, execution).join().orElseThrow(() -> new CasualConnectionException("result is missing, it should always be returned"));
         }
         catch (Exception e)
@@ -91,6 +97,13 @@ public class CasualServiceCaller implements CasualServiceApi
     public CompletableFuture<Optional<ServiceReturn<CasualBuffer>>> tpacall(String serviceName, CasualBuffer data, Flag<AtmiFlags> flags, UUID execution)
     {
         throwIfTpacallFlagsInvalid(serviceName, flags);
+        if(RuntimeInformation.isDomainBeingShutdown())
+        {
+            CompletableFuture<Optional<ServiceReturn<CasualBuffer>>> future = new CompletableFuture<>();
+            Optional<ServiceReturn<CasualBuffer>> noentry = Optional.of(tpenoent());
+            future.complete(noentry);
+            return future;
+        }
         return issueAsyncCall(serviceName, data, flags, execution);
     }
 
@@ -246,6 +259,12 @@ public class CasualServiceCaller implements CasualServiceApi
     {
         CasualServiceCallReplyMessage serviceReplyMessage = v.getMessage();
         return new ServiceReturn<>(serviceReplyMessage.getServiceBuffer(), (serviceReplyMessage.getError() == ErrorState.OK) ? ServiceReturnState.TPSUCCESS : ServiceReturnState.TPFAIL, serviceReplyMessage.getError(), serviceReplyMessage.getUserDefinedCode());
+    }
+
+    private ServiceReturn<CasualBuffer> tpenoent()
+    {
+        CasualBuffer buffer = CStringBuffer.of("domain is going down");
+        return new ServiceReturn<>(buffer, ServiceReturnState.TPFAIL, ErrorState.TPENOENT, 0);
     }
 
     ServiceCallEventPublisher getEventPublisher()

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/service/CasualServiceCaller.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/service/CasualServiceCaller.java
@@ -9,7 +9,6 @@ package se.laz.casual.jca.service;
 import se.laz.casual.api.CasualServiceApi;
 import se.laz.casual.api.buffer.CasualBuffer;
 import se.laz.casual.api.buffer.ServiceReturn;
-import se.laz.casual.api.buffer.type.CStringBuffer;
 import se.laz.casual.api.buffer.type.ServiceBuffer;
 import se.laz.casual.api.flags.AtmiFlags;
 import se.laz.casual.api.flags.ErrorState;
@@ -263,8 +262,7 @@ public class CasualServiceCaller implements CasualServiceApi
 
     private ServiceReturn<CasualBuffer> tpenoent()
     {
-        CasualBuffer buffer = CStringBuffer.of("domain is going down");
-        return new ServiceReturn<>(buffer, ServiceReturnState.TPFAIL, ErrorState.TPENOENT, 0);
+        return new ServiceReturn<>(ServiceBuffer.empty(), ServiceReturnState.TPFAIL, ErrorState.TPENOENT, 0L);
     }
 
     ServiceCallEventPublisher getEventPublisher()

--- a/casual/casual-jca/src/test/groovy/se/laz/casual/jca/CasualManagedConnectionTest.groovy
+++ b/casual/casual-jca/src/test/groovy/se/laz/casual/jca/CasualManagedConnectionTest.groovy
@@ -1,20 +1,21 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2025, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
 
 package se.laz.casual.jca
 
+import jakarta.resource.NotSupportedException
+import jakarta.resource.ResourceException
+import jakarta.resource.spi.ConnectionEvent
+import jakarta.resource.spi.ConnectionEventListener
+import se.laz.casual.api.flags.XAFlags
 import se.laz.casual.api.xa.XID
 import se.laz.casual.internal.network.NetworkConnection
 import spock.lang.Shared
 import spock.lang.Specification
 
-import jakarta.resource.NotSupportedException
-import jakarta.resource.ResourceException
-import jakarta.resource.spi.ConnectionEvent
-import jakarta.resource.spi.ConnectionEventListener
 import javax.transaction.xa.XAResource
 import javax.transaction.xa.Xid
 
@@ -183,10 +184,15 @@ class CasualManagedConnectionTest extends Specification
         setup:
         Xid xid = XID.NULL_XID
         CasualXAResource resource = instance.getXAResource()
+        when:
         resource.start( xid, 0 )
-
-        expect:
+        then:
         instance.getCurrentXid() == xid
+        CasualResourceManager.getInstance().hasPending()
+        when:
+        resource.end(xid, XAFlags.TMSUCCESS.value)
+        then:
+        !CasualResourceManager.getInstance().hasPending()
     }
 
     def "GetMetaData returns an object."()

--- a/casual/casual-jca/src/test/groovy/se/laz/casual/jca/CasualResourceAdapterTest.groovy
+++ b/casual/casual-jca/src/test/groovy/se/laz/casual/jca/CasualResourceAdapterTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2025, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -15,6 +15,7 @@ import jakarta.resource.spi.endpoint.MessageEndpointFactory
 import jakarta.resource.spi.work.WorkException
 import jakarta.resource.spi.work.WorkManager
 import se.laz.casual.jca.inflow.CasualActivationSpec
+import se.laz.casual.jca.inflow.CasualInboundTransactionRegistry
 import se.laz.casual.network.inbound.CasualServer
 import spock.lang.Shared
 import spock.lang.Specification
@@ -27,6 +28,11 @@ class CasualResourceAdapterTest extends Specification
     def setup()
     {
         instance = new CasualResourceAdapter()
+    }
+
+    def cleanup()
+    {
+       RuntimeInformation.setDomainIsBeingShutdown(false)
     }
 
     def "GetXAResources"()
@@ -152,6 +158,9 @@ class CasualResourceAdapterTest extends Specification
         def server = new CasualServer(channel)
         instance.server = server
 
+        CasualInboundTransactionRegistry inboundTransactionRegistry = new CasualInboundTransactionRegistry()
+        instance.inboundTransactionRegistry = inboundTransactionRegistry
+
         MessageEndpointFactory factory = Mock(MessageEndpointFactory)
         CasualActivationSpec spec = new CasualActivationSpec()
         spec.setPort(okAddress.getPort())
@@ -161,5 +170,6 @@ class CasualResourceAdapterTest extends Specification
 
         then:
         !channel.isOpen()
+        RuntimeInformation.isDomainBeingShutdown()
     }
 }

--- a/casual/casual-jca/src/test/groovy/se/laz/casual/jca/ShutdownBarrierTest.groovy
+++ b/casual/casual-jca/src/test/groovy/se/laz/casual/jca/ShutdownBarrierTest.groovy
@@ -10,7 +10,7 @@ import spock.lang.Specification
 
 class ShutdownBarrierTest extends Specification
 {
-   def 'should only continue when predicate is true'()
+   def 'should only continue when predicate is true - no timeout'()
    {
       given:
       Predicate predicate = Mock(Predicate){

--- a/casual/casual-jca/src/test/groovy/se/laz/casual/jca/ShutdownBarrierTest.groovy
+++ b/casual/casual-jca/src/test/groovy/se/laz/casual/jca/ShutdownBarrierTest.groovy
@@ -10,7 +10,7 @@ import spock.lang.Specification
 
 class ShutdownBarrierTest extends Specification
 {
-   def 'should only continue when predicate is true - no timeout'()
+   def 'should only continue when predicate is true'()
    {
       given:
       Predicate predicate = Mock(Predicate){
@@ -22,18 +22,4 @@ class ShutdownBarrierTest extends Specification
       then:
       noExceptionThrown()
    }
-   def 'predicate always true, with timeout that should be honoured'()
-   {
-      given:
-      Predicate predicate = Mock(Predicate){
-         3 * eval() >>> [true, true, true, true, true, true]
-      }
-      long timeout = 25
-      ShutdownBarrier barrier = ShutdownBarrier.of(20, timeout, predicate)
-      when:
-      barrier.intermittentSleep()
-      then:
-      noExceptionThrown()
-   }
-
 }

--- a/casual/casual-jca/src/test/groovy/se/laz/casual/jca/ShutdownBarrierTest.groovy
+++ b/casual/casual-jca/src/test/groovy/se/laz/casual/jca/ShutdownBarrierTest.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
+package se.laz.casual.jca
+
+import spock.lang.Specification
+
+class ShutdownBarrierTest extends Specification
+{
+   def 'should only continue when predicate is true'()
+   {
+      given:
+      Predicate predicate = Mock(Predicate){
+         4 * eval() >>> [true, true, true, false]
+      }
+      ShutdownBarrier barrier = ShutdownBarrier.of(20, predicate)
+      when:
+      barrier.intermittentSleep()
+      then:
+      noExceptionThrown()
+   }
+   def 'predicate always true, with timeout that should be honoured'()
+   {
+      given:
+      Predicate predicate = Mock(Predicate){
+         3 * eval() >>> [true, true, true, true, true, true]
+      }
+      long timeout = 25
+      ShutdownBarrier barrier = ShutdownBarrier.of(20, timeout, predicate)
+      when:
+      barrier.intermittentSleep()
+      then:
+      noExceptionThrown()
+   }
+
+}

--- a/casual/casual-jca/src/test/groovy/se/laz/casual/jca/service/CasualServiceCallerTest.groovy
+++ b/casual/casual-jca/src/test/groovy/se/laz/casual/jca/service/CasualServiceCallerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2025, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -28,6 +28,7 @@ import se.laz.casual.jca.CasualManagedConnectionFactory
 import se.laz.casual.jca.CasualResourceAdapter
 import se.laz.casual.jca.CasualResourceManager
 import se.laz.casual.jca.DomainId
+import se.laz.casual.jca.RuntimeInformation
 import se.laz.casual.network.connection.CasualConnectionException
 import se.laz.casual.network.messages.domain.TransactionType
 import se.laz.casual.network.protocol.messages.CasualNWMessageImpl
@@ -69,6 +70,7 @@ class CasualServiceCallerTest extends Specification
 
     def setup()
     {
+        RuntimeInformation.setDomainIsBeingShutdown(false)
         ra = new CasualResourceAdapter()
         workManager = Mock(WorkManager)
         ra.workManager = workManager
@@ -375,6 +377,32 @@ class CasualServiceCallerTest extends Specification
         0 * serviceCallEventPublisher.post(_ as ServiceCallEvent)
     }
 
+    def 'domain is being shutdown, expecting TPENOENT'()
+    {
+       when:
+       RuntimeInformation.setDomainIsBeingShutdown(true)
+       Optional<ServiceReturn<CasualBuffer>> result = instance.tpacall( serviceName, message, Flag.of( AtmiFlags.NOFLAG)).get()
+
+       then:
+       noExceptionThrown()
+       result != null
+       result.isPresent()
+       result.get().getServiceReturnState() == ServiceReturnState.TPFAIL
+       result.get().errorState == ErrorState.TPENOENT
+
+       0 * networkConnection.request( _ ) >> {
+          CasualNWMessageImpl<CasualServiceCallRequestMessage> input ->
+             actualServiceRequest = input
+             return CompletableFuture.completedFuture(serviceReply)
+       }
+
+       0 * serviceCallEventPublisher.post(_ as ServiceCallEvent) >> { ServiceCallEvent event ->
+          event.getService() == serviceName
+          event.getCode() == ErrorState.TPESVCFAIL.name()
+          event.getOrder() == Order.CONCURRENT.value
+       }
+
+    }
 
     def "toString test."()
     {

--- a/casual/casual-jca/src/test/groovy/se/laz/casual/jca/work/StartInboundServerWorkTest.groovy
+++ b/casual/casual-jca/src/test/groovy/se/laz/casual/jca/work/StartInboundServerWorkTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, The casual project. All rights reserved.
+ * Copyright (c) 2021 - 2025, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -14,6 +14,7 @@ import se.laz.casual.config.Mode
 import se.laz.casual.jca.InboundStartupException
 import se.laz.casual.jca.inbound.handler.service.ServiceHandlerFactory
 import se.laz.casual.jca.inbound.handler.test.TestServiceHandler
+import se.laz.casual.jca.inflow.CasualInboundTransactionRegistry
 import se.laz.casual.network.inbound.CasualServer
 import se.laz.casual.network.inbound.ConnectionInformation
 import spock.lang.Shared
@@ -44,8 +45,11 @@ class StartInboundServerWorkTest extends Specification
 
     CasualServer server
 
+    CasualInboundTransactionRegistry inboundTransactionRegistry
+
     def setup()
     {
+        inboundTransactionRegistry = new CasualInboundTransactionRegistry()
         MessageEndpointFactory endpointFactory = Mock( MessageEndpointFactory )
         WorkManager workManager = Mock( WorkManager)
         XATerminator xaTerminator = Mock( XATerminator )
@@ -54,6 +58,7 @@ class StartInboundServerWorkTest extends Specification
                 .withPort( port )
                 .withWorkManager(workManager)
                 .withXaTerminator(xaTerminator)
+                .withInboundTransactionRegistry(inboundTransactionRegistry)
                 .build()
     }
 

--- a/casual/casual-network/src/main/java/se/laz/casual/network/InboundMessageSender.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/InboundMessageSender.java
@@ -27,7 +27,7 @@ public class InboundMessageSender
     {
         Objects.requireNonNull(channel,"channel can not be null" );
         channel.writeAndFlush(createDomainDisconnectMessage());
-        log.finest(() -> "domain disconnect request sent to " + channel);
+        log.info(() -> "domain disconnect request sent to " + channel);
     }
 
     public static void sendDomainDiscoveryImplicitUpdate(Channel channel, UUID executionId)

--- a/casual/casual-network/src/main/java/se/laz/casual/network/InboundMessageSender.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/InboundMessageSender.java
@@ -27,7 +27,7 @@ public class InboundMessageSender
     {
         Objects.requireNonNull(channel,"channel can not be null" );
         channel.writeAndFlush(createDomainDisconnectMessage());
-        log.info(() -> "domain disconnect request sent to " + channel);
+        log.finest(() -> "domain disconnect request sent to " + channel);
     }
 
     public static void sendDomainDiscoveryImplicitUpdate(Channel channel, UUID executionId)

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/CasualMessageHandler.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/CasualMessageHandler.java
@@ -14,6 +14,7 @@ import jakarta.resource.spi.endpoint.MessageEndpoint;
 import jakarta.resource.spi.endpoint.MessageEndpointFactory;
 import jakarta.resource.spi.work.WorkManager;
 import se.laz.casual.api.network.protocol.messages.CasualNWMessage;
+import se.laz.casual.jca.inflow.CasualInboundTransactionRegistry;
 import se.laz.casual.jca.inflow.CasualMessageListener;
 import se.laz.casual.network.protocol.messages.domain.CasualDomainConnectRequestMessage;
 import se.laz.casual.network.protocol.messages.domain.CasualDomainDiscoveryRequestMessage;
@@ -33,20 +34,23 @@ public final class CasualMessageHandler extends SimpleChannelInboundHandler<Casu
     private final MessageEndpointFactory factory;
     private final XATerminator xaTerminator;
     private final WorkManager workManager;
+    private final CasualInboundTransactionRegistry inboundTransactionRegistry;
 
-    private CasualMessageHandler(MessageEndpointFactory factory, XATerminator xaTerminator, WorkManager workManager)
+    private CasualMessageHandler(MessageEndpointFactory factory, XATerminator xaTerminator, WorkManager workManager, CasualInboundTransactionRegistry inboundTransactionRegistry)
     {
         this.factory = factory;
         this.xaTerminator = xaTerminator;
         this.workManager = workManager;
+        this.inboundTransactionRegistry = inboundTransactionRegistry;
     }
 
-    public static CasualMessageHandler of(final MessageEndpointFactory factory, final XATerminator xaTerminator, final WorkManager workManager)
+    public static CasualMessageHandler of(final MessageEndpointFactory factory, final XATerminator xaTerminator, final WorkManager workManager, CasualInboundTransactionRegistry inboundTransactionRegistry)
     {
         Objects.requireNonNull(factory, "factory can not be null");
         Objects.requireNonNull(xaTerminator, "xaTerminator can not be null");
         Objects.requireNonNull(workManager, "workManager can not be null");
-        return new CasualMessageHandler(factory, xaTerminator, workManager);
+        Objects.requireNonNull(inboundTransactionRegistry, "inboundTransactionRegistry can not be null");
+        return new CasualMessageHandler(factory, xaTerminator, workManager, inboundTransactionRegistry);
     }
 
     @SuppressWarnings("unchecked")
@@ -55,19 +59,20 @@ public final class CasualMessageHandler extends SimpleChannelInboundHandler<Casu
     {
         MessageEndpoint endpoint = factory.createEndpoint(null);
         CasualMessageListener listener = (CasualMessageListener) endpoint;
+        log.info(() -> "inbound msg: " + message);
         switch ( message.getType() )
         {
             case COMMIT_REQUEST:
-                listener.commitRequest((CasualNWMessage<CasualTransactionResourceCommitRequestMessage>)message, ctx.channel(), xaTerminator);
+                listener.commitRequest((CasualNWMessage<CasualTransactionResourceCommitRequestMessage>)message, ctx.channel(), xaTerminator, inboundTransactionRegistry);
                 break;
             case PREPARE_REQUEST:
-                listener.prepareRequest((CasualNWMessage<CasualTransactionResourcePrepareRequestMessage>)message, ctx.channel(), xaTerminator);
+                listener.prepareRequest((CasualNWMessage<CasualTransactionResourcePrepareRequestMessage>)message, ctx.channel(), xaTerminator, inboundTransactionRegistry);
                 break;
             case REQUEST_ROLLBACK:
-                listener.requestRollback((CasualNWMessage<CasualTransactionResourceRollbackRequestMessage>)message, ctx.channel(), xaTerminator);
+                listener.requestRollback((CasualNWMessage<CasualTransactionResourceRollbackRequestMessage>)message, ctx.channel(), xaTerminator, inboundTransactionRegistry);
                 break;
             case SERVICE_CALL_REQUEST:
-                listener.serviceCallRequest((CasualNWMessage<CasualServiceCallRequestMessage>)message, ctx.channel(), workManager);
+                listener.serviceCallRequest((CasualNWMessage<CasualServiceCallRequestMessage>)message, ctx.channel(), workManager, inboundTransactionRegistry);
                 break;
             case DOMAIN_CONNECT_REQUEST:
                 listener.domainConnectRequest((CasualNWMessage<CasualDomainConnectRequestMessage>)message, ctx.channel());

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/CasualMessageHandler.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/CasualMessageHandler.java
@@ -59,7 +59,7 @@ public final class CasualMessageHandler extends SimpleChannelInboundHandler<Casu
     {
         MessageEndpoint endpoint = factory.createEndpoint(null);
         CasualMessageListener listener = (CasualMessageListener) endpoint;
-        log.info(() -> "inbound msg: " + message);
+        log.finest(() -> "inbound msg: " + message);
         switch ( message.getType() )
         {
             case COMMIT_REQUEST:

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/CasualServer.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/CasualServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2025, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -41,8 +41,8 @@ public final class CasualServer
 
     public static CasualServer of(final ConnectionInformation ci)
     {
-        CasualMessageHandler mh = CasualMessageHandler.of(ci.getFactory(), ci.getXaTerminator(), ci.getWorkManager());
-        Channel c = init(mh, ExceptionHandler.of(), ci.getPort(), ci.isLogHandlerEnabled(), ci.isUseEpoll() );
+        CasualMessageHandler mh = CasualMessageHandler.of(ci.getFactory(), ci.getXaTerminator(), ci.getWorkManager(), ci.getInboundTransactionRegistry());
+        Channel c = init(mh, ExceptionHandler.of(ci.getInboundTransactionRegistry()), ci.getPort(), ci.isLogHandlerEnabled(), ci.isUseEpoll() );
         return new CasualServer(c);
     }
 

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/ConnectionInformation.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/ConnectionInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2024, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2025, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -11,6 +11,7 @@ import jakarta.resource.spi.endpoint.MessageEndpointFactory;
 import jakarta.resource.spi.work.WorkManager;
 import se.laz.casual.config.ConfigurationOptions;
 import se.laz.casual.config.ConfigurationService;
+import se.laz.casual.jca.inflow.CasualInboundTransactionRegistry;
 
 import java.util.Objects;
 
@@ -22,6 +23,7 @@ public final class ConnectionInformation
     private final WorkManager workManager;
     private final boolean logHandlerEnabled;
     private final boolean useEpoll;
+    private final CasualInboundTransactionRegistry inboundTransactionRegistry;
 
     private ConnectionInformation( Builder builder )
     {
@@ -31,6 +33,7 @@ public final class ConnectionInformation
         this.workManager = builder.workManager;
         this.logHandlerEnabled = builder.logHandlerEnabled;
         this.useEpoll = builder.useEpoll;
+        this.inboundTransactionRegistry = builder.inboundTransactionRegistry;
     }
 
     public int getPort()
@@ -63,6 +66,11 @@ public final class ConnectionInformation
         return useEpoll;
     }
 
+    public CasualInboundTransactionRegistry getInboundTransactionRegistry()
+    {
+        return inboundTransactionRegistry;
+    }
+
     public static Builder createBuilder()
     {
         return new Builder();
@@ -76,6 +84,7 @@ public final class ConnectionInformation
         private WorkManager workManager;
         private boolean useEpoll;
         private Boolean logHandlerEnabled;
+        private CasualInboundTransactionRegistry inboundTransactionRegistry;
 
         public Builder withPort(int port)
         {
@@ -110,6 +119,12 @@ public final class ConnectionInformation
         public Builder withEnabledLogHandler( boolean enabled )
         {
             this.logHandlerEnabled = enabled;
+            return this;
+        }
+
+        public Builder withInboundTransactionRegistry(CasualInboundTransactionRegistry inboundTransactionRegistry)
+        {
+            this.inboundTransactionRegistry = inboundTransactionRegistry;
             return this;
         }
 

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/ExceptionHandler.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/ExceptionHandler.java
@@ -9,18 +9,28 @@ package se.laz.casual.network.inbound;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import se.laz.casual.jca.inflow.CasualInboundTransactionRegistry;
 import se.laz.casual.network.InboundDeactivatedContext;
 import se.laz.casual.network.InboundTopologyUpdateContext;
 
+import java.util.Objects;
 import java.util.logging.Logger;
 
 @ChannelHandler.Sharable
 public final class ExceptionHandler extends ChannelInboundHandlerAdapter
 {
     private static final Logger log = Logger.getLogger(ExceptionHandler.class.getName());
-    public static ExceptionHandler of()
+    private final CasualInboundTransactionRegistry inboundTransactionRegistry;
+
+    public ExceptionHandler(CasualInboundTransactionRegistry inboundTransactionRegistry)
     {
-        return new ExceptionHandler();
+        this.inboundTransactionRegistry = inboundTransactionRegistry;
+    }
+
+    public static ExceptionHandler of(CasualInboundTransactionRegistry inboundTransactionRegistry)
+    {
+        Objects.requireNonNull(inboundTransactionRegistry, "inboundTransactionRegistry can not be null");
+        return new ExceptionHandler(inboundTransactionRegistry);
     }
 
     @Override
@@ -29,6 +39,7 @@ public final class ExceptionHandler extends ChannelInboundHandlerAdapter
         log.warning(() -> "casual inbound exception caught: " + cause + " closing channel");
         InboundDeactivatedContext.remove(ctx.channel());
         InboundTopologyUpdateContext.remove(ctx.channel());
+        inboundTransactionRegistry.remove(ctx.channel().id());
         ctx.close();
     }
 }

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundConnectionInformation.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundConnectionInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 - 2024, The casual project. All rights reserved.
+ * Copyright (c) 2022 - 2025, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -14,6 +14,7 @@ import jakarta.resource.spi.endpoint.MessageEndpointFactory;
 import jakarta.resource.spi.work.WorkManager;
 import se.laz.casual.config.ConfigurationOptions;
 import se.laz.casual.config.ConfigurationService;
+import se.laz.casual.jca.inflow.CasualInboundTransactionRegistry;
 import se.laz.casual.network.ProtocolVersion;
 import se.laz.casual.network.outbound.Correlator;
 import se.laz.casual.network.outbound.CorrelatorImpl;
@@ -34,6 +35,7 @@ public class ReverseInboundConnectionInformation
     private final UUID domainId;
     private final String domainName;
     private final Class<? extends Channel> channelClass;
+    private final CasualInboundTransactionRegistry inboundTransactionRegistry;
     private boolean useEpoll;
     private final long maxBackoffMillis;
 
@@ -51,6 +53,7 @@ public class ReverseInboundConnectionInformation
         this.channelClass = builder.channelClass;
         this.useEpoll = builder.useEpoll;
         this.maxBackoffMillis = builder.maxBackoffMillis;
+        this.inboundTransactionRegistry = builder.inboundTransactionRegistry;
     }
 
     public InetSocketAddress getAddress()
@@ -118,6 +121,11 @@ public class ReverseInboundConnectionInformation
         return maxBackoffMillis;
     }
 
+    public CasualInboundTransactionRegistry getInboundTransactionRegistry()
+    {
+        return inboundTransactionRegistry;
+    }
+
     public static final class Builder
     {
         private InetSocketAddress address;
@@ -132,6 +140,7 @@ public class ReverseInboundConnectionInformation
         private boolean logHandlerEnabled;
         private boolean useEpoll;
         private long maxBackoffMillis;
+        private CasualInboundTransactionRegistry inboundTransactionRegistry;
 
         public Builder withAddress(InetSocketAddress address)
         {
@@ -193,6 +202,12 @@ public class ReverseInboundConnectionInformation
             return this;
         }
 
+        public Builder withInboundTransactionRegistry(CasualInboundTransactionRegistry inboundTransactionRegistry)
+        {
+            this.inboundTransactionRegistry = inboundTransactionRegistry;
+            return this;
+        }
+
         public ReverseInboundConnectionInformation build()
         {
             Objects.requireNonNull(address, "address can not be null");
@@ -202,10 +217,13 @@ public class ReverseInboundConnectionInformation
             Objects.requireNonNull(workManager, "workManager can not be null");
             Objects.requireNonNull(domainId, "domainId can not be null");
             Objects.requireNonNull(domainName, "domainName can not be null");
+            Objects.requireNonNull(inboundTransactionRegistry, "inboundTransactionRegistry can not be null");
             correlator = null == correlator ? CorrelatorImpl.of() : correlator;
             channelClass = useEpoll ? EpollSocketChannel.class : NioSocketChannel.class;
             logHandlerEnabled = ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_NETWORK_REVERSE_INBOUND_ENABLE_LOGHANDLER );
             return new ReverseInboundConnectionInformation(this);
         }
+
+
     }
 }

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundExceptionHandler.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundExceptionHandler.java
@@ -8,17 +8,27 @@ package se.laz.casual.network.inbound.reverse;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import se.laz.casual.jca.inflow.CasualInboundTransactionRegistry;
 import se.laz.casual.network.InboundDeactivatedContext;
 import se.laz.casual.network.InboundTopologyUpdateContext;
 
+import java.util.Objects;
 import java.util.logging.Logger;
 
 public final class ReverseInboundExceptionHandler extends ChannelInboundHandlerAdapter
 {
     private static final Logger log = Logger.getLogger(ReverseInboundExceptionHandler.class.getName());
-    public static ReverseInboundExceptionHandler of()
+    private final CasualInboundTransactionRegistry inboundTransactionRegistry;
+
+    private ReverseInboundExceptionHandler(CasualInboundTransactionRegistry inboundTransactionRegistry)
     {
-        return new ReverseInboundExceptionHandler();
+        this.inboundTransactionRegistry = inboundTransactionRegistry;
+    }
+
+    public static ReverseInboundExceptionHandler of(CasualInboundTransactionRegistry inboundTransactionRegistry)
+    {
+        Objects.requireNonNull(inboundTransactionRegistry, "inboundTransactionRegistry can not be null");
+        return new ReverseInboundExceptionHandler(inboundTransactionRegistry);
     }
 
     @Override
@@ -27,6 +37,7 @@ public final class ReverseInboundExceptionHandler extends ChannelInboundHandlerA
         log.warning(() -> "casual reverse inbound exception caught: " + cause + " closing channel");
         InboundDeactivatedContext.remove(ctx.channel());
         InboundTopologyUpdateContext.remove(ctx.channel());
+        inboundTransactionRegistry.remove(ctx.channel().id());
         ctx.close();
     }
 }

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundMessageHandler.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundMessageHandler.java
@@ -60,6 +60,7 @@ public final class ReverseInboundMessageHandler extends SimpleChannelInboundHand
     {
         MessageEndpoint endpoint = factory.createEndpoint(null);
         CasualMessageListener listener = (CasualMessageListener) endpoint;
+        log.finest(() -> "reverse inbound msg: " + message);
         switch ( message.getType() )
         {
             case COMMIT_REQUEST:

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundMessageHandler.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundMessageHandler.java
@@ -13,6 +13,7 @@ import jakarta.resource.spi.endpoint.MessageEndpoint;
 import jakarta.resource.spi.endpoint.MessageEndpointFactory;
 import jakarta.resource.spi.work.WorkManager;
 import se.laz.casual.api.network.protocol.messages.CasualNWMessage;
+import se.laz.casual.jca.inflow.CasualInboundTransactionRegistry;
 import se.laz.casual.jca.inflow.CasualMessageListener;
 import se.laz.casual.network.protocol.messages.domain.CasualDomainConnectRequestMessage;
 import se.laz.casual.network.protocol.messages.domain.CasualDomainDiscoveryRequestMessage;
@@ -34,20 +35,23 @@ public final class ReverseInboundMessageHandler extends SimpleChannelInboundHand
     private final MessageEndpointFactory factory;
     private final XATerminator xaTerminator;
     private final WorkManager workManager;
+    private final CasualInboundTransactionRegistry inboundTransactionRegistry;
 
-    private ReverseInboundMessageHandler(MessageEndpointFactory factory, XATerminator xaTerminator, WorkManager workManager)
+    private ReverseInboundMessageHandler(MessageEndpointFactory factory, XATerminator xaTerminator, WorkManager workManager, CasualInboundTransactionRegistry inboundTransactionRegistry)
     {
         this.factory = factory;
         this.xaTerminator = xaTerminator;
         this.workManager = workManager;
+        this.inboundTransactionRegistry = inboundTransactionRegistry;
     }
 
-    public static ReverseInboundMessageHandler of(final MessageEndpointFactory factory, final XATerminator xaTerminator, final WorkManager workManager)
+    public static ReverseInboundMessageHandler of(final MessageEndpointFactory factory, final XATerminator xaTerminator, final WorkManager workManager, CasualInboundTransactionRegistry inboundTransactionRegistry)
     {
         Objects.requireNonNull(factory, "factory can not be null");
         Objects.requireNonNull(xaTerminator, "xaTerminator can not be null");
         Objects.requireNonNull(workManager, "workManager can not be null");
-        return new ReverseInboundMessageHandler(factory, xaTerminator, workManager);
+        Objects.requireNonNull(inboundTransactionRegistry, "inboundTransactionRegistry can not be null");
+        return new ReverseInboundMessageHandler(factory, xaTerminator, workManager, inboundTransactionRegistry);
     }
 
     @SuppressWarnings("unchecked")
@@ -59,16 +63,16 @@ public final class ReverseInboundMessageHandler extends SimpleChannelInboundHand
         switch ( message.getType() )
         {
             case COMMIT_REQUEST:
-                executor.execute(() -> listener.commitRequest((CasualNWMessage<CasualTransactionResourceCommitRequestMessage>)message, ctx.channel(), xaTerminator));
+                executor.execute(() -> listener.commitRequest((CasualNWMessage<CasualTransactionResourceCommitRequestMessage>)message, ctx.channel(), xaTerminator, inboundTransactionRegistry));
                 break;
             case PREPARE_REQUEST:
-                executor.execute(() -> listener.prepareRequest((CasualNWMessage<CasualTransactionResourcePrepareRequestMessage>)message, ctx.channel(), xaTerminator));
+                executor.execute(() -> listener.prepareRequest((CasualNWMessage<CasualTransactionResourcePrepareRequestMessage>)message, ctx.channel(), xaTerminator, inboundTransactionRegistry));
                 break;
             case REQUEST_ROLLBACK:
-                executor.execute(() -> listener.requestRollback((CasualNWMessage<CasualTransactionResourceRollbackRequestMessage>)message, ctx.channel(), xaTerminator));
+                executor.execute(() -> listener.requestRollback((CasualNWMessage<CasualTransactionResourceRollbackRequestMessage>)message, ctx.channel(), xaTerminator, inboundTransactionRegistry));
                 break;
             case SERVICE_CALL_REQUEST:
-                listener.serviceCallRequest((CasualNWMessage<CasualServiceCallRequestMessage>)message, ctx.channel(), workManager);
+                listener.serviceCallRequest((CasualNWMessage<CasualServiceCallRequestMessage>)message, ctx.channel(), workManager, inboundTransactionRegistry);
                 break;
             case DOMAIN_CONNECT_REQUEST:
                 listener.domainConnectRequest((CasualNWMessage<CasualDomainConnectRequestMessage>)message, ctx.channel());

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundServerImpl.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundServerImpl.java
@@ -54,8 +54,8 @@ public class ReverseInboundServerImpl implements ReverseInboundServer
     public static ReverseInboundServer of(ReverseInboundConnectionInformation reverseInboundConnectionInformation, ReverseInboundListener eventListener, Supplier<WorkManager> workManagerSupplier)
     {
         Objects.requireNonNull(reverseInboundConnectionInformation, "connectionInformation can not be null");
-        ReverseInboundMessageHandler messageHandler = ReverseInboundMessageHandler.of(reverseInboundConnectionInformation.getFactory(), reverseInboundConnectionInformation.getXaTerminator(), reverseInboundConnectionInformation.getWorkManager());
-        Channel ch = init(reverseInboundConnectionInformation.getAddress(), messageHandler, ReverseInboundExceptionHandler.of(), reverseInboundConnectionInformation.isLogHandlerEnabled(), reverseInboundConnectionInformation.getChannelClass());
+        ReverseInboundMessageHandler messageHandler = ReverseInboundMessageHandler.of(reverseInboundConnectionInformation.getFactory(), reverseInboundConnectionInformation.getXaTerminator(), reverseInboundConnectionInformation.getWorkManager(), reverseInboundConnectionInformation.getInboundTransactionRegistry());
+        Channel ch = init(reverseInboundConnectionInformation.getAddress(), messageHandler, ReverseInboundExceptionHandler.of(reverseInboundConnectionInformation.getInboundTransactionRegistry()), reverseInboundConnectionInformation.isLogHandlerEnabled(), reverseInboundConnectionInformation.getChannelClass());
         ReverseInboundServerImpl server = new ReverseInboundServerImpl(ch, reverseInboundConnectionInformation.getAddress(), workManagerSupplier);
         ch.closeFuture().addListener(f -> server.onClose(reverseInboundConnectionInformation, eventListener));
         LOG.info(() -> "reverse inbound connected to: " + server.getAddress());

--- a/casual/casual-network/src/test/groovy/se/laz/casual/network/inbound/CasualMessageHandlerTest.groovy
+++ b/casual/casual-network/src/test/groovy/se/laz/casual/network/inbound/CasualMessageHandlerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2025, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -7,15 +7,15 @@
 package se.laz.casual.network.inbound
 
 import io.netty.channel.ChannelHandlerContext
-import se.laz.casual.api.network.protocol.messages.CasualNWMessage
-import se.laz.casual.api.network.protocol.messages.CasualNWMessageType
-import se.laz.casual.network.utils.FakeListener
-import spock.lang.Shared
-import spock.lang.Specification
-
 import jakarta.resource.spi.XATerminator
 import jakarta.resource.spi.endpoint.MessageEndpointFactory
 import jakarta.resource.spi.work.WorkManager
+import se.laz.casual.api.network.protocol.messages.CasualNWMessage
+import se.laz.casual.api.network.protocol.messages.CasualNWMessageType
+import se.laz.casual.jca.inflow.CasualInboundTransactionRegistry
+import se.laz.casual.network.utils.FakeListener
+import spock.lang.Shared
+import spock.lang.Specification
 
 class CasualMessageHandlerTest extends Specification
 {
@@ -25,6 +25,13 @@ class CasualMessageHandlerTest extends Specification
     def mockXATerminator = Mock(XATerminator)
     @Shared
     def mockWorkManager = Mock(WorkManager)
+    @Shared
+    CasualInboundTransactionRegistry inboundTransactionRegistry
+
+    def setup()
+    {
+       inboundTransactionRegistry = new CasualInboundTransactionRegistry()
+    }
 
     def 'test message routing'()
     {
@@ -40,7 +47,7 @@ class CasualMessageHandlerTest extends Specification
         }
         def xaTerminator = Mock(XATerminator)
         def workManager = Mock(WorkManager)
-        def instance = CasualMessageHandler.of(factory, xaTerminator, workManager)
+        def instance = CasualMessageHandler.of(factory, xaTerminator, workManager, inboundTransactionRegistry)
         def ctx = Mock(ChannelHandlerContext)
         when:
         instance.channelRead0(ctx, msg)
@@ -59,7 +66,7 @@ class CasualMessageHandlerTest extends Specification
     def 'test failed construction'()
     {
         when:
-        CasualMessageHandler.of(factory, xaTerminator, workManager)
+        CasualMessageHandler.of(factory, xaTerminator, workManager, inboundTransactionRegistry)
         then:
         thrown(NullPointerException)
         where:

--- a/casual/casual-network/src/test/groovy/se/laz/casual/network/inbound/CasualServerTest.groovy
+++ b/casual/casual-network/src/test/groovy/se/laz/casual/network/inbound/CasualServerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2025, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -10,6 +10,10 @@ import io.netty.channel.Channel
 import io.netty.channel.ChannelFuture
 import io.netty.channel.EventLoop
 import io.netty.channel.epoll.EpollServerSocketChannel
+import jakarta.resource.spi.XATerminator
+import jakarta.resource.spi.endpoint.MessageEndpointFactory
+import jakarta.resource.spi.work.WorkManager
+import se.laz.casual.jca.inflow.CasualInboundTransactionRegistry
 import se.laz.casual.network.protocol.encoding.CasualMessageEncoder
 import se.laz.casual.network.protocol.messages.CasualNWMessageImpl
 import se.laz.casual.network.protocol.messages.domain.CasualDomainConnectRequestMessage
@@ -18,9 +22,6 @@ import spock.lang.Requires
 import spock.lang.Shared
 import spock.lang.Specification
 
-import jakarta.resource.spi.XATerminator
-import jakarta.resource.spi.endpoint.MessageEndpointFactory
-import jakarta.resource.spi.work.WorkManager
 import java.nio.channels.SocketChannel
 
 class CasualServerTest extends Specification
@@ -32,9 +33,11 @@ class CasualServerTest extends Specification
     @Shared String domainName = "java"
     @Shared UUID execution = UUID.randomUUID()
     @Shared long protocolVersion = 1000L
+    @Shared CasualInboundTransactionRegistry inboundTransactionRegistry
 
     def setup()
     {
+        inboundTransactionRegistry = new CasualInboundTransactionRegistry()
         channel = Mock(Channel)
         channel.close () >> {
             def f = Mock(ChannelFuture)
@@ -89,6 +92,7 @@ class CasualServerTest extends Specification
                                                                   .withXaTerminator(xaTerminator)
                                                                   .withFactory(factory)
                                                                   .withWorkManager(workManager)
+                                                                  .withInboundTransactionRegistry(inboundTransactionRegistry)
                                                                   .build())
         InetSocketAddress address = (InetSocketAddress) server.channel.localAddress()
 
@@ -133,6 +137,7 @@ class CasualServerTest extends Specification
                 .withFactory(factory)
                 .withWorkManager(workManager)
                 .withUseEpoll( true )
+                .withInboundTransactionRegistry(inboundTransactionRegistry)
                 .build())
         InetSocketAddress address = (InetSocketAddress) server.channel.localAddress()
 
@@ -171,6 +176,7 @@ class CasualServerTest extends Specification
                 .withFactory(factory)
                 .withWorkManager(workManager)
                 .withUseEpoll( true )
+                .withInboundTransactionRegistry(inboundTransactionRegistry)
                 .build())
         Channel channel = server.channel
 

--- a/casual/casual-network/src/test/groovy/se/laz/casual/network/inbound/ExceptionHandlerTest.groovy
+++ b/casual/casual-network/src/test/groovy/se/laz/casual/network/inbound/ExceptionHandlerTest.groovy
@@ -9,6 +9,7 @@ package se.laz.casual.network.inbound
 import io.netty.channel.Channel
 import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelId
+import se.laz.casual.jca.inflow.CasualInboundTransactionRegistry
 import spock.lang.Specification
 
 class ExceptionHandlerTest extends Specification
@@ -16,12 +17,13 @@ class ExceptionHandlerTest extends Specification
     def 'should close context'()
     {
         setup:
+        CasualInboundTransactionRegistry inboundTransactionRegistry = new CasualInboundTransactionRegistry()
         def ctx = Mock(ChannelHandlerContext){
            channel() >> Mock(Channel){
               id() >> Mock(ChannelId)
            }
         }
-        def handler = ExceptionHandler.of()
+        def handler = ExceptionHandler.of(inboundTransactionRegistry)
         when:
         handler.exceptionCaught(ctx, new RuntimeException())
         then:

--- a/casual/casual-network/src/test/groovy/se/laz/casual/network/inbound/reverse/ReverseInboundConnectionInformationTest.groovy
+++ b/casual/casual-network/src/test/groovy/se/laz/casual/network/inbound/reverse/ReverseInboundConnectionInformationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, The casual project. All rights reserved.
+ * Copyright (c) 2024 - 2025, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -14,6 +14,7 @@ import jakarta.resource.spi.endpoint.MessageEndpointFactory
 import jakarta.resource.spi.work.WorkManager
 import se.laz.casual.config.ConfigurationOptions
 import se.laz.casual.config.ConfigurationService
+import se.laz.casual.jca.inflow.CasualInboundTransactionRegistry
 import se.laz.casual.network.ProtocolVersion
 import se.laz.casual.network.outbound.Correlator
 import spock.lang.Specification
@@ -41,6 +42,7 @@ class ReverseInboundConnectionInformationTest extends Specification
       long maxBackoffMillis = 12345
       boolean isLogHandlerEnabled = true
 
+      CasualInboundTransactionRegistry inboundTransactionRegistry = new CasualInboundTransactionRegistry()
       ReverseInboundConnectionInformation connectionInfo
 
       ConfigurationService.setConfiguration( ConfigurationOptions.CASUAL_NETWORK_REVERSE_INBOUND_ENABLE_LOGHANDLER, isLogHandlerEnabled )
@@ -56,6 +58,7 @@ class ReverseInboundConnectionInformationTest extends Specification
               .withDomainName(domainName)
               .withUseEpoll(useEpoll)
               .withMaxBackoffMillils(maxBackoffMillis)
+              .withInboundTransactionRegistry(inboundTransactionRegistry)
               .build()
 
       expect:
@@ -88,6 +91,7 @@ class ReverseInboundConnectionInformationTest extends Specification
       boolean useEpoll = false
       long maxBackoffMillis = 12345
       boolean isLogHandlerEnabled = false
+      CasualInboundTransactionRegistry inboundTransactionRegistry = new CasualInboundTransactionRegistry()
 
       ReverseInboundConnectionInformation connectionInfo
 
@@ -104,6 +108,7 @@ class ReverseInboundConnectionInformationTest extends Specification
               .withDomainName(domainName)
               .withUseEpoll(useEpoll)
               .withMaxBackoffMillils(maxBackoffMillis)
+              .withInboundTransactionRegistry(inboundTransactionRegistry)
               .build()
 
       expect:

--- a/casual/casual-network/src/test/groovy/se/laz/casual/network/utils/FakeListener.groovy
+++ b/casual/casual-network/src/test/groovy/se/laz/casual/network/utils/FakeListener.groovy
@@ -11,6 +11,7 @@ import jakarta.resource.spi.XATerminator
 import jakarta.resource.spi.endpoint.MessageEndpoint
 import jakarta.resource.spi.work.WorkManager
 import se.laz.casual.api.network.protocol.messages.CasualNWMessage
+import se.laz.casual.jca.inflow.CasualInboundTransactionRegistry
 import se.laz.casual.jca.inflow.CasualMessageListener
 import se.laz.casual.network.protocol.messages.domain.CasualDomainConnectRequestMessage
 import se.laz.casual.network.protocol.messages.domain.CasualDomainDiscoveryRequestMessage
@@ -56,22 +57,22 @@ class FakeListener implements MessageEndpoint, CasualMessageListener
     }
 
     @Override
-    void serviceCallRequest(CasualNWMessage<CasualServiceCallRequestMessage> message, Channel channel, WorkManager workManager) {
+    void serviceCallRequest(CasualNWMessage<CasualServiceCallRequestMessage> message, Channel channel, WorkManager workManager, CasualInboundTransactionRegistry inboundTransactionRegistry) {
 
     }
 
     @Override
-    void prepareRequest(CasualNWMessage<CasualTransactionResourcePrepareRequestMessage> message, Channel channel, XATerminator xaTerminator) {
+    void prepareRequest(CasualNWMessage<CasualTransactionResourcePrepareRequestMessage> message, Channel channel, XATerminator xaTerminator, CasualInboundTransactionRegistry inboundTransactionRegistry) {
 
     }
 
     @Override
-    void commitRequest(CasualNWMessage<CasualTransactionResourceCommitRequestMessage> message, Channel channel, XATerminator xaTerminator) {
+    void commitRequest(CasualNWMessage<CasualTransactionResourceCommitRequestMessage> message, Channel channel, XATerminator xaTerminator, CasualInboundTransactionRegistry inboundTransactionRegistry) {
 
     }
 
     @Override
-    void requestRollback(CasualNWMessage<CasualTransactionResourceRollbackRequestMessage> message, Channel channel, XATerminator xaTerminator) {
+    void requestRollback(CasualNWMessage<CasualTransactionResourceRollbackRequestMessage> message, Channel channel, XATerminator xaTerminator, CasualInboundTransactionRegistry inboundTransactionRegistry) {
 
     }
 }

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '3.3.4'
+version = '3.3.5'
 
 def netty_version = '4.1.114.Final'
 def gson_version = '2.11.0'


### PR DESCRIPTION
When there is a graceful shutdown we:
* drain the current in flight transactions
* return TPENOENT for new outbound requests

