### PR TITLE
refactor: Replace java.util.logging.Logger with System.Logger

### DIFF
--- a/casual/casual-api/src/main/java/se/laz/casual/api/buffer/type/fielded/EncodingInfo.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/buffer/type/fielded/EncodingInfo.java
@@ -8,6 +8,8 @@ package se.laz.casual.api.buffer.type.fielded;
 
 import java.nio.charset.Charset;
 
+import static java.lang.System.Logger.Level.*;
+
 /**
  * Encoding information to use for string encoding/decoding
  * @see EncodingInfoProvider
@@ -22,7 +24,7 @@ public final class EncodingInfo
     {
         EncodingInfoProvider p = EncodingInfoProvider.of();
         charset = p.getCharset();
-        log.log(System.Logger.Level.INFO,() -> "casual fielded encoding set to charset: " + charset);
+        log.log(INFO,() -> "casual fielded encoding set to charset: " + charset);
     }
 
     /**

--- a/casual/casual-api/src/main/java/se/laz/casual/api/buffer/type/fielded/EncodingInfo.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/buffer/type/fielded/EncodingInfo.java
@@ -7,7 +7,6 @@
 package se.laz.casual.api.buffer.type.fielded;
 
 import java.nio.charset.Charset;
-import java.util.logging.Logger;
 
 /**
  * Encoding information to use for string encoding/decoding
@@ -15,7 +14,7 @@ import java.util.logging.Logger;
  */
 public final class EncodingInfo
 {
-    private static final Logger log = Logger.getLogger(EncodingInfo.class.getName());
+    private static final System.Logger log = System.getLogger(EncodingInfo.class.getName());
     private static final Charset charset;
     private EncodingInfo()
     {}
@@ -23,7 +22,7 @@ public final class EncodingInfo
     {
         EncodingInfoProvider p = EncodingInfoProvider.of();
         charset = p.getCharset();
-        log.info(() -> "casual fielded encoding set to charset: " + charset);
+        log.log(System.Logger.Level.INFO,() -> "casual fielded encoding set to charset: " + charset);
     }
 
     /**

--- a/casual/casual-api/src/main/java/se/laz/casual/api/buffer/type/fielded/EncodingInfoProvider.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/buffer/type/fielded/EncodingInfoProvider.java
@@ -12,6 +12,8 @@ import se.laz.casual.config.ConfigurationService;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
+import static java.lang.System.Logger.Level.*;
+
 /**
  * Provides the encoding information for encoding/decoding strings
  * Value determined by the {@link ConfigurationService}.
@@ -43,7 +45,7 @@ public class EncodingInfoProvider
         }
         catch(IllegalArgumentException e)
         {
-            log.log(System.Logger.Level.WARNING, () -> "could not find charset by name: " + name + " falling back to utf-8");
+            log.log(WARNING, () -> "could not find charset by name: " + name + " falling back to utf-8",e);
             c = StandardCharsets.UTF_8;
         }
         return c;

--- a/casual/casual-api/src/main/java/se/laz/casual/api/buffer/type/fielded/EncodingInfoProvider.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/buffer/type/fielded/EncodingInfoProvider.java
@@ -11,8 +11,6 @@ import se.laz.casual.config.ConfigurationService;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Provides the encoding information for encoding/decoding strings
@@ -20,7 +18,7 @@ import java.util.logging.Logger;
  */
 public class EncodingInfoProvider
 {
-    private static final Logger log = Logger.getLogger(EncodingInfoProvider.class.getName());
+    private static final System.Logger log = System.getLogger(EncodingInfoProvider.class.getName());
     private EncodingInfoProvider()
     {}
 
@@ -45,7 +43,7 @@ public class EncodingInfoProvider
         }
         catch(IllegalArgumentException e)
         {
-            log.log(Level.WARNING, e, () -> "could not find charset by name: " + name + " falling back to utf-8");
+            log.log(System.Logger.Level.WARNING, () -> "could not find charset by name: " + name + " falling back to utf-8");
             c = StandardCharsets.UTF_8;
         }
         return c;

--- a/casual/casual-api/src/main/java/se/laz/casual/api/util/work/RepeatUntilSuccessTaskWork.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/util/work/RepeatUntilSuccessTaskWork.java
@@ -15,6 +15,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import static java.lang.System.Logger.Level.*;
+
 public class RepeatUntilSuccessTaskWork<T> implements Work
 {
     private static final System.Logger LOG = System.getLogger(RepeatUntilSuccessTaskWork.class.getName());
@@ -59,7 +61,7 @@ public class RepeatUntilSuccessTaskWork<T> implements Work
         catch(Exception e)
         {
             long currentBackoff = backoffHelper.registerFailure();
-            LOG.log(System.Logger.Level.WARNING,() -> "task failed: failure #" + backoffHelper.getFailures() + ", retrying in " + currentBackoff + " " + e);
+            LOG.log(WARNING,() -> "task failed: failure #" + backoffHelper.getFailures() + ", retrying in " + currentBackoff + " " + e,e);
             backoffScheduler.schedule(this::scheduleWork, currentBackoff, TimeUnit.MILLISECONDS);
         }
     }
@@ -89,7 +91,7 @@ public class RepeatUntilSuccessTaskWork<T> implements Work
         }
         catch (WorkException e)
         {
-            LOG.log(System.Logger.Level.WARNING,() -> "failed to schedule work, will retry once: " + e);
+            LOG.log(WARNING,() -> "failed to schedule work, will retry once: " + e,e);
             try
             {
                 workManagerSupplier.get().scheduleWork(this, WorkManager.INDEFINITE, null, RepeatUntilSuccessTaskWorkListener.of());

--- a/casual/casual-api/src/main/java/se/laz/casual/api/util/work/RepeatUntilSuccessTaskWork.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/util/work/RepeatUntilSuccessTaskWork.java
@@ -14,11 +14,10 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import java.util.logging.Logger;
 
 public class RepeatUntilSuccessTaskWork<T> implements Work
 {
-    private static final Logger LOG = Logger.getLogger(RepeatUntilSuccessTaskWork.class.getName());
+    private static final System.Logger LOG = System.getLogger(RepeatUntilSuccessTaskWork.class.getName());
     private final Supplier<T> supplier;
     private final Consumer<T> consumer;
     private final Supplier<WorkManager> workManagerSupplier;
@@ -60,7 +59,7 @@ public class RepeatUntilSuccessTaskWork<T> implements Work
         catch(Exception e)
         {
             long currentBackoff = backoffHelper.registerFailure();
-            LOG.warning(() -> "task failed: failure #" + backoffHelper.getFailures() + ", retrying in " + currentBackoff + " " + e);
+            LOG.log(System.Logger.Level.WARNING,() -> "task failed: failure #" + backoffHelper.getFailures() + ", retrying in " + currentBackoff + " " + e);
             backoffScheduler.schedule(this::scheduleWork, currentBackoff, TimeUnit.MILLISECONDS);
         }
     }
@@ -90,7 +89,7 @@ public class RepeatUntilSuccessTaskWork<T> implements Work
         }
         catch (WorkException e)
         {
-            LOG.warning(() -> "failed to schedule work, will retry once: " + e);
+            LOG.log(System.Logger.Level.WARNING,() -> "failed to schedule work, will retry once: " + e);
             try
             {
                 workManagerSupplier.get().scheduleWork(this, WorkManager.INDEFINITE, null, RepeatUntilSuccessTaskWorkListener.of());

--- a/casual/casual-api/src/main/java/se/laz/casual/api/util/work/RepeatUntilSuccessTaskWorkListener.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/util/work/RepeatUntilSuccessTaskWorkListener.java
@@ -9,6 +9,8 @@ package se.laz.casual.api.util.work;
 import jakarta.resource.spi.work.WorkEvent;
 import jakarta.resource.spi.work.WorkListener;
 
+import static java.lang.System.Logger.Level.*;
+
 public class RepeatUntilSuccessTaskWorkListener implements WorkListener
 {
     private static System.Logger log = System.getLogger( RepeatUntilSuccessTaskWorkListener.class.getName());
@@ -27,7 +29,7 @@ public class RepeatUntilSuccessTaskWorkListener implements WorkListener
     @Override
     public void workRejected(WorkEvent e)
     {
-        log.log(System.Logger.Level.WARNING,() -> "RepeatUntilSuccessTaskWork rejected");
+        log.log(WARNING,() -> "RepeatUntilSuccessTaskWork rejected",e.getException());
     }
 
     @Override
@@ -41,8 +43,8 @@ public class RepeatUntilSuccessTaskWorkListener implements WorkListener
     {
         if(null != event.getException())
         {
-            log.log(System.Logger.Level.WARNING,() -> "workCompleted failed: " + event.getException());
-            log.log(System.Logger.Level.WARNING,() -> "cause: " + event.getException().getCause());
+            log.log(WARNING,() -> "workCompleted failed: " + event.getException(),event.getException());
+            log.log(WARNING,() -> "cause: " + event.getException().getCause(),event.getException());
         }
     }
 }

--- a/casual/casual-api/src/main/java/se/laz/casual/api/util/work/RepeatUntilSuccessTaskWorkListener.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/api/util/work/RepeatUntilSuccessTaskWorkListener.java
@@ -8,11 +8,10 @@ package se.laz.casual.api.util.work;
 
 import jakarta.resource.spi.work.WorkEvent;
 import jakarta.resource.spi.work.WorkListener;
-import java.util.logging.Logger;
 
 public class RepeatUntilSuccessTaskWorkListener implements WorkListener
 {
-    private static Logger log = Logger.getLogger( RepeatUntilSuccessTaskWorkListener.class.getName());
+    private static System.Logger log = System.getLogger( RepeatUntilSuccessTaskWorkListener.class.getName());
 
     public static RepeatUntilSuccessTaskWorkListener of()
     {
@@ -28,7 +27,7 @@ public class RepeatUntilSuccessTaskWorkListener implements WorkListener
     @Override
     public void workRejected(WorkEvent e)
     {
-        log.warning(() -> "RepeatUntilSuccessTaskWork rejected");
+        log.log(System.Logger.Level.WARNING,() -> "RepeatUntilSuccessTaskWork rejected");
     }
 
     @Override
@@ -42,8 +41,8 @@ public class RepeatUntilSuccessTaskWorkListener implements WorkListener
     {
         if(null != event.getException())
         {
-            log.warning(() -> "workCompleted failed: " + event.getException());
-            log.warning(() -> "cause: " + event.getException().getCause());
+            log.log(System.Logger.Level.WARNING,() -> "workCompleted failed: " + event.getException());
+            log.log(System.Logger.Level.WARNING,() -> "cause: " + event.getException().getCause());
         }
     }
 }

--- a/casual/casual-api/src/main/java/se/laz/casual/config/ConfigurationEnvsReader.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/config/ConfigurationEnvsReader.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static java.lang.System.Logger.Level.*;
+
 /**
  * Read system environment variables to populate the configuration store appropriately.
  * <br/>
@@ -179,7 +181,7 @@ public class ConfigurationEnvsReader
         {
             Supplier<String> message =
                     () -> "Invalid environment variable data: " + name + " has value: '" + value + "'.";
-            logger.log(System.Logger.Level.ERROR, message );
+            logger.log(ERROR, message );
             throw new ConfigurationException( message.get(), e );
         }
     }

--- a/casual/casual-api/src/main/java/se/laz/casual/config/ConfigurationEnvsReader.java
+++ b/casual/casual-api/src/main/java/se/laz/casual/config/ConfigurationEnvsReader.java
@@ -9,7 +9,6 @@ package se.laz.casual.config;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.logging.Logger;
 
 /**
  * Read system environment variables to populate the configuration store appropriately.
@@ -19,7 +18,7 @@ import java.util.logging.Logger;
  */
 public class ConfigurationEnvsReader
 {
-    private static final Logger logger = Logger.getLogger( ConfigurationEnvsReader.class.getName() );
+    private static final System.Logger logger = System.getLogger( ConfigurationEnvsReader.class.getName() );
 
     private final ConfigurationStore store;
 
@@ -180,7 +179,7 @@ public class ConfigurationEnvsReader
         {
             Supplier<String> message =
                     () -> "Invalid environment variable data: " + name + " has value: '" + value + "'.";
-            logger.severe( message );
+            logger.log(System.Logger.Level.ERROR, message );
             throw new ConfigurationException( message.get(), e );
         }
     }

--- a/casual/casual-event-api/src/main/java/se/laz/casual/event/Process.java
+++ b/casual/casual-event-api/src/main/java/se/laz/casual/event/Process.java
@@ -5,12 +5,10 @@
  */
 package se.laz.casual.event;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public final class Process
 {
-    private static final Logger LOG = Logger.getLogger(Process.class.getName());
+    private static final System.Logger LOG = System.getLogger(Process.class.getName());
     private static final long CAN_NOT_GET_PID = -1L;
     private static long currentPID = CAN_NOT_GET_PID;
     private Process()
@@ -23,7 +21,7 @@ public final class Process
         }
         catch(Exception e)
         {
-            LOG.log(Level.WARNING, e, () -> "could not get process id");
+            LOG.log(System.Logger.Level.WARNING, () -> "could not get process id");
         }
         return currentPID;
     }

--- a/casual/casual-event-api/src/main/java/se/laz/casual/event/Process.java
+++ b/casual/casual-event-api/src/main/java/se/laz/casual/event/Process.java
@@ -5,6 +5,7 @@
  */
 package se.laz.casual.event;
 
+import static java.lang.System.Logger.Level.*;
 
 public final class Process
 {
@@ -21,7 +22,7 @@ public final class Process
         }
         catch(Exception e)
         {
-            LOG.log(System.Logger.Level.WARNING, () -> "could not get process id");
+            LOG.log(WARNING, () -> "could not get process id",e);
         }
         return currentPID;
     }

--- a/casual/casual-event-api/src/main/java/se/laz/casual/event/ServiceCallEventPublisher.java
+++ b/casual/casual-event-api/src/main/java/se/laz/casual/event/ServiceCallEventPublisher.java
@@ -9,6 +9,8 @@ import se.laz.casual.jca.RuntimeInformation;
 
 import java.util.Objects;
 
+import static java.lang.System.Logger.Level.*;
+
 public class ServiceCallEventPublisher
 {
     private static final System.Logger log = System.getLogger(ServiceCallEventPublisher.class.getName());
@@ -45,7 +47,7 @@ public class ServiceCallEventPublisher
         catch(Exception ee)
         {
             // catch,almost all, since failure to post should not impact any service call flow
-            log.log(System.Logger.Level.WARNING, () -> "Failed to post service call event - metrics will not be available for " + event);
+            log.log(WARNING, () -> "Failed to post service call event - metrics will not be available for " + event,ee);
         }
     }
 

--- a/casual/casual-event-api/src/main/java/se/laz/casual/event/ServiceCallEventPublisher.java
+++ b/casual/casual-event-api/src/main/java/se/laz/casual/event/ServiceCallEventPublisher.java
@@ -8,12 +8,10 @@ package se.laz.casual.event;
 import se.laz.casual.jca.RuntimeInformation;
 
 import java.util.Objects;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class ServiceCallEventPublisher
 {
-    private static final Logger log = Logger.getLogger(ServiceCallEventPublisher.class.getName());
+    private static final System.Logger log = System.getLogger(ServiceCallEventPublisher.class.getName());
     private final ServiceCallEventStore handler;
 
     private ServiceCallEventPublisher(ServiceCallEventStore handler)
@@ -47,7 +45,7 @@ public class ServiceCallEventPublisher
         catch(Exception ee)
         {
             // catch,almost all, since failure to post should not impact any service call flow
-            log.log(Level.WARNING, ee, () -> "Failed to post service call event - metrics will not be available for " + event);
+            log.log(System.Logger.Level.WARNING, () -> "Failed to post service call event - metrics will not be available for " + event);
         }
     }
 

--- a/casual/casual-event-client/src/main/java/se/laz/casual/event/client/EventClient.java
+++ b/casual/casual-event-client/src/main/java/se/laz/casual/event/client/EventClient.java
@@ -22,7 +22,6 @@ import se.laz.casual.event.client.messages.ConnectionMessage;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Logger;
 
 /**
  * Can be used to consume events from casuals EventServer
@@ -37,7 +36,7 @@ import java.util.logging.Logger;
  */
 public class EventClient
 {
-    private static final Logger LOG = Logger.getLogger(EventClient.class.getName());
+    private static final System.Logger LOG = System.getLogger(EventClient.class.getName());
     private final Channel channel;
     private final CompletableFuture<Boolean> connectFuture;
     private final AtomicBoolean connected = new AtomicBoolean(true);
@@ -109,7 +108,7 @@ public class EventClient
                         }
                     }
                 });
-        LOG.finest(() -> "about to connect to: " + clientInformation.getConnectionInformation().getAddress());
+        LOG.log(System.Logger.Level.TRACE,() -> "about to connect to: " + clientInformation.getConnectionInformation().getAddress());
         return b.connect(clientInformation.getConnectionInformation().getAddress()).syncUninterruptibly().channel();
     }
 }

--- a/casual/casual-event-client/src/main/java/se/laz/casual/event/client/EventClient.java
+++ b/casual/casual-event-client/src/main/java/se/laz/casual/event/client/EventClient.java
@@ -23,6 +23,8 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static java.lang.System.Logger.Level.*;
+
 /**
  * Can be used to consume events from casuals EventServer
  *
@@ -108,7 +110,7 @@ public class EventClient
                         }
                     }
                 });
-        LOG.log(System.Logger.Level.TRACE,() -> "about to connect to: " + clientInformation.getConnectionInformation().getAddress());
+        LOG.log(DEBUG,() -> "about to connect to: " + clientInformation.getConnectionInformation().getAddress());
         return b.connect(clientInformation.getConnectionInformation().getAddress()).syncUninterruptibly().channel();
     }
 }

--- a/casual/casual-event-client/src/main/java/se/laz/casual/event/client/handlers/ExceptionHandler.java
+++ b/casual/casual-event-client/src/main/java/se/laz/casual/event/client/handlers/ExceptionHandler.java
@@ -8,6 +8,8 @@ package se.laz.casual.event.client.handlers;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 
+import static java.lang.System.Logger.Level.*;
+
 public class ExceptionHandler extends ChannelInboundHandlerAdapter
 {
     private static final System.Logger LOG = System.getLogger(ExceptionHandler.class.getName());
@@ -18,7 +20,7 @@ public class ExceptionHandler extends ChannelInboundHandlerAdapter
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)
     {
-        LOG.log(System.Logger.Level.WARNING, () -> String.format("Exception caught %s - closing connection", cause.getMessage()));
+        LOG.log(WARNING, () -> String.format("Exception caught %s - closing connection", cause.getMessage()),cause);
         ctx.close();
     }
 }

--- a/casual/casual-event-client/src/main/java/se/laz/casual/event/client/handlers/ExceptionHandler.java
+++ b/casual/casual-event-client/src/main/java/se/laz/casual/event/client/handlers/ExceptionHandler.java
@@ -8,12 +8,9 @@ package se.laz.casual.event.client.handlers;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 public class ExceptionHandler extends ChannelInboundHandlerAdapter
 {
-    private static final Logger LOG = Logger.getLogger(ExceptionHandler.class.getName());
+    private static final System.Logger LOG = System.getLogger(ExceptionHandler.class.getName());
     public static ExceptionHandler of()
     {
         return new ExceptionHandler();
@@ -21,7 +18,7 @@ public class ExceptionHandler extends ChannelInboundHandlerAdapter
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)
     {
-        LOG.log(Level.WARNING, cause, () -> String.format("Exception caught %s - closing connection", cause.getMessage()));
+        LOG.log(System.Logger.Level.WARNING, () -> String.format("Exception caught %s - closing connection", cause.getMessage()));
         ctx.close();
     }
 }

--- a/casual/casual-event-client/src/main/java/se/laz/casual/event/client/handlers/FromJSONEventMessageDecoder.java
+++ b/casual/casual-event-client/src/main/java/se/laz/casual/event/client/handlers/FromJSONEventMessageDecoder.java
@@ -15,11 +15,10 @@ import se.laz.casual.event.client.EventObserver;
 
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import java.util.logging.Logger;
 
 public class FromJSONEventMessageDecoder extends SimpleChannelInboundHandler<Object>
 {
-    private static final Logger LOG = Logger.getLogger(FromJSONEventMessageDecoder.class.getName());
+    private static final System.Logger LOG = System.getLogger(FromJSONEventMessageDecoder.class.getName());
     private final CompletableFuture<Boolean> connectFuture;
 
     private enum State{
@@ -53,7 +52,7 @@ public class FromJSONEventMessageDecoder extends SimpleChannelInboundHandler<Obj
         {
             ServiceCallEvent event = JsonProviderFactory.getJsonProvider().fromJson(json, ServiceCallEvent.class);
             observer.notify(event);
-            LOG.finest(() -> "read msg: " + event + " on channel: " + channelHandlerContext.channel());
+            LOG.log(System.Logger.Level.TRACE,() -> "read msg: " + event + " on channel: " + channelHandlerContext.channel());
         }
     }
 }

--- a/casual/casual-event-client/src/main/java/se/laz/casual/event/client/handlers/FromJSONEventMessageDecoder.java
+++ b/casual/casual-event-client/src/main/java/se/laz/casual/event/client/handlers/FromJSONEventMessageDecoder.java
@@ -16,6 +16,8 @@ import se.laz.casual.event.client.EventObserver;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
+import static java.lang.System.Logger.Level.*;
+
 public class FromJSONEventMessageDecoder extends SimpleChannelInboundHandler<Object>
 {
     private static final System.Logger LOG = System.getLogger(FromJSONEventMessageDecoder.class.getName());
@@ -52,7 +54,7 @@ public class FromJSONEventMessageDecoder extends SimpleChannelInboundHandler<Obj
         {
             ServiceCallEvent event = JsonProviderFactory.getJsonProvider().fromJson(json, ServiceCallEvent.class);
             observer.notify(event);
-            LOG.log(System.Logger.Level.TRACE,() -> "read msg: " + event + " on channel: " + channelHandlerContext.channel());
+            LOG.log(DEBUG,() -> "read msg: " + event + " on channel: " + channelHandlerContext.channel());
         }
     }
 }

--- a/casual/casual-event-server/src/main/java/se/laz/casual/event/server/DefaultMessageLoop.java
+++ b/casual/casual-event-server/src/main/java/se/laz/casual/event/server/DefaultMessageLoop.java
@@ -11,11 +11,10 @@ import se.laz.casual.event.ServiceCallEventStore;
 
 import java.util.Objects;
 import java.util.function.BooleanSupplier;
-import java.util.logging.Logger;
 
 public class DefaultMessageLoop implements MessageLoop
 {
-    private static final Logger log = Logger.getLogger(DefaultMessageLoop.class.getName());
+    private static final System.Logger log = System.getLogger(DefaultMessageLoop.class.getName());
     private final ChannelGroup connectedClients;
     private final ServiceCallEventStore serviceCallEventStore;
     private BooleanSupplier continueLoop = () -> false;
@@ -38,8 +37,8 @@ public class DefaultMessageLoop implements MessageLoop
         while (continueLoop.getAsBoolean())
         {
             ServiceCallEvent event = serviceCallEventStore.take();
-            log.finest(() -> "# of clients: " + connectedClients.size());
-            log.finest(() -> "writing: " + event + " to all clients");
+            log.log(System.Logger.Level.TRACE,() -> "# of clients: " + connectedClients.size());
+            log.log(System.Logger.Level.TRACE,() -> "writing: " + event + " to all clients");
             connectedClients.writeAndFlush(event);
         }
     }

--- a/casual/casual-event-server/src/main/java/se/laz/casual/event/server/DefaultMessageLoop.java
+++ b/casual/casual-event-server/src/main/java/se/laz/casual/event/server/DefaultMessageLoop.java
@@ -12,6 +12,8 @@ import se.laz.casual.event.ServiceCallEventStore;
 import java.util.Objects;
 import java.util.function.BooleanSupplier;
 
+import static java.lang.System.Logger.Level.*;
+
 public class DefaultMessageLoop implements MessageLoop
 {
     private static final System.Logger log = System.getLogger(DefaultMessageLoop.class.getName());
@@ -37,8 +39,8 @@ public class DefaultMessageLoop implements MessageLoop
         while (continueLoop.getAsBoolean())
         {
             ServiceCallEvent event = serviceCallEventStore.take();
-            log.log(System.Logger.Level.TRACE,() -> "# of clients: " + connectedClients.size());
-            log.log(System.Logger.Level.TRACE,() -> "writing: " + event + " to all clients");
+            log.log(DEBUG,() -> "# of clients: " + connectedClients.size());
+            log.log(DEBUG,() -> "writing: " + event + " to all clients");
             connectedClients.writeAndFlush(event);
         }
     }

--- a/casual/casual-event-server/src/main/java/se/laz/casual/event/server/DefaultServerInitialization.java
+++ b/casual/casual-event-server/src/main/java/se/laz/casual/event/server/DefaultServerInitialization.java
@@ -23,6 +23,8 @@ import se.laz.casual.event.server.handlers.FromJSONConnectDecoder;
 import java.net.InetSocketAddress;
 import java.util.Objects;
 
+import static java.lang.System.Logger.Level.*;
+
 public class DefaultServerInitialization implements ServerInitialization
 {
     private static final System.Logger log = System.getLogger(DefaultServerInitialization.class.getName());
@@ -54,7 +56,7 @@ public class DefaultServerInitialization implements ServerInitialization
                         if (connectionInformation.isLogHandlerEnabled())
                         {
                             ch.pipeline().addFirst(LOG_HANDLER_NAME, new LoggingHandler());
-                            log.log(System.Logger.Level.INFO,() -> "EventServer network log handler enabled");
+                            log.log(INFO,() -> "EventServer network log handler enabled");
                         }
                     }
                 }).childOption(ChannelOption.SO_KEEPALIVE, true);

--- a/casual/casual-event-server/src/main/java/se/laz/casual/event/server/DefaultServerInitialization.java
+++ b/casual/casual-event-server/src/main/java/se/laz/casual/event/server/DefaultServerInitialization.java
@@ -22,11 +22,10 @@ import se.laz.casual.event.server.handlers.FromJSONConnectDecoder;
 
 import java.net.InetSocketAddress;
 import java.util.Objects;
-import java.util.logging.Logger;
 
 public class DefaultServerInitialization implements ServerInitialization
 {
-    private static final Logger log = Logger.getLogger(DefaultServerInitialization.class.getName());
+    private static final System.Logger log = System.getLogger(DefaultServerInitialization.class.getName());
     private static final String LOG_HANDLER_NAME = "logHandler";
 
     private DefaultServerInitialization()
@@ -55,7 +54,7 @@ public class DefaultServerInitialization implements ServerInitialization
                         if (connectionInformation.isLogHandlerEnabled())
                         {
                             ch.pipeline().addFirst(LOG_HANDLER_NAME, new LoggingHandler());
-                            log.info(() -> "EventServer network log handler enabled");
+                            log.log(System.Logger.Level.INFO,() -> "EventServer network log handler enabled");
                         }
                     }
                 }).childOption(ChannelOption.SO_KEEPALIVE, true);

--- a/casual/casual-event-server/src/main/java/se/laz/casual/event/server/EventServer.java
+++ b/casual/casual-event-server/src/main/java/se/laz/casual/event/server/EventServer.java
@@ -19,6 +19,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import static java.lang.System.Logger.Level.*;
+
 public class EventServer
 {
     private static final System.Logger log = System.getLogger(EventServer.class.getName());
@@ -73,10 +75,10 @@ public class EventServer
 
     public void close()
     {
-        log.log(System.Logger.Level.INFO,() -> "closing event server");
+        log.log(INFO,() -> "closing event server");
         bossGroup.shutdownGracefully( shutdownQuietPeriod, shutdownTimeout, TimeUnit.MILLISECONDS ).syncUninterruptibly();
         workerGroup.shutdownGracefully( shutdownQuietPeriod, shutdownTimeout, TimeUnit.MILLISECONDS ).syncUninterruptibly();
-        log.log(System.Logger.Level.INFO,() -> "event server closed");
+        log.log(INFO,() -> "event server closed");
     }
 
 }

--- a/casual/casual-event-server/src/main/java/se/laz/casual/event/server/EventServer.java
+++ b/casual/casual-event-server/src/main/java/se/laz/casual/event/server/EventServer.java
@@ -18,11 +18,10 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 
 public class EventServer
 {
-    private static final Logger log = Logger.getLogger(EventServer.class.getName());
+    private static final System.Logger log = System.getLogger(EventServer.class.getName());
     private final Channel channel;
     private final long shutdownQuietPeriod;
     private final long shutdownTimeout;
@@ -74,10 +73,10 @@ public class EventServer
 
     public void close()
     {
-        log.info(() -> "closing event server");
+        log.log(System.Logger.Level.INFO,() -> "closing event server");
         bossGroup.shutdownGracefully( shutdownQuietPeriod, shutdownTimeout, TimeUnit.MILLISECONDS ).syncUninterruptibly();
         workerGroup.shutdownGracefully( shutdownQuietPeriod, shutdownTimeout, TimeUnit.MILLISECONDS ).syncUninterruptibly();
-        log.info(() -> "event server closed");
+        log.log(System.Logger.Level.INFO,() -> "event server closed");
     }
 
 }

--- a/casual/casual-event-server/src/main/java/se/laz/casual/event/server/handlers/ExceptionHandler.java
+++ b/casual/casual-event-server/src/main/java/se/laz/casual/event/server/handlers/ExceptionHandler.java
@@ -11,12 +11,10 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.group.ChannelGroup;
 
-import java.util.logging.Logger;
-
 @ChannelHandler.Sharable
 public final class ExceptionHandler extends ChannelInboundHandlerAdapter
 {
-    private static final Logger log = Logger.getLogger(ExceptionHandler.class.getName());
+    private static final System.Logger log = System.getLogger(ExceptionHandler.class.getName());
     private final ChannelGroup connectedClients;
 
     public ExceptionHandler(ChannelGroup connectedClients)
@@ -32,7 +30,7 @@ public final class ExceptionHandler extends ChannelInboundHandlerAdapter
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)
     {
-        log.warning(() -> "EventServer exception caught: " + cause + " closing channel: " + ctx.channel());
+        log.log(System.Logger.Level.WARNING,() -> "EventServer exception caught: " + cause + " closing channel: " + ctx.channel());
         connectedClients.remove(ctx.channel());
         ctx.close();
     }

--- a/casual/casual-event-server/src/main/java/se/laz/casual/event/server/handlers/ExceptionHandler.java
+++ b/casual/casual-event-server/src/main/java/se/laz/casual/event/server/handlers/ExceptionHandler.java
@@ -11,6 +11,8 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.group.ChannelGroup;
 
+import static java.lang.System.Logger.Level.*;
+
 @ChannelHandler.Sharable
 public final class ExceptionHandler extends ChannelInboundHandlerAdapter
 {
@@ -30,7 +32,7 @@ public final class ExceptionHandler extends ChannelInboundHandlerAdapter
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)
     {
-        log.log(System.Logger.Level.WARNING,() -> "EventServer exception caught: " + cause + " closing channel: " + ctx.channel());
+        log.log(WARNING,() -> "EventServer exception caught: " + cause + " closing channel: " + ctx.channel(),cause);
         connectedClients.remove(ctx.channel());
         ctx.close();
     }

--- a/casual/casual-event-server/src/main/java/se/laz/casual/event/server/handlers/FromJSONConnectDecoder.java
+++ b/casual/casual-event-server/src/main/java/se/laz/casual/event/server/handlers/FromJSONConnectDecoder.java
@@ -17,12 +17,11 @@ import se.laz.casual.event.server.messages.ConnectRequestMessage;
 import se.laz.casual.event.server.messages.ConnectRequestMessageTypeAdapter;
 
 import java.util.Objects;
-import java.util.logging.Logger;
 
 @ChannelHandler.Sharable
 public class FromJSONConnectDecoder extends SimpleChannelInboundHandler<Object>
 {
-    private static final Logger log = Logger.getLogger(FromJSONConnectDecoder.class.getName());
+    private static final System.Logger log = System.getLogger(FromJSONConnectDecoder.class.getName());
     private static final ConnectionReplier CONNECTION_REPLIER = ConnectionReplier.of();
     private final ChannelGroup connectedClients;
 
@@ -48,6 +47,6 @@ public class FromJSONConnectDecoder extends SimpleChannelInboundHandler<Object>
         CONNECTION_REPLIER.clientConnected(ctx.channel()).join();
         connectedClients.add(ctx.channel());
         ctx.fireChannelRead(requestMessage);
-        log.finest(() -> "EventServer, client logged on: " + requestMessage + " channel: " + ctx.channel());
+        log.log(System.Logger.Level.TRACE,() -> "EventServer, client logged on: " + requestMessage + " channel: " + ctx.channel());
     }
 }

--- a/casual/casual-event-server/src/main/java/se/laz/casual/event/server/handlers/FromJSONConnectDecoder.java
+++ b/casual/casual-event-server/src/main/java/se/laz/casual/event/server/handlers/FromJSONConnectDecoder.java
@@ -18,6 +18,8 @@ import se.laz.casual.event.server.messages.ConnectRequestMessageTypeAdapter;
 
 import java.util.Objects;
 
+import static java.lang.System.Logger.Level.*;
+
 @ChannelHandler.Sharable
 public class FromJSONConnectDecoder extends SimpleChannelInboundHandler<Object>
 {
@@ -47,6 +49,6 @@ public class FromJSONConnectDecoder extends SimpleChannelInboundHandler<Object>
         CONNECTION_REPLIER.clientConnected(ctx.channel()).join();
         connectedClients.add(ctx.channel());
         ctx.fireChannelRead(requestMessage);
-        log.log(System.Logger.Level.TRACE,() -> "EventServer, client logged on: " + requestMessage + " channel: " + ctx.channel());
+        log.log(DEBUG,() -> "EventServer, client logged on: " + requestMessage + " channel: " + ctx.channel());
     }
 }

--- a/casual/casual-event-server/src/main/java/se/laz/casual/event/server/messages/ConnectRequestMessageTypeAdapter.java
+++ b/casual/casual-event-server/src/main/java/se/laz/casual/event/server/messages/ConnectRequestMessageTypeAdapter.java
@@ -12,6 +12,8 @@ import com.google.gson.JsonParseException;
 
 import java.lang.reflect.Type;
 
+import static java.lang.System.Logger.Level.*;
+
 public class ConnectRequestMessageTypeAdapter implements JsonDeserializer<ConnectRequestMessage>
 {
     private static final System.Logger log = System.getLogger(ConnectRequestMessageTypeAdapter.class.getName());
@@ -23,7 +25,7 @@ public class ConnectRequestMessageTypeAdapter implements JsonDeserializer<Connec
     public ConnectRequestMessage deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException
     {
         String message = json.getAsJsonObject().get("message").getAsString();
-        log.log(System.Logger.Level.TRACE,() -> "message: " + message);
+        log.log(DEBUG,() -> "message: " + message);
         ConnectRequest connectRequest = ConnectRequest.unmarshall(message);
         return ConnectRequestMessage.of(connectRequest);
     }

--- a/casual/casual-event-server/src/main/java/se/laz/casual/event/server/messages/ConnectRequestMessageTypeAdapter.java
+++ b/casual/casual-event-server/src/main/java/se/laz/casual/event/server/messages/ConnectRequestMessageTypeAdapter.java
@@ -11,11 +11,10 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 
 import java.lang.reflect.Type;
-import java.util.logging.Logger;
 
 public class ConnectRequestMessageTypeAdapter implements JsonDeserializer<ConnectRequestMessage>
 {
-    private static final Logger log = Logger.getLogger(ConnectRequestMessageTypeAdapter.class.getName());
+    private static final System.Logger log = System.getLogger(ConnectRequestMessageTypeAdapter.class.getName());
     public static ConnectRequestMessageTypeAdapter of()
     {
         return new ConnectRequestMessageTypeAdapter();
@@ -24,7 +23,7 @@ public class ConnectRequestMessageTypeAdapter implements JsonDeserializer<Connec
     public ConnectRequestMessage deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException
     {
         String message = json.getAsJsonObject().get("message").getAsString();
-        log.finest(() -> "message: " + message);
+        log.log(System.Logger.Level.TRACE,() -> "message: " + message);
         ConnectRequest connectRequest = ConnectRequest.unmarshall(message);
         return ConnectRequestMessage.of(connectRequest);
     }

--- a/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/CasualActivationSpec.java
+++ b/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/CasualActivationSpec.java
@@ -10,6 +10,8 @@ import jakarta.resource.spi.ActivationSpec;
 import jakarta.resource.spi.InvalidPropertyException;
 import jakarta.resource.spi.ResourceAdapter;
 
+import static java.lang.System.Logger.Level.*;
+
 /**
  * Activation Specification for Inbound Message Listener.
  */
@@ -34,21 +36,21 @@ public class CasualActivationSpec implements ActivationSpec
    @Override
    public void validate() throws InvalidPropertyException
    {
-      logger.log(System.Logger.Level.TRACE,"validate()");
+      logger.log(DEBUG,"validate()");
 
    }
 
    @Override
    public ResourceAdapter getResourceAdapter()
    {
-      logger.log(System.Logger.Level.TRACE,"getResourceAdapter()");
+      logger.log(DEBUG,"getResourceAdapter()");
       return ra;
    }
 
    @Override
    public void setResourceAdapter(ResourceAdapter ra)
    {
-      logger.log(System.Logger.Level.TRACE,"setResourceAdapter()");
+      logger.log(DEBUG,"setResourceAdapter()");
       this.ra = ra;
    }
 

--- a/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/CasualActivationSpec.java
+++ b/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/CasualActivationSpec.java
@@ -9,7 +9,6 @@ import jakarta.resource.spi.Activation;
 import jakarta.resource.spi.ActivationSpec;
 import jakarta.resource.spi.InvalidPropertyException;
 import jakarta.resource.spi.ResourceAdapter;
-import java.util.logging.Logger;
 
 /**
  * Activation Specification for Inbound Message Listener.
@@ -17,7 +16,7 @@ import java.util.logging.Logger;
 @Activation(messageListeners = { CasualMessageListener.class })
 public class CasualActivationSpec implements ActivationSpec
 {
-   private static Logger logger = Logger.getLogger(CasualActivationSpec.class.getName());
+   private static System.Logger logger = System.getLogger(CasualActivationSpec.class.getName());
    private ResourceAdapter ra;
 
    private Integer port;
@@ -35,21 +34,21 @@ public class CasualActivationSpec implements ActivationSpec
    @Override
    public void validate() throws InvalidPropertyException
    {
-      logger.finest("validate()");
+      logger.log(System.Logger.Level.TRACE,"validate()");
 
    }
 
    @Override
    public ResourceAdapter getResourceAdapter()
    {
-      logger.finest("getResourceAdapter()");
+      logger.log(System.Logger.Level.TRACE,"getResourceAdapter()");
       return ra;
    }
 
    @Override
    public void setResourceAdapter(ResourceAdapter ra)
    {
-      logger.finest("setResourceAdapter()");
+      logger.log(System.Logger.Level.TRACE,"setResourceAdapter()");
       this.ra = ra;
    }
 

--- a/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/CasualInboundTransactionRegistry.java
+++ b/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/CasualInboundTransactionRegistry.java
@@ -12,11 +12,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Logger;
 
 public class CasualInboundTransactionRegistry
 {
-    private static final Logger log = Logger.getLogger(CasualInboundTransactionRegistry.class.getName());
+    private static final System.Logger log = System.getLogger(CasualInboundTransactionRegistry.class.getName());
     private static final String CHANNEL_ID_CAN_NOT_BE_NULL = "channelId can not be null";
     private final Map<ChannelId, Set<XidKey>> transactions = new ConcurrentHashMap<>();
 
@@ -24,14 +23,14 @@ public class CasualInboundTransactionRegistry
     {
         Objects.requireNonNull(channelId, CHANNEL_ID_CAN_NOT_BE_NULL);
         Objects.requireNonNull(key, "key can not be null");
-        log.finest(() -> "adding transaction " + key + " for channel id: " + channelId + " to inbound transaction registry");
+        log.log(System.Logger.Level.TRACE,() -> "adding transaction " + key + " for channel id: " + channelId + " to inbound transaction registry");
         transactions.computeIfAbsent(channelId, id -> ConcurrentHashMap.newKeySet()).add(key);
     }
     public void remove(ChannelId channelId, XidKey key)
     {
         Objects.requireNonNull(channelId, CHANNEL_ID_CAN_NOT_BE_NULL);
         Objects.requireNonNull(key, "key can not be null");
-        log.finest(() -> "removing transaction " + key + "for channel id: " + channelId +" from transaction registry");
+        log.log(System.Logger.Level.TRACE,() -> "removing transaction " + key + "for channel id: " + channelId +" from transaction registry");
         transactions.computeIfPresent(channelId, (id, set) ->{
            set.remove(key);
            return set.isEmpty() ? null : set;
@@ -41,13 +40,13 @@ public class CasualInboundTransactionRegistry
     public void remove(ChannelId channelId)
     {
         Objects.requireNonNull(channelId, CHANNEL_ID_CAN_NOT_BE_NULL);
-        log.finest(() -> "Removing all pending transactions for " + channelId + " from transaction registry");
+        log.log(System.Logger.Level.TRACE,() -> "Removing all pending transactions for " + channelId + " from transaction registry");
         transactions.remove(channelId);
     }
 
     public boolean hasPending()
     {
-        log.finest(() -> "# of inbound pending: " + transactions.size());
+        log.log(System.Logger.Level.TRACE,() -> "# of inbound pending: " + transactions.size());
         return !transactions.isEmpty();
     }
 }

--- a/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/CasualInboundTransactionRegistry.java
+++ b/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/CasualInboundTransactionRegistry.java
@@ -13,6 +13,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static java.lang.System.Logger.Level.*;
+
 public class CasualInboundTransactionRegistry
 {
     private static final System.Logger log = System.getLogger(CasualInboundTransactionRegistry.class.getName());
@@ -23,14 +25,14 @@ public class CasualInboundTransactionRegistry
     {
         Objects.requireNonNull(channelId, CHANNEL_ID_CAN_NOT_BE_NULL);
         Objects.requireNonNull(key, "key can not be null");
-        log.log(System.Logger.Level.TRACE,() -> "adding transaction " + key + " for channel id: " + channelId + " to inbound transaction registry");
+        log.log(DEBUG,() -> "adding transaction " + key + " for channel id: " + channelId + " to inbound transaction registry");
         transactions.computeIfAbsent(channelId, id -> ConcurrentHashMap.newKeySet()).add(key);
     }
     public void remove(ChannelId channelId, XidKey key)
     {
         Objects.requireNonNull(channelId, CHANNEL_ID_CAN_NOT_BE_NULL);
         Objects.requireNonNull(key, "key can not be null");
-        log.log(System.Logger.Level.TRACE,() -> "removing transaction " + key + "for channel id: " + channelId +" from transaction registry");
+        log.log(DEBUG,() -> "removing transaction " + key + "for channel id: " + channelId +" from transaction registry");
         transactions.computeIfPresent(channelId, (id, set) ->{
            set.remove(key);
            return set.isEmpty() ? null : set;
@@ -40,13 +42,13 @@ public class CasualInboundTransactionRegistry
     public void remove(ChannelId channelId)
     {
         Objects.requireNonNull(channelId, CHANNEL_ID_CAN_NOT_BE_NULL);
-        log.log(System.Logger.Level.TRACE,() -> "Removing all pending transactions for " + channelId + " from transaction registry");
+        log.log(DEBUG,() -> "Removing all pending transactions for " + channelId + " from transaction registry");
         transactions.remove(channelId);
     }
 
     public boolean hasPending()
     {
-        log.log(System.Logger.Level.TRACE,() -> "# of inbound pending: " + transactions.size());
+        log.log(DEBUG,() -> "# of inbound pending: " + transactions.size());
         return !transactions.isEmpty();
     }
 }

--- a/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/work/CasualServiceCallWork.java
+++ b/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/work/CasualServiceCallWork.java
@@ -22,14 +22,13 @@ import se.laz.casual.network.protocol.messages.service.CasualServiceCallReplyMes
 import se.laz.casual.network.protocol.messages.service.CasualServiceCallRequestMessage;
 
 import java.util.UUID;
-import java.util.logging.Logger;
 
 /**
  * Work instance for performing inbound casual service call requests within the work manager.
  */
 public final class CasualServiceCallWork implements Work
 {
-    private static final Logger log = Logger.getLogger(CasualServiceCallWork.class.getName());
+    private static final System.Logger log = System.getLogger(CasualServiceCallWork.class.getName());
 
     private final CasualServiceCallRequestMessage message;
     private final UUID correlationId;
@@ -95,7 +94,7 @@ public final class CasualServiceCallWork implements Work
         }
         catch( ServiceHandlerNotFoundException e)
         {
-            log.warning( ()-> "ServiceHandler not available for: " + message.getServiceName() );
+            log.log(System.Logger.Level.WARNING,()-> "ServiceHandler not available for: " + message.getServiceName() );
         }
     }
 
@@ -119,7 +118,7 @@ public final class CasualServiceCallWork implements Work
         {
             replyBuilder.setError( ErrorState.TPENOENT )
                         .setTransactionState( TransactionState.ROLLBACK_ONLY );
-            log.warning( ()-> "ServiceHandler not available for: " + message.getServiceName() );
+            log.log(System.Logger.Level.WARNING,()-> "ServiceHandler not available for: " + message.getServiceName() );
         }
         finally
         {

--- a/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/work/CasualServiceCallWork.java
+++ b/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/work/CasualServiceCallWork.java
@@ -23,6 +23,8 @@ import se.laz.casual.network.protocol.messages.service.CasualServiceCallRequestM
 
 import java.util.UUID;
 
+import static java.lang.System.Logger.Level.*;
+
 /**
  * Work instance for performing inbound casual service call requests within the work manager.
  */
@@ -94,7 +96,7 @@ public final class CasualServiceCallWork implements Work
         }
         catch( ServiceHandlerNotFoundException e)
         {
-            log.log(System.Logger.Level.WARNING,()-> "ServiceHandler not available for: " + message.getServiceName() );
+            log.log(WARNING,()-> "ServiceHandler not available for: " + message.getServiceName() ,e);
         }
     }
 
@@ -118,7 +120,7 @@ public final class CasualServiceCallWork implements Work
         {
             replyBuilder.setError( ErrorState.TPENOENT )
                         .setTransactionState( TransactionState.ROLLBACK_ONLY );
-            log.log(System.Logger.Level.WARNING,()-> "ServiceHandler not available for: " + message.getServiceName() );
+            log.log(WARNING,()-> "ServiceHandler not available for: " + message.getServiceName(),e );
         }
         finally
         {

--- a/casual/casual-inbound-handler-api/src/main/java/se/laz/casual/jca/inbound/handler/service/ServiceHandlerFactory.java
+++ b/casual/casual-inbound-handler-api/src/main/java/se/laz/casual/jca/inbound/handler/service/ServiceHandlerFactory.java
@@ -15,6 +15,8 @@ import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static java.lang.System.Logger.Level.*;
+
 /**
  * SPI factory for retrieving registered {@link ServiceHandler} instances.
  */
@@ -66,7 +68,7 @@ public final class ServiceHandlerFactory
             if( h.canHandleService( serviceName ) )
             {
                 serviceHandlerCache.put( serviceName, h );
-                LOG.log(System.Logger.Level.TRACE,() -> "service handler: " + h + " chosen for service: " + serviceName);
+                LOG.log(DEBUG,() -> "service handler: " + h + " chosen for service: " + serviceName);
                 return h;
             }
         }
@@ -75,7 +77,7 @@ public final class ServiceHandlerFactory
 
     private static void log(List<ServiceHandler> handlers)
     {
-        LOG.log(System.Logger.Level.TRACE,()-> "# of service handlers: " + handlers.size() + "\n" + logHandlers(handlers));
+        LOG.log(DEBUG,()-> "# of service handlers: " + handlers.size() + "\n" + logHandlers(handlers));
     }
 
     private static String logHandlers(List<ServiceHandler> handlers)

--- a/casual/casual-inbound-handler-api/src/main/java/se/laz/casual/jca/inbound/handler/service/ServiceHandlerFactory.java
+++ b/casual/casual-inbound-handler-api/src/main/java/se/laz/casual/jca/inbound/handler/service/ServiceHandlerFactory.java
@@ -14,14 +14,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Logger;
 
 /**
  * SPI factory for retrieving registered {@link ServiceHandler} instances.
  */
 public final class ServiceHandlerFactory
 {
-    private static final Logger LOG = Logger.getLogger(ServiceHandlerFactory.class.getName());
+    private static final System.Logger LOG = System.getLogger(ServiceHandlerFactory.class.getName());
     private static final Map<String,ServiceHandler> serviceHandlerCache = new ConcurrentHashMap<>();
 
     private ServiceHandlerFactory()
@@ -67,7 +66,7 @@ public final class ServiceHandlerFactory
             if( h.canHandleService( serviceName ) )
             {
                 serviceHandlerCache.put( serviceName, h );
-                LOG.finest(() -> "service handler: " + h + " chosen for service: " + serviceName);
+                LOG.log(System.Logger.Level.TRACE,() -> "service handler: " + h + " chosen for service: " + serviceName);
                 return h;
             }
         }
@@ -76,7 +75,7 @@ public final class ServiceHandlerFactory
 
     private static void log(List<ServiceHandler> handlers)
     {
-        LOG.finest(()-> "# of service handlers: " + handlers.size() + "\n" + logHandlers(handlers));
+        LOG.log(System.Logger.Level.TRACE,()-> "# of service handlers: " + handlers.size() + "\n" + logHandlers(handlers));
     }
 
     private static String logHandlers(List<ServiceHandler> handlers)

--- a/casual/casual-inbound-handler-casual-service/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/CasualServiceHandler.java
+++ b/casual/casual-inbound-handler-casual-service/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/CasualServiceHandler.java
@@ -36,7 +36,7 @@ import java.lang.reflect.Proxy;
 import java.util.Arrays;
 
 import static se.laz.casual.jca.inbound.handler.service.casual.discovery.MethodMatcher.matches;
-
+import static java.lang.System.Logger.Level.*;
 @Stateless
 public class CasualServiceHandler implements ServiceHandler
 {
@@ -73,7 +73,7 @@ public class CasualServiceHandler implements ServiceHandler
     @Override
     public InboundResponse invokeService(InboundRequest request)
     {
-        LOG.log(System.Logger.Level.TRACE,()->"Request received: " + request );
+        LOG.log(DEBUG,()->"Request received: " + request );
         CasualServiceEntry entry = CasualServiceRegistry.getInstance().getServiceEntry( request.getServiceName() );
         ThreadClassLoaderTool tool = new ThreadClassLoaderTool();
         ServiceHandlerExtension serviceHandlerExtension = ServiceHandlerExtensionFactory.getExtension( CasualService.class.getName() );
@@ -89,7 +89,7 @@ public class CasualServiceHandler implements ServiceHandler
         }
         catch( Throwable e )
         {
-            LOG.log(System.Logger.Level.WARNING, ()-> "Error invoking service: " + e.getMessage() );
+            LOG.log(WARNING, ()-> "Error invoking service: " + e.getMessage() ,e);
             InboundResponse response = InboundResponse.createBuilder()
                     .errorState( ErrorState.TPESVCERR )
                     .transactionState( TransactionState.ROLLBACK_ONLY )
@@ -121,7 +121,7 @@ public class CasualServiceHandler implements ServiceHandler
     {
         Context c = getContext();
         Object r = c.lookup( jndiName );
-        LOG.log(System.Logger.Level.TRACE,()->"Found " + r.getClass() + " : " + r );
+        LOG.log(DEBUG,()->"Found " + r.getClass() + " : " + r );
         return r;
     }
 

--- a/casual/casual-inbound-handler-casual-service/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/CasualServiceHandler.java
+++ b/casual/casual-inbound-handler-casual-service/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/CasualServiceHandler.java
@@ -34,15 +34,13 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Arrays;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import static se.laz.casual.jca.inbound.handler.service.casual.discovery.MethodMatcher.matches;
 
 @Stateless
 public class CasualServiceHandler implements ServiceHandler
 {
-    private static final Logger LOG = Logger.getLogger(CasualServiceHandler.class.getName());
+    private static final System.Logger LOG = System.getLogger(CasualServiceHandler.class.getName());
 
     private Context context;
 
@@ -75,7 +73,7 @@ public class CasualServiceHandler implements ServiceHandler
     @Override
     public InboundResponse invokeService(InboundRequest request)
     {
-        LOG.finest( ()->"Request received: " + request );
+        LOG.log(System.Logger.Level.TRACE,()->"Request received: " + request );
         CasualServiceEntry entry = CasualServiceRegistry.getInstance().getServiceEntry( request.getServiceName() );
         ThreadClassLoaderTool tool = new ThreadClassLoaderTool();
         ServiceHandlerExtension serviceHandlerExtension = ServiceHandlerExtensionFactory.getExtension( CasualService.class.getName() );
@@ -91,7 +89,7 @@ public class CasualServiceHandler implements ServiceHandler
         }
         catch( Throwable e )
         {
-            LOG.log( Level.WARNING, e, ()-> "Error invoking service: " + e.getMessage() );
+            LOG.log(System.Logger.Level.WARNING, ()-> "Error invoking service: " + e.getMessage() );
             InboundResponse response = InboundResponse.createBuilder()
                     .errorState( ErrorState.TPESVCERR )
                     .transactionState( TransactionState.ROLLBACK_ONLY )
@@ -123,7 +121,7 @@ public class CasualServiceHandler implements ServiceHandler
     {
         Context c = getContext();
         Object r = c.lookup( jndiName );
-        LOG.finest( ()->"Found " + r.getClass() + " : " + r );
+        LOG.log(System.Logger.Level.TRACE,()->"Found " + r.getClass() + " : " + r );
         return r;
     }
 

--- a/casual/casual-inbound-handler-casual-service/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/discovery/JndiSearchTimerEjbSingleton.java
+++ b/casual/casual-inbound-handler-casual-service/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/discovery/JndiSearchTimerEjbSingleton.java
@@ -24,8 +24,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import static se.laz.casual.jca.inbound.handler.service.casual.discovery.MethodMatcher.matches;
 
@@ -37,7 +35,7 @@ import static se.laz.casual.jca.inbound.handler.service.casual.discovery.MethodM
 @Singleton
 public class JndiSearchTimerEjbSingleton
 {
-    private static final Logger logger = Logger.getLogger(JndiSearchTimerEjbSingleton.class.getName());
+    private static final System.Logger logger = System.getLogger(JndiSearchTimerEjbSingleton.class.getName());
     private final TimerStopCondition stopCondition = TimerStopCondition.of(ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_INBOUND_STARTUP_MODE ));
 
     @Schedule(hour = "*", minute = "*", second = "*/10", persistent = false)
@@ -45,20 +43,20 @@ public class JndiSearchTimerEjbSingleton
     {
         if(stopCondition.stop())
         {
-            logger.finest(() -> "Inbound startup mode is Trigger and inbound server has started, cancelling JndiSearchTimerEjbSingleton timer");
+            logger.log(System.Logger.Level.TRACE,() -> "Inbound startup mode is Trigger and inbound server has started, cancelling JndiSearchTimerEjbSingleton timer");
             timer.cancel();
             return;
         }
         try
         {
-            logger.finest( ()-> "Fetch all unresolved casual services." );
+            logger.log(System.Logger.Level.TRACE, ()-> "Fetch all unresolved casual services." );
             List<CasualServiceMetaData> toFind = CasualServiceRegistry.getInstance().getUnresolvedServices();
-            logger.finest( ()-> "Unresolved: " + toFind.size() );
+            logger.log(System.Logger.Level.TRACE, ()-> "Unresolved: " + toFind.size() );
             if( toFind.isEmpty() )
             {
                 return;
             }
-            logger.finest( ()-> "Fetch all global apps." );
+            logger.log(System.Logger.Level.TRACE, ()-> "Fetch all global apps." );
             Map<String,Map<String,Proxy>> apps = JndiUtil.findAllGlobalJndiProxies( new InitialContext() );
 
             resolveAll( toFind, apps );
@@ -67,7 +65,7 @@ public class JndiSearchTimerEjbSingleton
         catch (Exception e)
         {
             // since method with @Timeout annotation are not allowed to throw
-            logger.log( Level.WARNING, e, ()-> "Error with jndi lookup." );
+            logger.log( System.Logger.Level.WARNING, ()-> "Error with jndi lookup." );
         }
     }
 

--- a/casual/casual-inbound-handler-casual-service/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/discovery/JndiSearchTimerEjbSingleton.java
+++ b/casual/casual-inbound-handler-casual-service/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/discovery/JndiSearchTimerEjbSingleton.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import static se.laz.casual.jca.inbound.handler.service.casual.discovery.MethodMatcher.matches;
-
+import static java.lang.System.Logger.Level.*;
 /**
  * Periodically check to find any newly deployed {@link CasualService} annotated EJBs.
  *
@@ -43,20 +43,20 @@ public class JndiSearchTimerEjbSingleton
     {
         if(stopCondition.stop())
         {
-            logger.log(System.Logger.Level.TRACE,() -> "Inbound startup mode is Trigger and inbound server has started, cancelling JndiSearchTimerEjbSingleton timer");
+            logger.log(DEBUG,() -> "Inbound startup mode is Trigger and inbound server has started, cancelling JndiSearchTimerEjbSingleton timer");
             timer.cancel();
             return;
         }
         try
         {
-            logger.log(System.Logger.Level.TRACE, ()-> "Fetch all unresolved casual services." );
+            logger.log(DEBUG, ()-> "Fetch all unresolved casual services." );
             List<CasualServiceMetaData> toFind = CasualServiceRegistry.getInstance().getUnresolvedServices();
-            logger.log(System.Logger.Level.TRACE, ()-> "Unresolved: " + toFind.size() );
+            logger.log(DEBUG, ()-> "Unresolved: " + toFind.size() );
             if( toFind.isEmpty() )
             {
                 return;
             }
-            logger.log(System.Logger.Level.TRACE, ()-> "Fetch all global apps." );
+            logger.log(DEBUG, ()-> "Fetch all global apps." );
             Map<String,Map<String,Proxy>> apps = JndiUtil.findAllGlobalJndiProxies( new InitialContext() );
 
             resolveAll( toFind, apps );
@@ -65,7 +65,7 @@ public class JndiSearchTimerEjbSingleton
         catch (Exception e)
         {
             // since method with @Timeout annotation are not allowed to throw
-            logger.log( System.Logger.Level.WARNING, ()-> "Error with jndi lookup." );
+            logger.log( WARNING, ()-> "Error with jndi lookup.",e );
         }
     }
 

--- a/casual/casual-inbound-handler-casual-service/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/discovery/JndiUtil.java
+++ b/casual/casual-inbound-handler-casual-service/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/discovery/JndiUtil.java
@@ -14,6 +14,8 @@ import java.lang.reflect.Proxy;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.lang.System.Logger.Level.*;
+
 public class JndiUtil
 {
     private static final System.Logger logger = System.getLogger(JndiUtil.class.getName());
@@ -99,7 +101,7 @@ public class JndiUtil
             }
             catch(NamingException e)
             {
-                logger.log( System.Logger.Level.TRACE, () -> "lookup failed for: " + name);
+                logger.log( DEBUG, () -> "lookup failed for: " + name);
             }
         }
         return results;

--- a/casual/casual-inbound-handler-casual-service/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/discovery/JndiUtil.java
+++ b/casual/casual-inbound-handler-casual-service/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/discovery/JndiUtil.java
@@ -13,12 +13,10 @@ import javax.naming.NamingException;
 import java.lang.reflect.Proxy;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class JndiUtil
 {
-    private static final Logger logger = Logger.getLogger(JndiUtil.class.getName());
+    private static final System.Logger logger = System.getLogger(JndiUtil.class.getName());
     private static final String BEAN_INTERFACE_SEPERATOR = "!";
     private static final String SEPERATOR = "/";
     private static final String PACKAGE_SEPERATOR = ".";
@@ -101,7 +99,7 @@ public class JndiUtil
             }
             catch(NamingException e)
             {
-                logger.log( Level.FINEST, e, () -> "lookup failed for: " + name);
+                logger.log( System.Logger.Level.TRACE, () -> "lookup failed for: " + name);
             }
         }
         return results;

--- a/casual/casual-inbound-handler-casual-service/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/discovery/TimerStopCondition.java
+++ b/casual/casual-inbound-handler-casual-service/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/discovery/TimerStopCondition.java
@@ -7,6 +7,7 @@ package se.laz.casual.jca.inbound.handler.service.casual.discovery;
 
 import se.laz.casual.config.Mode;
 import se.laz.casual.jca.RuntimeInformation;
+import static java.lang.System.Logger.Level.*;
 
 public class TimerStopCondition
 {
@@ -24,8 +25,8 @@ public class TimerStopCondition
 
     public boolean stop( )
     {
-        log.log(System.Logger.Level.TRACE,() -> "startupmode TRIGGER?" + triggerMode);
-        log.log(System.Logger.Level.TRACE,() -> "RuntimeInformation.isInboundStarted()?" + RuntimeInformation.isInboundStarted());
+        log.log(DEBUG,() -> "startupmode TRIGGER?" + triggerMode);
+        log.log(DEBUG,() -> "RuntimeInformation.isInboundStarted()?" + RuntimeInformation.isInboundStarted());
         return triggerMode && RuntimeInformation.isInboundStarted();
     }
 }

--- a/casual/casual-inbound-handler-casual-service/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/discovery/TimerStopCondition.java
+++ b/casual/casual-inbound-handler-casual-service/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/discovery/TimerStopCondition.java
@@ -8,11 +8,9 @@ package se.laz.casual.jca.inbound.handler.service.casual.discovery;
 import se.laz.casual.config.Mode;
 import se.laz.casual.jca.RuntimeInformation;
 
-import java.util.logging.Logger;
-
 public class TimerStopCondition
 {
-    private static final Logger log = Logger.getLogger( TimerStopCondition.class.getName());
+    private static final System.Logger log = System.getLogger( TimerStopCondition.class.getName());
     private final boolean triggerMode;
     private TimerStopCondition( Mode mode )
     {
@@ -26,8 +24,8 @@ public class TimerStopCondition
 
     public boolean stop( )
     {
-        log.finest(() -> "startupmode TRIGGER?" + triggerMode);
-        log.finest(() -> "RuntimeInformation.isInboundStarted()?" + RuntimeInformation.isInboundStarted());
+        log.log(System.Logger.Level.TRACE,() -> "startupmode TRIGGER?" + triggerMode);
+        log.log(System.Logger.Level.TRACE,() -> "RuntimeInformation.isInboundStarted()?" + RuntimeInformation.isInboundStarted());
         return triggerMode && RuntimeInformation.isInboundStarted();
     }
 }

--- a/casual/casual-inbound-handler-javaee-service/src/main/java/se/laz/casual/jca/inbound/handler/service/javaee/JavaeeServiceHandler.java
+++ b/casual/casual-inbound-handler-javaee-service/src/main/java/se/laz/casual/jca/inbound/handler/service/javaee/JavaeeServiceHandler.java
@@ -29,13 +29,11 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 @Stateless
 public class JavaeeServiceHandler implements ServiceHandler
 {
-    private static final Logger LOG = Logger.getLogger(JavaeeServiceHandler.class.getName());
+    private static final System.Logger LOG = System.getLogger(JavaeeServiceHandler.class.getName());
 
     private Context context;
 
@@ -62,7 +60,7 @@ public class JavaeeServiceHandler implements ServiceHandler
     @Override
     public InboundResponse invokeService(InboundRequest request)
     {
-        LOG.finest( ()->"Request received: " + request );
+        LOG.log(System.Logger.Level.TRACE, ()->"Request received: " + request );
         ThreadClassLoaderTool tool = new ThreadClassLoaderTool();
         ServiceHandlerExtension serviceHandlerExtension = ServiceHandlerExtensionFactory.getExtension( Remote.class.getName() );
         ServiceHandlerExtensionContext extensionContext = null;
@@ -77,7 +75,7 @@ public class JavaeeServiceHandler implements ServiceHandler
         }
         catch( Throwable e )
         {
-            LOG.log( Level.WARNING, e, ()-> "Error invoking service: " + e.getMessage() );
+            LOG.log(System.Logger.Level.WARNING, ()-> "Error invoking service: " + e.getMessage() );
             InboundResponse response = InboundResponse.createBuilder()
                     .errorState( ErrorState.TPESVCERR )
                     .transactionState( TransactionState.ROLLBACK_ONLY )
@@ -106,7 +104,7 @@ public class JavaeeServiceHandler implements ServiceHandler
     {
         Context c = getContext();
         Object r = c.lookup( jndiName );
-        LOG.finest( ()->"Found " + r.getClass() + " : " + r );
+        LOG.log(System.Logger.Level.TRACE, ()->"Found " + r.getClass() + " : " + r );
         return r;
     }
 
@@ -127,7 +125,7 @@ public class JavaeeServiceHandler implements ServiceHandler
 
         Object result = method.invoke( p, params );
 
-        LOG.finest( ()-> "Result: " + result );
+        LOG.log(System.Logger.Level.TRACE, ()-> "Result: " + result );
         return bufferHandler.toResponse( serviceCallInfo, result );
     }
 

--- a/casual/casual-inbound-handler-javaee-service/src/main/java/se/laz/casual/jca/inbound/handler/service/javaee/JavaeeServiceHandler.java
+++ b/casual/casual-inbound-handler-javaee-service/src/main/java/se/laz/casual/jca/inbound/handler/service/javaee/JavaeeServiceHandler.java
@@ -30,6 +30,8 @@ import javax.naming.NamingException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 
+import static java.lang.System.Logger.Level.*;
+
 @Stateless
 public class JavaeeServiceHandler implements ServiceHandler
 {
@@ -60,7 +62,7 @@ public class JavaeeServiceHandler implements ServiceHandler
     @Override
     public InboundResponse invokeService(InboundRequest request)
     {
-        LOG.log(System.Logger.Level.TRACE, ()->"Request received: " + request );
+        LOG.log(DEBUG, ()->"Request received: " + request );
         ThreadClassLoaderTool tool = new ThreadClassLoaderTool();
         ServiceHandlerExtension serviceHandlerExtension = ServiceHandlerExtensionFactory.getExtension( Remote.class.getName() );
         ServiceHandlerExtensionContext extensionContext = null;
@@ -75,7 +77,7 @@ public class JavaeeServiceHandler implements ServiceHandler
         }
         catch( Throwable e )
         {
-            LOG.log(System.Logger.Level.WARNING, ()-> "Error invoking service: " + e.getMessage() );
+            LOG.log(WARNING, ()-> "Error invoking service: " + e.getMessage(),e );
             InboundResponse response = InboundResponse.createBuilder()
                     .errorState( ErrorState.TPESVCERR )
                     .transactionState( TransactionState.ROLLBACK_ONLY )
@@ -104,7 +106,7 @@ public class JavaeeServiceHandler implements ServiceHandler
     {
         Context c = getContext();
         Object r = c.lookup( jndiName );
-        LOG.log(System.Logger.Level.TRACE, ()->"Found " + r.getClass() + " : " + r );
+        LOG.log(DEBUG, ()->"Found " + r.getClass() + " : " + r );
         return r;
     }
 
@@ -125,7 +127,7 @@ public class JavaeeServiceHandler implements ServiceHandler
 
         Object result = method.invoke( p, params );
 
-        LOG.log(System.Logger.Level.TRACE, ()-> "Result: " + result );
+        LOG.log(DEBUG, ()-> "Result: " + result );
         return bufferHandler.toResponse( serviceCallInfo, result );
     }
 

--- a/casual/casual-inbound/src/main/java/se/laz/casual/jca/inflow/CasualMessageListenerImpl.java
+++ b/casual/casual-inbound/src/main/java/se/laz/casual/jca/inflow/CasualMessageListenerImpl.java
@@ -55,8 +55,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Inbound Casual Message Listener, responsible for handling all inbound requests received.
@@ -69,15 +67,15 @@ import java.util.logging.Logger;
                 })
 public class CasualMessageListenerImpl implements CasualMessageListener
 {
-    private static Logger log = Logger.getLogger(CasualMessageListenerImpl.class.getName());
+    private static System.Logger log = System.getLogger(CasualMessageListenerImpl.class.getName());
     @Override
     public void domainConnectRequest(CasualNWMessage<CasualDomainConnectRequestMessage> message, Channel channel)
     {
-        log.finest(() -> "domainConnectRequest(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution()) + message );
-        log.info(()-> "domainConnectRequest(). client" + channel + " asking for protocol version(s)" + message.getMessage().getProtocols());
-        log.info(()-> "domainConnectRequest(). supported protocols: " + ProtocolVersion.supportedVersions());
+        log.log(System.Logger.Level.TRACE,() -> "domainConnectRequest(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution()) + message );
+        log.log(System.Logger.Level.INFO,()-> "domainConnectRequest(). client" + channel + " asking for protocol version(s)" + message.getMessage().getProtocols());
+        log.log(System.Logger.Level.INFO,()-> "domainConnectRequest(). supported protocols: " + ProtocolVersion.supportedVersions());
         Long matchedProtocolVersion = ProtocolMatcher.match(message.getMessage().getProtocols());
-        log.info(() -> "domainConnectRequest(). matched protocol version: " + ProtocolVersion.unmarshall(matchedProtocolVersion));
+        log.log(System.Logger.Level.INFO,() -> "domainConnectRequest(). matched protocol version: " + ProtocolVersion.unmarshall(matchedProtocolVersion));
 
         if(matchedProtocolVersion >= ProtocolVersion.VERSION_1_1.getVersion())
         {
@@ -107,13 +105,13 @@ public class CasualMessageListenerImpl implements CasualMessageListener
     @Override
     public void domainDisconnectReply(CasualNWMessage<DomainDisconnectReplyMessage> message)
     {
-        log.finest(() -> "domainDisconnectReply(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution()) + message );
+        log.log(System.Logger.Level.TRACE,() -> "domainDisconnectReply(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution()) + message );
     }
 
     @Override
     public void domainDiscoveryRequest(CasualNWMessage<CasualDomainDiscoveryRequestMessage> message, Channel channel)
     {
-        log.finest(() -> "domainDiscoveryRequest(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution()) + message);
+        log.log(System.Logger.Level.TRACE,() -> "domainDiscoveryRequest(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution()) + message);
 
         String domainName = ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_DOMAIN_NAME );
         UUID domainId = ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_DOMAIN_ID ).getId();
@@ -144,12 +142,12 @@ public class CasualMessageListenerImpl implements CasualMessageListener
     @Override
     public void serviceCallRequest(CasualNWMessage<CasualServiceCallRequestMessage> message, Channel channel, WorkManager workManager, CasualInboundTransactionRegistry inboundTransactionRegistry)
     {
-        log.finest(() -> "serviceCallRequest(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution(), message.getMessage().getXid()) + message);
+        log.log(System.Logger.Level.TRACE,() -> "serviceCallRequest(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution(), message.getMessage().getXid()) + message);
 
         Xid xid = message.getMessage().getXid();
         if(tpNoReplyOutOfProtocol( message, isServiceCallTransactional( xid )))
         {
-            log.warning(() ->{
+            log.log(System.Logger.Level.WARNING,() ->{
                 String casualMessageInfo = String.format("xid: %s, correlation: %s, execution: %s",PrettyPrinter.casualStringify(message.getMessage().getXid()),
                         PrettyPrinter.casualStringify(message.getCorrelationId()), PrettyPrinter.casualStringify(message.getMessage().getExecution()));
                 return "For message: " + message + " TPNOREPLY is set but the call is transactional. It is out of protocol so call will be issued but non transactional\n" + casualMessageInfo;
@@ -204,7 +202,7 @@ public class CasualMessageListenerImpl implements CasualMessageListener
             }
             catch (NotSupportedException e)
             {
-                log.warning("Timeout is not set as is not supported. " + e.getMessage());
+                log.log(System.Logger.Level.WARNING,"Timeout is not set as is not supported. " + e.getMessage());
             }
         }
         return context;
@@ -213,7 +211,7 @@ public class CasualMessageListenerImpl implements CasualMessageListener
     @Override
     public void prepareRequest(CasualNWMessage<CasualTransactionResourcePrepareRequestMessage> message, Channel channel, XATerminator xaTerminator, CasualInboundTransactionRegistry inboundTransactionRegistry)
     {
-        log.finest(() ->  "prepareRequest(). " + PrettyPrinter.format(message.getCorrelationId(),
+        log.log(System.Logger.Level.TRACE,() ->  "prepareRequest(). " + PrettyPrinter.format(message.getCorrelationId(),
                 message.getMessage().getExecution(), message.getMessage().getXid()) + "flags:" + message.getMessage().getFlags() + " " + message);
         Xid xid = message.getMessage().getXid();
         int status = -1;
@@ -225,7 +223,7 @@ public class CasualMessageListenerImpl implements CasualMessageListener
         {
 
             status = e.errorCode;
-            log.log( Level.WARNING, e, ()-> "XAException prepare()" + e.getMessage() );
+            log.log( System.Logger.Level.WARNING, ()-> "XAException prepare()" + e.getMessage() );
         }
         finally
         {
@@ -249,7 +247,7 @@ public class CasualMessageListenerImpl implements CasualMessageListener
     @Override
     public void commitRequest(CasualNWMessage<CasualTransactionResourceCommitRequestMessage> message, Channel channel, XATerminator xaTerminator, CasualInboundTransactionRegistry inboundTransactionRegistry)
     {
-        log.finest(() -> "commitRequest(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution(), message.getMessage().getXid()) + message);
+        log.log(System.Logger.Level.TRACE,() -> "commitRequest(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution(), message.getMessage().getXid()) + message);
         Xid xid = message.getMessage().getXid();
         boolean onePhase = message.getMessage().getFlags().isSet( XAFlags.TMONEPHASE );
 
@@ -261,7 +259,7 @@ public class CasualMessageListenerImpl implements CasualMessageListener
         } catch (XAException e)
         {
             status = e.errorCode;
-            log.log( Level.WARNING, e, ()-> "XAException commit()" + e.getMessage() );
+            log.log( System.Logger.Level.WARNING, ()-> "XAException commit()" + e.getMessage() );
         }
         finally
         {
@@ -281,7 +279,7 @@ public class CasualMessageListenerImpl implements CasualMessageListener
     @Override
     public void requestRollback(CasualNWMessage<CasualTransactionResourceRollbackRequestMessage> message, Channel channel, XATerminator xaTerminator, CasualInboundTransactionRegistry inboundTransactionRegistry)
     {
-        log.finest(() -> "requestRollback(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution(), message.getMessage().getXid()) + message );
+        log.log(System.Logger.Level.TRACE,() -> "requestRollback(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution(), message.getMessage().getXid()) + message );
 
         Xid xid = message.getMessage().getXid();
         int status = -1;
@@ -292,7 +290,7 @@ public class CasualMessageListenerImpl implements CasualMessageListener
         } catch (XAException e)
         {
             status = e.errorCode;
-            log.log( Level.WARNING, e, ()-> "XAException rollback()" + e.getMessage() );
+            log.log( System.Logger.Level.WARNING, ()-> "XAException rollback()" + e.getMessage() );
         }
         finally
         {

--- a/casual/casual-inbound/src/main/java/se/laz/casual/jca/inflow/CasualMessageListenerImpl.java
+++ b/casual/casual-inbound/src/main/java/se/laz/casual/jca/inflow/CasualMessageListenerImpl.java
@@ -56,6 +56,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import static java.lang.System.Logger.Level.*;
+
 /**
  * Inbound Casual Message Listener, responsible for handling all inbound requests received.
  */
@@ -71,11 +73,11 @@ public class CasualMessageListenerImpl implements CasualMessageListener
     @Override
     public void domainConnectRequest(CasualNWMessage<CasualDomainConnectRequestMessage> message, Channel channel)
     {
-        log.log(System.Logger.Level.TRACE,() -> "domainConnectRequest(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution()) + message );
-        log.log(System.Logger.Level.INFO,()-> "domainConnectRequest(). client" + channel + " asking for protocol version(s)" + message.getMessage().getProtocols());
-        log.log(System.Logger.Level.INFO,()-> "domainConnectRequest(). supported protocols: " + ProtocolVersion.supportedVersions());
+        log.log(DEBUG,() -> "domainConnectRequest(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution()) + message );
+        log.log(INFO,()-> "domainConnectRequest(). client" + channel + " asking for protocol version(s)" + message.getMessage().getProtocols());
+        log.log(INFO,()-> "domainConnectRequest(). supported protocols: " + ProtocolVersion.supportedVersions());
         Long matchedProtocolVersion = ProtocolMatcher.match(message.getMessage().getProtocols());
-        log.log(System.Logger.Level.INFO,() -> "domainConnectRequest(). matched protocol version: " + ProtocolVersion.unmarshall(matchedProtocolVersion));
+        log.log(INFO,() -> "domainConnectRequest(). matched protocol version: " + ProtocolVersion.unmarshall(matchedProtocolVersion));
 
         if(matchedProtocolVersion >= ProtocolVersion.VERSION_1_1.getVersion())
         {
@@ -105,13 +107,13 @@ public class CasualMessageListenerImpl implements CasualMessageListener
     @Override
     public void domainDisconnectReply(CasualNWMessage<DomainDisconnectReplyMessage> message)
     {
-        log.log(System.Logger.Level.TRACE,() -> "domainDisconnectReply(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution()) + message );
+        log.log(DEBUG,() -> "domainDisconnectReply(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution()) + message );
     }
 
     @Override
     public void domainDiscoveryRequest(CasualNWMessage<CasualDomainDiscoveryRequestMessage> message, Channel channel)
     {
-        log.log(System.Logger.Level.TRACE,() -> "domainDiscoveryRequest(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution()) + message);
+        log.log(DEBUG,() -> "domainDiscoveryRequest(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution()) + message);
 
         String domainName = ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_DOMAIN_NAME );
         UUID domainId = ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_DOMAIN_ID ).getId();
@@ -142,12 +144,12 @@ public class CasualMessageListenerImpl implements CasualMessageListener
     @Override
     public void serviceCallRequest(CasualNWMessage<CasualServiceCallRequestMessage> message, Channel channel, WorkManager workManager, CasualInboundTransactionRegistry inboundTransactionRegistry)
     {
-        log.log(System.Logger.Level.TRACE,() -> "serviceCallRequest(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution(), message.getMessage().getXid()) + message);
+        log.log(DEBUG,() -> "serviceCallRequest(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution(), message.getMessage().getXid()) + message);
 
         Xid xid = message.getMessage().getXid();
         if(tpNoReplyOutOfProtocol( message, isServiceCallTransactional( xid )))
         {
-            log.log(System.Logger.Level.WARNING,() ->{
+            log.log(WARNING,() ->{
                 String casualMessageInfo = String.format("xid: %s, correlation: %s, execution: %s",PrettyPrinter.casualStringify(message.getMessage().getXid()),
                         PrettyPrinter.casualStringify(message.getCorrelationId()), PrettyPrinter.casualStringify(message.getMessage().getExecution()));
                 return "For message: " + message + " TPNOREPLY is set but the call is transactional. It is out of protocol so call will be issued but non transactional\n" + casualMessageInfo;
@@ -202,7 +204,7 @@ public class CasualMessageListenerImpl implements CasualMessageListener
             }
             catch (NotSupportedException e)
             {
-                log.log(System.Logger.Level.WARNING,"Timeout is not set as is not supported. " + e.getMessage());
+                log.log(WARNING,"Timeout is not set as is not supported. " + e.getMessage(),e);
             }
         }
         return context;
@@ -211,7 +213,7 @@ public class CasualMessageListenerImpl implements CasualMessageListener
     @Override
     public void prepareRequest(CasualNWMessage<CasualTransactionResourcePrepareRequestMessage> message, Channel channel, XATerminator xaTerminator, CasualInboundTransactionRegistry inboundTransactionRegistry)
     {
-        log.log(System.Logger.Level.TRACE,() ->  "prepareRequest(). " + PrettyPrinter.format(message.getCorrelationId(),
+        log.log(DEBUG,() ->  "prepareRequest(). " + PrettyPrinter.format(message.getCorrelationId(),
                 message.getMessage().getExecution(), message.getMessage().getXid()) + "flags:" + message.getMessage().getFlags() + " " + message);
         Xid xid = message.getMessage().getXid();
         int status = -1;
@@ -223,7 +225,7 @@ public class CasualMessageListenerImpl implements CasualMessageListener
         {
 
             status = e.errorCode;
-            log.log( System.Logger.Level.WARNING, ()-> "XAException prepare()" + e.getMessage() );
+            log.log( WARNING, ()-> "XAException prepare()" + e.getMessage() ,e);
         }
         finally
         {
@@ -247,7 +249,7 @@ public class CasualMessageListenerImpl implements CasualMessageListener
     @Override
     public void commitRequest(CasualNWMessage<CasualTransactionResourceCommitRequestMessage> message, Channel channel, XATerminator xaTerminator, CasualInboundTransactionRegistry inboundTransactionRegistry)
     {
-        log.log(System.Logger.Level.TRACE,() -> "commitRequest(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution(), message.getMessage().getXid()) + message);
+        log.log(DEBUG,() -> "commitRequest(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution(), message.getMessage().getXid()) + message);
         Xid xid = message.getMessage().getXid();
         boolean onePhase = message.getMessage().getFlags().isSet( XAFlags.TMONEPHASE );
 
@@ -259,7 +261,7 @@ public class CasualMessageListenerImpl implements CasualMessageListener
         } catch (XAException e)
         {
             status = e.errorCode;
-            log.log( System.Logger.Level.WARNING, ()-> "XAException commit()" + e.getMessage() );
+            log.log( WARNING, ()-> "XAException commit()" + e.getMessage(),e );
         }
         finally
         {
@@ -279,7 +281,7 @@ public class CasualMessageListenerImpl implements CasualMessageListener
     @Override
     public void requestRollback(CasualNWMessage<CasualTransactionResourceRollbackRequestMessage> message, Channel channel, XATerminator xaTerminator, CasualInboundTransactionRegistry inboundTransactionRegistry)
     {
-        log.log(System.Logger.Level.TRACE,() -> "requestRollback(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution(), message.getMessage().getXid()) + message );
+        log.log(DEBUG,() -> "requestRollback(). " + PrettyPrinter.format(message.getCorrelationId(), message.getMessage().getExecution(), message.getMessage().getXid()) + message );
 
         Xid xid = message.getMessage().getXid();
         int status = -1;
@@ -290,7 +292,7 @@ public class CasualMessageListenerImpl implements CasualMessageListener
         } catch (XAException e)
         {
             status = e.errorCode;
-            log.log( System.Logger.Level.WARNING, ()-> "XAException rollback()" + e.getMessage() );
+            log.log( WARNING, ()-> "XAException rollback()" + e.getMessage(),e );
         }
         finally
         {

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualConnectionFactoryImpl.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualConnectionFactoryImpl.java
@@ -12,7 +12,6 @@ import jakarta.resource.ResourceException;
 import jakarta.resource.spi.ConnectionManager;
 import jakarta.resource.spi.ConnectionRequestInfo;
 import java.util.Objects;
-import java.util.logging.Logger;
 
 /**
  * CasualConnectionFactoryImpl
@@ -23,7 +22,7 @@ public class CasualConnectionFactoryImpl implements CasualConnectionFactory
 {
 
     private static final long serialVersionUID = 1L;
-    private static Logger log = Logger.getLogger(CasualConnectionFactoryImpl.class.getName());
+    private static System.Logger log = System.getLogger(CasualConnectionFactoryImpl.class.getName());
     private Reference reference;
     private CasualManagedConnectionFactory managedConnectionFactory;
     private ConnectionManager connectionManager;
@@ -47,28 +46,28 @@ public class CasualConnectionFactoryImpl implements CasualConnectionFactory
     @Override
     public CasualConnection getConnection() throws ResourceException
     {
-        log.finest("getConnection()");
+        log.log(System.Logger.Level.TRACE,"getConnection()");
         return getConnection(null);
     }
 
     @Override
     public CasualConnection getConnection(ConnectionRequestInfo connectionRequestInfo) throws ResourceException
     {
-        log.finest("getConnection()");
+        log.log(System.Logger.Level.TRACE,"getConnection()");
         return (CasualConnection) connectionManager.allocateConnection(managedConnectionFactory, connectionRequestInfo);
     }
 
     @Override
     public Reference getReference() throws NamingException
     {
-        log.finest("getReference()");
+        log.log(System.Logger.Level.TRACE,"getReference()");
         return reference;
     }
 
     @Override
     public void setReference(Reference reference)
     {
-        log.finest("setReference()");
+        log.log(System.Logger.Level.TRACE,"setReference()");
         this.reference = reference;
     }
 

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualConnectionFactoryImpl.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualConnectionFactoryImpl.java
@@ -13,6 +13,8 @@ import jakarta.resource.spi.ConnectionManager;
 import jakarta.resource.spi.ConnectionRequestInfo;
 import java.util.Objects;
 
+import static java.lang.System.Logger.Level.*;
+
 /**
  * CasualConnectionFactoryImpl
  *
@@ -46,28 +48,28 @@ public class CasualConnectionFactoryImpl implements CasualConnectionFactory
     @Override
     public CasualConnection getConnection() throws ResourceException
     {
-        log.log(System.Logger.Level.TRACE,"getConnection()");
+        log.log(DEBUG,"getConnection()");
         return getConnection(null);
     }
 
     @Override
     public CasualConnection getConnection(ConnectionRequestInfo connectionRequestInfo) throws ResourceException
     {
-        log.log(System.Logger.Level.TRACE,"getConnection()");
+        log.log(DEBUG,"getConnection()");
         return (CasualConnection) connectionManager.allocateConnection(managedConnectionFactory, connectionRequestInfo);
     }
 
     @Override
     public Reference getReference() throws NamingException
     {
-        log.log(System.Logger.Level.TRACE,"getReference()");
+        log.log(DEBUG,"getReference()");
         return reference;
     }
 
     @Override
     public void setReference(Reference reference)
     {
-        log.log(System.Logger.Level.TRACE,"setReference()");
+        log.log(DEBUG,"setReference()");
         this.reference = reference;
     }
 

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualManagedConnection.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualManagedConnection.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.logging.Logger;
 
 /**
  * CasualManagedConnection
@@ -46,7 +45,7 @@ import java.util.logging.Logger;
  */
 public class CasualManagedConnection implements ManagedConnection, NetworkListener
 {
-    private static final Logger log = Logger.getLogger(CasualManagedConnection.class.getName());
+    private static final System.Logger log = System.getLogger(CasualManagedConnection.class.getName());
 
     private PrintWriter logwriter;
     private final CasualManagedConnectionFactory mcf;
@@ -85,7 +84,7 @@ public class CasualManagedConnection implements ManagedConnection, NetworkListen
             {
                 if(null != mcf.getNetworkConnectionPoolName() && null == mcf.getNetworkConnectionPoolSize())
                 {
-                    log.warning(() -> "networkPoolName set to: " + mcf.getNetworkConnectionPoolName() + " but missing networkPoolSize!");
+                    log.log(System.Logger.Level.WARNING,() -> "networkPoolName set to: " + mcf.getNetworkConnectionPoolName() + " but missing networkPoolSize!");
                 }
                 networkConnection = networkPoolNameAndNetworkPoolSizeSet() ? getOrCreateFromPool() : createOneToOneManagedConnection();
             }
@@ -115,7 +114,7 @@ public class CasualManagedConnection implements ManagedConnection, NetworkListen
     {
         try
         {
-            log.finest("getConnection()");
+            log.log(System.Logger.Level.TRACE,"getConnection()");
             if (!getNetworkConnection().isActive())
             {
                 closeNetworkConnection();
@@ -137,7 +136,7 @@ public class CasualManagedConnection implements ManagedConnection, NetworkListen
     @Override
     public void associateConnection(Object connection) throws ResourceException
     {
-        log.finest("associateConnection()");
+        log.log(System.Logger.Level.TRACE,"associateConnection()");
         Objects.requireNonNull( connection, "Null connection handle." );
 
         if (!(connection instanceof CasualConnectionImpl))
@@ -153,7 +152,7 @@ public class CasualManagedConnection implements ManagedConnection, NetworkListen
     @Override
     public void cleanup() throws ResourceException
     {
-        log.finest("cleanup()");
+        log.log(System.Logger.Level.TRACE,"cleanup()");
         for(CasualConnectionImpl c : connectionHandles)
         {
             c.invalidate();
@@ -164,7 +163,7 @@ public class CasualManagedConnection implements ManagedConnection, NetworkListen
     @Override
     public void destroy() throws ResourceException
     {
-        log.finest(() -> "destroy()" + this);
+        log.log(System.Logger.Level.TRACE,() -> "destroy()" + this);
         closeNetworkConnection();
         connectionHandles.clear();
     }
@@ -172,41 +171,41 @@ public class CasualManagedConnection implements ManagedConnection, NetworkListen
     @Override
     public void addConnectionEventListener(ConnectionEventListener listener)
     {
-        log.finest("addConnectionEventListener()");
+        log.log(System.Logger.Level.TRACE,"addConnectionEventListener()");
         connectionEventHandler.addConnectionEventListener( listener );
     }
 
     @Override
     public void removeConnectionEventListener(ConnectionEventListener listener) {
-        log.finest("removeConnectionEventListener()");
+        log.log(System.Logger.Level.TRACE,"removeConnectionEventListener()");
         connectionEventHandler.removeConnectionEventListener(listener);
     }
 
     @Override
     public PrintWriter getLogWriter() throws ResourceException
     {
-        log.finest("getLogWriter()");
+        log.log(System.Logger.Level.TRACE,"getLogWriter()");
         return logwriter;
     }
 
     @Override
     public void setLogWriter(PrintWriter out) throws ResourceException
     {
-        log.finest("setLogWriter()");
+        log.log(System.Logger.Level.TRACE,"setLogWriter()");
         logwriter = out;
     }
 
     @Override
     public LocalTransaction getLocalTransaction() throws ResourceException
     {
-        log.finest("getLocalTransaction(), this is not supported.");
+        log.log(System.Logger.Level.TRACE,"getLocalTransaction(), this is not supported.");
         throw new NotSupportedException( "LocalTransactions are not supported." );
     }
 
     @Override
     public synchronized XAResource getXAResource() throws ResourceException
     {
-        log.finest("getXAResource()");
+        log.log(System.Logger.Level.TRACE,"getXAResource()");
         return this.xaResource;
     }
 
@@ -223,7 +222,7 @@ public class CasualManagedConnection implements ManagedConnection, NetworkListen
     @Override
     public ManagedConnectionMetaData getMetaData() throws ResourceException
     {
-        log.finest("getMetaData()");
+        log.log(System.Logger.Level.TRACE,"getMetaData()");
         return new CasualManagedConnectionMetaData();
     }
 
@@ -295,7 +294,7 @@ public class CasualManagedConnection implements ManagedConnection, NetworkListen
     @Override
     public void disconnected(Exception reason)
     {
-        log.finest(() -> "disconnected: " + this);
+        log.log(System.Logger.Level.TRACE,() -> "disconnected: " + this);
         ConnectionEvent event = new ConnectionEvent(this, ConnectionEvent.CONNECTION_ERROR_OCCURRED, reason);
         connectionEventHandler.sendEvent(event);
     }
@@ -323,7 +322,7 @@ public class CasualManagedConnection implements ManagedConnection, NetworkListen
     {
         NettyConnectionInformation ci = NettyConnectionInformationCreator.create(InetSocketAddress.createUnresolved(mcf.getHostName(), mcf.getPortNumber()), mcf.getCasualProtocolVersion());
         NetworkConnection newNetworkConnection = NettyNetworkConnection.of(ci, this);
-        log.finest(() -> "created new nw connection " + this);
+        log.log(System.Logger.Level.TRACE,() -> "created new nw connection " + this);
         return newNetworkConnection;
     }
 }

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualManagedConnection.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualManagedConnection.java
@@ -35,6 +35,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+import static java.lang.System.Logger.Level.*;
+
 /**
  * CasualManagedConnection
  * The application server pools these objects
@@ -84,7 +86,7 @@ public class CasualManagedConnection implements ManagedConnection, NetworkListen
             {
                 if(null != mcf.getNetworkConnectionPoolName() && null == mcf.getNetworkConnectionPoolSize())
                 {
-                    log.log(System.Logger.Level.WARNING,() -> "networkPoolName set to: " + mcf.getNetworkConnectionPoolName() + " but missing networkPoolSize!");
+                    log.log(WARNING,() -> "networkPoolName set to: " + mcf.getNetworkConnectionPoolName() + " but missing networkPoolSize!");
                 }
                 networkConnection = networkPoolNameAndNetworkPoolSizeSet() ? getOrCreateFromPool() : createOneToOneManagedConnection();
             }
@@ -114,7 +116,7 @@ public class CasualManagedConnection implements ManagedConnection, NetworkListen
     {
         try
         {
-            log.log(System.Logger.Level.TRACE,"getConnection()");
+            log.log(DEBUG,"getConnection()");
             if (!getNetworkConnection().isActive())
             {
                 closeNetworkConnection();
@@ -136,7 +138,7 @@ public class CasualManagedConnection implements ManagedConnection, NetworkListen
     @Override
     public void associateConnection(Object connection) throws ResourceException
     {
-        log.log(System.Logger.Level.TRACE,"associateConnection()");
+        log.log(DEBUG,"associateConnection()");
         Objects.requireNonNull( connection, "Null connection handle." );
 
         if (!(connection instanceof CasualConnectionImpl))
@@ -152,7 +154,7 @@ public class CasualManagedConnection implements ManagedConnection, NetworkListen
     @Override
     public void cleanup() throws ResourceException
     {
-        log.log(System.Logger.Level.TRACE,"cleanup()");
+        log.log(DEBUG,"cleanup()");
         for(CasualConnectionImpl c : connectionHandles)
         {
             c.invalidate();
@@ -163,7 +165,7 @@ public class CasualManagedConnection implements ManagedConnection, NetworkListen
     @Override
     public void destroy() throws ResourceException
     {
-        log.log(System.Logger.Level.TRACE,() -> "destroy()" + this);
+        log.log(DEBUG,() -> "destroy()" + this);
         closeNetworkConnection();
         connectionHandles.clear();
     }
@@ -171,41 +173,41 @@ public class CasualManagedConnection implements ManagedConnection, NetworkListen
     @Override
     public void addConnectionEventListener(ConnectionEventListener listener)
     {
-        log.log(System.Logger.Level.TRACE,"addConnectionEventListener()");
+        log.log(DEBUG,"addConnectionEventListener()");
         connectionEventHandler.addConnectionEventListener( listener );
     }
 
     @Override
     public void removeConnectionEventListener(ConnectionEventListener listener) {
-        log.log(System.Logger.Level.TRACE,"removeConnectionEventListener()");
+        log.log(DEBUG,"removeConnectionEventListener()");
         connectionEventHandler.removeConnectionEventListener(listener);
     }
 
     @Override
     public PrintWriter getLogWriter() throws ResourceException
     {
-        log.log(System.Logger.Level.TRACE,"getLogWriter()");
+        log.log(DEBUG,"getLogWriter()");
         return logwriter;
     }
 
     @Override
     public void setLogWriter(PrintWriter out) throws ResourceException
     {
-        log.log(System.Logger.Level.TRACE,"setLogWriter()");
+        log.log(DEBUG,"setLogWriter()");
         logwriter = out;
     }
 
     @Override
     public LocalTransaction getLocalTransaction() throws ResourceException
     {
-        log.log(System.Logger.Level.TRACE,"getLocalTransaction(), this is not supported.");
+        log.log(DEBUG,"getLocalTransaction(), this is not supported.");
         throw new NotSupportedException( "LocalTransactions are not supported." );
     }
 
     @Override
     public synchronized XAResource getXAResource() throws ResourceException
     {
-        log.log(System.Logger.Level.TRACE,"getXAResource()");
+        log.log(DEBUG,"getXAResource()");
         return this.xaResource;
     }
 
@@ -222,7 +224,7 @@ public class CasualManagedConnection implements ManagedConnection, NetworkListen
     @Override
     public ManagedConnectionMetaData getMetaData() throws ResourceException
     {
-        log.log(System.Logger.Level.TRACE,"getMetaData()");
+        log.log(DEBUG,"getMetaData()");
         return new CasualManagedConnectionMetaData();
     }
 
@@ -294,7 +296,7 @@ public class CasualManagedConnection implements ManagedConnection, NetworkListen
     @Override
     public void disconnected(Exception reason)
     {
-        log.log(System.Logger.Level.TRACE,() -> "disconnected: " + this);
+        log.log(DEBUG,() -> "disconnected: " + this);
         ConnectionEvent event = new ConnectionEvent(this, ConnectionEvent.CONNECTION_ERROR_OCCURRED, reason);
         connectionEventHandler.sendEvent(event);
     }
@@ -322,7 +324,7 @@ public class CasualManagedConnection implements ManagedConnection, NetworkListen
     {
         NettyConnectionInformation ci = NettyConnectionInformationCreator.create(InetSocketAddress.createUnresolved(mcf.getHostName(), mcf.getPortNumber()), mcf.getCasualProtocolVersion());
         NetworkConnection newNetworkConnection = NettyNetworkConnection.of(ci, this);
-        log.log(System.Logger.Level.TRACE,() -> "created new nw connection " + this);
+        log.log(DEBUG,() -> "created new nw connection " + this);
         return newNetworkConnection;
     }
 }

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualManagedConnectionFactory.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualManagedConnectionFactory.java
@@ -25,6 +25,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static java.lang.System.Logger.Level.*;
+
 /**
  * CasualManagedConnectionFactory
  *
@@ -107,7 +109,7 @@ public class CasualManagedConnectionFactory implements ManagedConnectionFactory,
    @Override
    public Object createConnectionFactory(ConnectionManager cxManager) throws ResourceException
    {
-      log.log(System.Logger.Level.TRACE,"createConnectionFactory()");
+      log.log(DEBUG,"createConnectionFactory()");
       return new CasualConnectionFactoryImpl(this, cxManager);
    }
 
@@ -124,7 +126,7 @@ public class CasualManagedConnectionFactory implements ManagedConnectionFactory,
       try
       {
          CasualManagedConnection managedConnection = casualManagedConnectionProducer.createManagedConnection(this);
-         log.log(System.Logger.Level.TRACE,() -> "Created a new managed connection: " + managedConnection);
+         log.log(DEBUG,() -> "Created a new managed connection: " + managedConnection);
          return managedConnection;
       }
       catch(Exception e)
@@ -133,7 +135,7 @@ public class CasualManagedConnectionFactory implements ManagedConnectionFactory,
          PrintWriter printWriter = new PrintWriter( writer );
          e.printStackTrace(printWriter);
          printWriter.flush();
-         log.log(System.Logger.Level.WARNING,() -> "createManagedConnection failed: " + writer);
+         log.log(WARNING,() -> "createManagedConnection failed: " + writer,e);
          throw new CommException(e);
       }
    }
@@ -143,7 +145,7 @@ public class CasualManagedConnectionFactory implements ManagedConnectionFactory,
    public ManagedConnection matchManagedConnections(Set connectionSet,
                                                     Subject subject, ConnectionRequestInfo cxRequestInfo) throws ResourceException
    {
-      log.log(System.Logger.Level.TRACE,"matchManagedConnections()");
+      log.log(DEBUG,"matchManagedConnections()");
       return (ManagedConnection)connectionSet.stream()
                                              .filter(CasualManagedConnection.class::isInstance)
                                              .findFirst( )
@@ -166,28 +168,28 @@ public class CasualManagedConnectionFactory implements ManagedConnectionFactory,
    @Override
    public PrintWriter getLogWriter() throws ResourceException
    {
-      log.log(System.Logger.Level.TRACE,"getLogWriter()");
+      log.log(DEBUG,"getLogWriter()");
       return logwriter;
    }
 
    @Override
    public void setLogWriter(PrintWriter out) throws ResourceException
    {
-      log.log(System.Logger.Level.TRACE,"setLogWriter()");
+      log.log(DEBUG,"setLogWriter()");
       logwriter = out;
    }
 
    @Override
    public ResourceAdapter getResourceAdapter()
    {
-      log.log(System.Logger.Level.TRACE,"getResourceAdapter()");
+      log.log(DEBUG,"getResourceAdapter()");
       return ra;
    }
 
    @Override
    public void setResourceAdapter(ResourceAdapter ra)
    {
-      log.log(System.Logger.Level.TRACE,"setResourceAdapter()");
+      log.log(DEBUG,"setResourceAdapter()");
       this.ra = ra;
    }
 

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualManagedConnectionFactory.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualManagedConnectionFactory.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /**
@@ -36,7 +35,7 @@ import java.util.stream.Collectors;
 public class CasualManagedConnectionFactory implements ManagedConnectionFactory, ResourceAdapterAssociation, ValidatingManagedConnectionFactory
 { 
    private static final long serialVersionUID = 1L;
-   private static Logger log = Logger.getLogger(CasualManagedConnectionFactory.class.getName());
+   private static System.Logger log = System.getLogger(CasualManagedConnectionFactory.class.getName());
    private  CasualManagedConnectionProducer casualManagedConnectionProducer;
    private ResourceAdapter ra;
    private PrintWriter logwriter;
@@ -108,7 +107,7 @@ public class CasualManagedConnectionFactory implements ManagedConnectionFactory,
    @Override
    public Object createConnectionFactory(ConnectionManager cxManager) throws ResourceException
    {
-      log.finest("createConnectionFactory()");
+      log.log(System.Logger.Level.TRACE,"createConnectionFactory()");
       return new CasualConnectionFactoryImpl(this, cxManager);
    }
 
@@ -125,7 +124,7 @@ public class CasualManagedConnectionFactory implements ManagedConnectionFactory,
       try
       {
          CasualManagedConnection managedConnection = casualManagedConnectionProducer.createManagedConnection(this);
-         log.finest(() -> "Created a new managed connection: " + managedConnection);
+         log.log(System.Logger.Level.TRACE,() -> "Created a new managed connection: " + managedConnection);
          return managedConnection;
       }
       catch(Exception e)
@@ -134,7 +133,7 @@ public class CasualManagedConnectionFactory implements ManagedConnectionFactory,
          PrintWriter printWriter = new PrintWriter( writer );
          e.printStackTrace(printWriter);
          printWriter.flush();
-         log.warning(() -> "createManagedConnection failed: " + writer);
+         log.log(System.Logger.Level.WARNING,() -> "createManagedConnection failed: " + writer);
          throw new CommException(e);
       }
    }
@@ -144,7 +143,7 @@ public class CasualManagedConnectionFactory implements ManagedConnectionFactory,
    public ManagedConnection matchManagedConnections(Set connectionSet,
                                                     Subject subject, ConnectionRequestInfo cxRequestInfo) throws ResourceException
    {
-      log.finest("matchManagedConnections()");
+      log.log(System.Logger.Level.TRACE,"matchManagedConnections()");
       return (ManagedConnection)connectionSet.stream()
                                              .filter(CasualManagedConnection.class::isInstance)
                                              .findFirst( )
@@ -167,28 +166,28 @@ public class CasualManagedConnectionFactory implements ManagedConnectionFactory,
    @Override
    public PrintWriter getLogWriter() throws ResourceException
    {
-      log.finest("getLogWriter()");
+      log.log(System.Logger.Level.TRACE,"getLogWriter()");
       return logwriter;
    }
 
    @Override
    public void setLogWriter(PrintWriter out) throws ResourceException
    {
-      log.finest("setLogWriter()");
+      log.log(System.Logger.Level.TRACE,"setLogWriter()");
       logwriter = out;
    }
 
    @Override
    public ResourceAdapter getResourceAdapter()
    {
-      log.finest("getResourceAdapter()");
+      log.log(System.Logger.Level.TRACE,"getResourceAdapter()");
       return ra;
    }
 
    @Override
    public void setResourceAdapter(ResourceAdapter ra)
    {
-      log.finest("setResourceAdapter()");
+      log.log(System.Logger.Level.TRACE,"setResourceAdapter()");
       this.ra = ra;
    }
 

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualManagedConnectionMetaData.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualManagedConnectionMetaData.java
@@ -10,6 +10,8 @@ import se.laz.casual.internal.CasualConstants;
 import jakarta.resource.ResourceException;
 import jakarta.resource.spi.ManagedConnectionMetaData;
 
+import static java.lang.System.Logger.Level.*;
+
 /**
  * CasualManagedConnectionMetaData
  *
@@ -22,21 +24,21 @@ public final class CasualManagedConnectionMetaData implements ManagedConnectionM
     @Override
     public String getEISProductName() throws ResourceException
     {
-        log.log(System.Logger.Level.TRACE,"getEISProductName()");
+        log.log(DEBUG,"getEISProductName()");
         return CasualConstants.CASUAL_NAME;
     }
 
     @Override
     public String getEISProductVersion() throws ResourceException
     {
-        log.log(System.Logger.Level.TRACE,"getEISProductVersion()");
+        log.log(DEBUG,"getEISProductVersion()");
         return CasualConstants.CASUAL_API_VERSION;
     }
 
     @Override
     public int getMaxConnections() throws ResourceException
     {
-        log.log(System.Logger.Level.TRACE,"getMaxConnections()");
+        log.log(DEBUG,"getMaxConnections()");
         //Assuming this is the EIS Server we are not aware of any limitations
         //so shall, to that effect, return 0.
         return 0;
@@ -45,7 +47,7 @@ public final class CasualManagedConnectionMetaData implements ManagedConnectionM
     @Override
     public String getUserName() throws ResourceException
     {
-        log.log(System.Logger.Level.TRACE,"getUserName()");
+        log.log(DEBUG,"getUserName()");
         return System.getProperty("user.name");
     }
 

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualManagedConnectionMetaData.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualManagedConnectionMetaData.java
@@ -9,7 +9,6 @@ import se.laz.casual.internal.CasualConstants;
 
 import jakarta.resource.ResourceException;
 import jakarta.resource.spi.ManagedConnectionMetaData;
-import java.util.logging.Logger;
 
 /**
  * CasualManagedConnectionMetaData
@@ -18,26 +17,26 @@ import java.util.logging.Logger;
  */
 public final class CasualManagedConnectionMetaData implements ManagedConnectionMetaData
 {
-    private static Logger log = Logger.getLogger(CasualManagedConnectionMetaData.class.getName());
+    private static System.Logger log = System.getLogger(CasualManagedConnectionMetaData.class.getName());
 
     @Override
     public String getEISProductName() throws ResourceException
     {
-        log.finest("getEISProductName()");
+        log.log(System.Logger.Level.TRACE,"getEISProductName()");
         return CasualConstants.CASUAL_NAME;
     }
 
     @Override
     public String getEISProductVersion() throws ResourceException
     {
-        log.finest("getEISProductVersion()");
+        log.log(System.Logger.Level.TRACE,"getEISProductVersion()");
         return CasualConstants.CASUAL_API_VERSION;
     }
 
     @Override
     public int getMaxConnections() throws ResourceException
     {
-        log.finest("getMaxConnections()");
+        log.log(System.Logger.Level.TRACE,"getMaxConnections()");
         //Assuming this is the EIS Server we are not aware of any limitations
         //so shall, to that effect, return 0.
         return 0;
@@ -46,7 +45,7 @@ public final class CasualManagedConnectionMetaData implements ManagedConnectionM
     @Override
     public String getUserName() throws ResourceException
     {
-        log.finest("getUserName()");
+        log.log(System.Logger.Level.TRACE,"getUserName()");
         return System.getProperty("user.name");
     }
 

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceAdapter.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceAdapter.java
@@ -51,6 +51,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import static java.lang.System.Logger.Level.*;
+
 /**
  * CasualResourceAdapter
  *
@@ -86,7 +88,7 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
         //JCA requires ResourceAdapter has a no arg constructor.
         //It is also not possible to inject with CDI on wildfly only ConfigProperty annotations.
 
-        log.log(System.Logger.Level.INFO, ConfigurationService.log() );
+        log.log(INFO, ConfigurationService.log() );
         initialiseFielded();
         startEventServer();
     }
@@ -107,7 +109,7 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
         if( ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_FIELD_TABLE ) != null )
         {
 
-            log.log(System.Logger.Level.TRACE, ()-> "CasualFieldedLookup static initialisation: " + CasualFieldedLookup.getURL() );
+            log.log(DEBUG, ()-> "CasualFieldedLookup static initialisation: " + CasualFieldedLookup.getURL() );
         }
     }
 
@@ -116,14 +118,14 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
         boolean enabled = ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_EVENT_SERVER_ENABLED );
         if( enabled )
         {
-            log.log(System.Logger.Level.INFO, ()-> "starting event server.");
+            log.log(INFO, ()-> "starting event server.");
             eventServer = EventServer.of(EventServerConnectionInformation.createBuilder()
                     .withUseEpoll( ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_EVENT_SERVER_USE_EPOLL ) )
                     .withPort( ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_EVENT_SERVER_PORT ) )
                     .withShutdownTimeout( ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_EVENT_SERVER_SHUTDOWN_TIMEOUT_MILLIS ) )
                     .withShutdownQuietPeriod( ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_EVENT_SERVER_SHUTDOWN_QUIET_PERIOD_MILLIS ) )
                     .build(), ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_DOMAIN_ID ).getId() );
-            log.log(System.Logger.Level.INFO, ()-> "event server started at port: " + ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_EVENT_SERVER_PORT ) );
+            log.log(INFO, ()-> "event server started at port: " + ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_EVENT_SERVER_PORT ) );
             RuntimeInformation.setEventServerStarted(true);
         }
     }
@@ -133,7 +135,7 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
     public void endpointActivation(MessageEndpointFactory endpointFactory,
                                    ActivationSpec spec) throws ResourceException
     {
-        log.log(System.Logger.Level.INFO,()->"start endpointActivation() ");
+        log.log(INFO,()->"start endpointActivation() ");
         inboundTransactionRegistry = new CasualInboundTransactionRegistry();
         RuntimeInformation.setDomainIsBeingShutdown(false);
         CasualActivationSpec as = (CasualActivationSpec) spec;
@@ -147,10 +149,10 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
                 .withInboundTransactionRegistry(inboundTransactionRegistry)
                 .build();
         activations.put(as.getPort(), as);
-        log.log(System.Logger.Level.INFO,() -> "start casual inbound server" );
+        log.log(INFO,() -> "start casual inbound server" );
         startInboundServer( ci );
         maybeStartReverseInbound( ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_REVERSE_INBOUND_INSTANCES ), endpointFactory, workManager, xaTerminator);
-        log.log(System.Logger.Level.TRACE,() -> "end endpointActivation()");
+        log.log(DEBUG,() -> "end endpointActivation()");
 
     }
 
@@ -224,7 +226,7 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
     public void endpointDeactivation(MessageEndpointFactory endpointFactory,
                                      ActivationSpec spec)
     {
-        log.log(System.Logger.Level.INFO,()->"endpointDeactivation() ");
+        log.log(INFO,()->"endpointDeactivation() ");
         RuntimeInformation.setDomainIsBeingShutdown(true);
         InboundDeactivatedContext.domainDisconnect();
         InboundDeactivatedContext.clear();
@@ -246,7 +248,7 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
     public void start(BootstrapContext ctx)
             throws ResourceAdapterInternalException
     {
-        log.log(System.Logger.Level.TRACE,()->"start()");
+        log.log(DEBUG,()->"start()");
         workManager = ctx.getWorkManager();
         xaTerminator = ctx.getXATerminator();
         JMXStartup.getInstance().initJMX();
@@ -255,7 +257,7 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
     @Override
     public void stop()
     {
-        log.log(System.Logger.Level.TRACE,()->"stop()");
+        log.log(DEBUG,()->"stop()");
     }
 
     //Return empty array not null. But specification says to return null if we don't support this feature, so ignoring.
@@ -264,7 +266,7 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
     public XAResource[] getXAResources(ActivationSpec[] specs)
             throws ResourceException
     {
-        log.log(System.Logger.Level.TRACE,()->"getXAResources()");
+        log.log(DEBUG,()->"getXAResources()");
         return null;
     }
 
@@ -296,14 +298,14 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
     @Override
     public void disconnected(ReverseInboundServer server)
     {
-        log.log(System.Logger.Level.INFO,() -> "ReverseInbound: " + server.getAddress() + " disconnected");
+        log.log(INFO,() -> "ReverseInbound: " + server.getAddress() + " disconnected");
         reverseInbounds.remove(server);
     }
 
     @Override
     public void connected(ReverseInboundServer server)
     {
-        log.log(System.Logger.Level.INFO,() -> "ReverseInbound: " + server.getAddress() + " connection resumed");
+        log.log(INFO,() -> "ReverseInbound: " + server.getAddress() + " connection resumed");
         reverseInbounds.add(server);
     }
 

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceAdapter.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualResourceAdapter.java
@@ -50,7 +50,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import java.util.logging.Logger;
 
 /**
  * CasualResourceAdapter
@@ -66,7 +65,7 @@ import java.util.logging.Logger;
 )
 public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundListener
 {
-    private static Logger log = Logger.getLogger(CasualResourceAdapter.class.getName());
+    private static System.Logger log = System.getLogger(CasualResourceAdapter.class.getName());
     private ConcurrentHashMap<Integer, CasualActivationSpec> activations = new ConcurrentHashMap<>();
     private List<ReverseInboundServer> reverseInbounds = new ArrayList<>();
     private CasualInboundTransactionRegistry inboundTransactionRegistry;
@@ -87,7 +86,7 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
         //JCA requires ResourceAdapter has a no arg constructor.
         //It is also not possible to inject with CDI on wildfly only ConfigProperty annotations.
 
-        log.info( ConfigurationService.log() );
+        log.log(System.Logger.Level.INFO, ConfigurationService.log() );
         initialiseFielded();
         startEventServer();
     }
@@ -108,7 +107,7 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
         if( ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_FIELD_TABLE ) != null )
         {
 
-            log.finest( ()-> "CasualFieldedLookup static initialisation: " + CasualFieldedLookup.getURL() );
+            log.log(System.Logger.Level.TRACE, ()-> "CasualFieldedLookup static initialisation: " + CasualFieldedLookup.getURL() );
         }
     }
 
@@ -117,14 +116,14 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
         boolean enabled = ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_EVENT_SERVER_ENABLED );
         if( enabled )
         {
-            log.info( ()-> "starting event server.");
+            log.log(System.Logger.Level.INFO, ()-> "starting event server.");
             eventServer = EventServer.of(EventServerConnectionInformation.createBuilder()
                     .withUseEpoll( ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_EVENT_SERVER_USE_EPOLL ) )
                     .withPort( ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_EVENT_SERVER_PORT ) )
                     .withShutdownTimeout( ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_EVENT_SERVER_SHUTDOWN_TIMEOUT_MILLIS ) )
                     .withShutdownQuietPeriod( ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_EVENT_SERVER_SHUTDOWN_QUIET_PERIOD_MILLIS ) )
                     .build(), ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_DOMAIN_ID ).getId() );
-            log.info( ()-> "event server started at port: " + ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_EVENT_SERVER_PORT ) );
+            log.log(System.Logger.Level.INFO, ()-> "event server started at port: " + ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_EVENT_SERVER_PORT ) );
             RuntimeInformation.setEventServerStarted(true);
         }
     }
@@ -134,7 +133,7 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
     public void endpointActivation(MessageEndpointFactory endpointFactory,
                                    ActivationSpec spec) throws ResourceException
     {
-        log.info(()->"start endpointActivation() ");
+        log.log(System.Logger.Level.INFO,()->"start endpointActivation() ");
         inboundTransactionRegistry = new CasualInboundTransactionRegistry();
         RuntimeInformation.setDomainIsBeingShutdown(false);
         CasualActivationSpec as = (CasualActivationSpec) spec;
@@ -148,10 +147,10 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
                 .withInboundTransactionRegistry(inboundTransactionRegistry)
                 .build();
         activations.put(as.getPort(), as);
-        log.info(() -> "start casual inbound server" );
+        log.log(System.Logger.Level.INFO,() -> "start casual inbound server" );
         startInboundServer( ci );
         maybeStartReverseInbound( ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_REVERSE_INBOUND_INSTANCES ), endpointFactory, workManager, xaTerminator);
-        log.finest(() -> "end endpointActivation()");
+        log.log(System.Logger.Level.TRACE,() -> "end endpointActivation()");
 
     }
 
@@ -225,7 +224,7 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
     public void endpointDeactivation(MessageEndpointFactory endpointFactory,
                                      ActivationSpec spec)
     {
-        log.info(()->"endpointDeactivation() ");
+        log.log(System.Logger.Level.INFO,()->"endpointDeactivation() ");
         RuntimeInformation.setDomainIsBeingShutdown(true);
         InboundDeactivatedContext.domainDisconnect();
         InboundDeactivatedContext.clear();
@@ -247,7 +246,7 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
     public void start(BootstrapContext ctx)
             throws ResourceAdapterInternalException
     {
-        log.finest(()->"start()");
+        log.log(System.Logger.Level.TRACE,()->"start()");
         workManager = ctx.getWorkManager();
         xaTerminator = ctx.getXATerminator();
         JMXStartup.getInstance().initJMX();
@@ -256,7 +255,7 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
     @Override
     public void stop()
     {
-        log.finest(()->"stop()");
+        log.log(System.Logger.Level.TRACE,()->"stop()");
     }
 
     //Return empty array not null. But specification says to return null if we don't support this feature, so ignoring.
@@ -265,7 +264,7 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
     public XAResource[] getXAResources(ActivationSpec[] specs)
             throws ResourceException
     {
-        log.finest(()->"getXAResources()");
+        log.log(System.Logger.Level.TRACE,()->"getXAResources()");
         return null;
     }
 
@@ -297,14 +296,14 @@ public class CasualResourceAdapter implements ResourceAdapter, ReverseInboundLis
     @Override
     public void disconnected(ReverseInboundServer server)
     {
-        log.info(() -> "ReverseInbound: " + server.getAddress() + " disconnected");
+        log.log(System.Logger.Level.INFO,() -> "ReverseInbound: " + server.getAddress() + " disconnected");
         reverseInbounds.remove(server);
     }
 
     @Override
     public void connected(ReverseInboundServer server)
     {
-        log.info(() -> "ReverseInbound: " + server.getAddress() + " connection resumed");
+        log.log(System.Logger.Level.INFO,() -> "ReverseInbound: " + server.getAddress() + " connection resumed");
         reverseInbounds.add(server);
     }
 

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualXAResource.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualXAResource.java
@@ -25,14 +25,13 @@ import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.logging.Logger;
 
 /**
  * @author jone
  */
 public class CasualXAResource implements XAResource
 {
-    private static final Logger LOG = Logger.getLogger(CasualXAResource.class.getName());
+    private static final System.Logger LOG = System.getLogger(CasualXAResource.class.getName());
     private static final Xid[] NO_XIDS = {};
     private final CasualManagedConnection casualManagedConnection;
     private final int resourceManagerId;
@@ -58,7 +57,7 @@ public class CasualXAResource implements XAResource
         {
             flags = Flag.of(XAFlags.TMONEPHASE);
         }
-        LOG.finest(() -> String.format("trying to commit, xid: %s ( %s ) onePhase?%b", PrettyPrinter.casualStringify(xid), xid, onePhaseCommit));
+        LOG.log(System.Logger.Level.TRACE,() -> String.format("trying to commit, xid: %s ( %s ) onePhase?%b", PrettyPrinter.casualStringify(xid), xid, onePhaseCommit));
         CasualTransactionResourceCommitRequestMessage commitRequest =
             CasualTransactionResourceCommitRequestMessage.of(UUID.randomUUID(), xid, resourceManagerId, flags);
         CasualNWMessage<CasualTransactionResourceCommitRequestMessage> requestEnvelope = CasualNWMessageImpl.of(UUID.randomUUID(), commitRequest);
@@ -67,7 +66,7 @@ public class CasualXAResource implements XAResource
         CasualNWMessage<CasualTransactionResourceCommitReplyMessage> replyEnvelope = replyEnvelopeFuture.join();
         CasualTransactionResourceCommitReplyMessage replyMsg = replyEnvelope.getMessage();
         throwWhenTransactionErrorCode(replyMsg.getTransactionReturnCode());
-        LOG.finest(() -> String.format("commited, xid: %s ( %s )", PrettyPrinter.casualStringify(xid), xid));
+        LOG.log(System.Logger.Level.TRACE,() -> String.format("commited, xid: %s ( %s )", PrettyPrinter.casualStringify(xid), xid));
     }
 
     /**
@@ -82,7 +81,7 @@ public class CasualXAResource implements XAResource
     @SuppressWarnings("java:S1301")
     public void end(Xid xid, int flag) throws XAException
     {
-        LOG.finest(()-> String.format("end, xid: %s (%s) flag: %d, %s ", PrettyPrinter.casualStringify(xid), xid, flag, XAFlags.unmarshall(flag)));
+        LOG.log(System.Logger.Level.TRACE,()-> String.format("end, xid: %s (%s) flag: %d, %s ", PrettyPrinter.casualStringify(xid), xid, flag, XAFlags.unmarshall(flag)));
         CasualResourceManager.getInstance().remove(domainId(), xid);
         disassociate();
         XAFlags f = XAFlags.unmarshall(flag);
@@ -91,7 +90,7 @@ public class CasualXAResource implements XAResource
             case TMSUCCESS, TMFAIL, TMSUSPEND:
                 break;
             default:
-                LOG.finest(()->"throwing XAException.XAER_RMFAIL");
+                LOG.log(System.Logger.Level.TRACE,()->"throwing XAException.XAER_RMFAIL");
                 throw new XAException(XAException.XAER_RMFAIL);
         }
     }
@@ -133,7 +132,7 @@ public class CasualXAResource implements XAResource
             return XAResource.XA_RDONLY;
         }
 
-        LOG.finest(() -> String.format("trying to prepare, xid: %s ( %s )", PrettyPrinter.casualStringify(xid), xid));
+        LOG.log(System.Logger.Level.TRACE,() -> String.format("trying to prepare, xid: %s ( %s )", PrettyPrinter.casualStringify(xid), xid));
         Flag<XAFlags> flags = Flag.of(XAFlags.TMNOFLAGS);
         CasualTransactionResourcePrepareRequestMessage prepareRequest = CasualTransactionResourcePrepareRequestMessage.of(UUID.randomUUID(), xid, resourceManagerId, flags);
         CasualNWMessage<CasualTransactionResourcePrepareRequestMessage> requestEnvelope = CasualNWMessageImpl.of(UUID.randomUUID(), prepareRequest);
@@ -142,7 +141,7 @@ public class CasualXAResource implements XAResource
         CasualNWMessage<CasualTransactionResourcePrepareReplyMessage> replyEnvelope = replyEnvelopeFuture.join();
         CasualTransactionResourcePrepareReplyMessage replyMsg = replyEnvelope.getMessage();
         throwWhenTransactionErrorCode(replyMsg.getTransactionReturnCode());
-        LOG.finest(() -> String.format("prepared, xid: %s ( %s ), XA_RDONLY: %b", PrettyPrinter.casualStringify(xid), xid, XAReturnCode.XA_RDONLY == replyMsg.getTransactionReturnCode()));
+        LOG.log(System.Logger.Level.TRACE,() -> String.format("prepared, xid: %s ( %s ), XA_RDONLY: %b", PrettyPrinter.casualStringify(xid), xid, XAReturnCode.XA_RDONLY == replyMsg.getTransactionReturnCode()));
         return replyMsg.getTransactionReturnCode().getId();
     }
 
@@ -155,7 +154,7 @@ public class CasualXAResource implements XAResource
     @Override
     public void rollback(Xid xid) throws XAException
     {
-        LOG.finest(() -> String.format("trying to rollback, xid: %s ( %s )", PrettyPrinter.casualStringify(xid), xid));
+        LOG.log(System.Logger.Level.TRACE,() -> String.format("trying to rollback, xid: %s ( %s )", PrettyPrinter.casualStringify(xid), xid));
         Flag<XAFlags> flags = Flag.of(XAFlags.TMNOFLAGS);
         CasualTransactionResourceRollbackRequestMessage request =
                 CasualTransactionResourceRollbackRequestMessage.of(UUID.randomUUID(), xid, resourceManagerId, flags);
@@ -165,7 +164,7 @@ public class CasualXAResource implements XAResource
         CasualNWMessage<CasualTransactionResourceRollbackReplyMessage> replyEnvelope = replyEnvelopeFuture.join();
         CasualTransactionResourceRollbackReplyMessage replyMsg = replyEnvelope.getMessage();
         throwWhenTransactionErrorCode(replyMsg.getTransactionReturnCode());
-        LOG.finest(() ->  String.format("rolled, xid: %s ( %s )", PrettyPrinter.casualStringify(xid), xid));
+        LOG.log(System.Logger.Level.TRACE,() ->  String.format("rolled, xid: %s ( %s )", PrettyPrinter.casualStringify(xid), xid));
     }
 
     @Override
@@ -178,12 +177,12 @@ public class CasualXAResource implements XAResource
     @Override
     public void start(Xid xid, int i) throws XAException
     {
-        LOG.finest(()-> String.format("start, xid: %s (%s) flag: %d, %s ", PrettyPrinter.casualStringify(xid), xid, i, XAFlags.unmarshall(i)));
+        LOG.log(System.Logger.Level.TRACE,()-> String.format("start, xid: %s (%s) flag: %d, %s ", PrettyPrinter.casualStringify(xid), xid, i, XAFlags.unmarshall(i)));
         readOnly = false;
         if(!(XAFlags.TMJOIN.getValue() == i || XAFlags.TMRESUME.getValue() == i) &&
             CasualResourceManager.getInstance().isPending(domainId(), xid))
         {
-            LOG.finest(()->"throwing XAException.XAER_DUPID");
+            LOG.log(System.Logger.Level.TRACE,()->"throwing XAException.XAER_DUPID");
             throw new XAException(XAException.XAER_DUPID);
         }
         associate(xid);
@@ -235,7 +234,7 @@ public class CasualXAResource implements XAResource
             case XA_OK, XA_RDONLY:
                 break;
             default:
-                LOG.finest(()->"throwing XAException for XAReturnCode: " + transactionReturnCode);
+                LOG.log(System.Logger.Level.TRACE,()->"throwing XAException for XAReturnCode: " + transactionReturnCode);
                 throw new XAException( transactionReturnCode.getId());
         }
     }

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualXAResource.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/CasualXAResource.java
@@ -26,6 +26,8 @@ import javax.transaction.xa.Xid;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
+import static java.lang.System.Logger.Level.*;
+
 /**
  * @author jone
  */
@@ -57,7 +59,7 @@ public class CasualXAResource implements XAResource
         {
             flags = Flag.of(XAFlags.TMONEPHASE);
         }
-        LOG.log(System.Logger.Level.TRACE,() -> String.format("trying to commit, xid: %s ( %s ) onePhase?%b", PrettyPrinter.casualStringify(xid), xid, onePhaseCommit));
+        LOG.log(DEBUG,() -> String.format("trying to commit, xid: %s ( %s ) onePhase?%b", PrettyPrinter.casualStringify(xid), xid, onePhaseCommit));
         CasualTransactionResourceCommitRequestMessage commitRequest =
             CasualTransactionResourceCommitRequestMessage.of(UUID.randomUUID(), xid, resourceManagerId, flags);
         CasualNWMessage<CasualTransactionResourceCommitRequestMessage> requestEnvelope = CasualNWMessageImpl.of(UUID.randomUUID(), commitRequest);
@@ -66,7 +68,7 @@ public class CasualXAResource implements XAResource
         CasualNWMessage<CasualTransactionResourceCommitReplyMessage> replyEnvelope = replyEnvelopeFuture.join();
         CasualTransactionResourceCommitReplyMessage replyMsg = replyEnvelope.getMessage();
         throwWhenTransactionErrorCode(replyMsg.getTransactionReturnCode());
-        LOG.log(System.Logger.Level.TRACE,() -> String.format("commited, xid: %s ( %s )", PrettyPrinter.casualStringify(xid), xid));
+        LOG.log(DEBUG,() -> String.format("commited, xid: %s ( %s )", PrettyPrinter.casualStringify(xid), xid));
     }
 
     /**
@@ -81,7 +83,7 @@ public class CasualXAResource implements XAResource
     @SuppressWarnings("java:S1301")
     public void end(Xid xid, int flag) throws XAException
     {
-        LOG.log(System.Logger.Level.TRACE,()-> String.format("end, xid: %s (%s) flag: %d, %s ", PrettyPrinter.casualStringify(xid), xid, flag, XAFlags.unmarshall(flag)));
+        LOG.log(DEBUG,()-> String.format("end, xid: %s (%s) flag: %d, %s ", PrettyPrinter.casualStringify(xid), xid, flag, XAFlags.unmarshall(flag)));
         CasualResourceManager.getInstance().remove(domainId(), xid);
         disassociate();
         XAFlags f = XAFlags.unmarshall(flag);
@@ -90,7 +92,7 @@ public class CasualXAResource implements XAResource
             case TMSUCCESS, TMFAIL, TMSUSPEND:
                 break;
             default:
-                LOG.log(System.Logger.Level.TRACE,()->"throwing XAException.XAER_RMFAIL");
+                LOG.log(DEBUG,()->"throwing XAException.XAER_RMFAIL");
                 throw new XAException(XAException.XAER_RMFAIL);
         }
     }
@@ -132,7 +134,7 @@ public class CasualXAResource implements XAResource
             return XAResource.XA_RDONLY;
         }
 
-        LOG.log(System.Logger.Level.TRACE,() -> String.format("trying to prepare, xid: %s ( %s )", PrettyPrinter.casualStringify(xid), xid));
+        LOG.log(DEBUG,() -> String.format("trying to prepare, xid: %s ( %s )", PrettyPrinter.casualStringify(xid), xid));
         Flag<XAFlags> flags = Flag.of(XAFlags.TMNOFLAGS);
         CasualTransactionResourcePrepareRequestMessage prepareRequest = CasualTransactionResourcePrepareRequestMessage.of(UUID.randomUUID(), xid, resourceManagerId, flags);
         CasualNWMessage<CasualTransactionResourcePrepareRequestMessage> requestEnvelope = CasualNWMessageImpl.of(UUID.randomUUID(), prepareRequest);
@@ -141,7 +143,7 @@ public class CasualXAResource implements XAResource
         CasualNWMessage<CasualTransactionResourcePrepareReplyMessage> replyEnvelope = replyEnvelopeFuture.join();
         CasualTransactionResourcePrepareReplyMessage replyMsg = replyEnvelope.getMessage();
         throwWhenTransactionErrorCode(replyMsg.getTransactionReturnCode());
-        LOG.log(System.Logger.Level.TRACE,() -> String.format("prepared, xid: %s ( %s ), XA_RDONLY: %b", PrettyPrinter.casualStringify(xid), xid, XAReturnCode.XA_RDONLY == replyMsg.getTransactionReturnCode()));
+        LOG.log(DEBUG,() -> String.format("prepared, xid: %s ( %s ), XA_RDONLY: %b", PrettyPrinter.casualStringify(xid), xid, XAReturnCode.XA_RDONLY == replyMsg.getTransactionReturnCode()));
         return replyMsg.getTransactionReturnCode().getId();
     }
 
@@ -154,7 +156,7 @@ public class CasualXAResource implements XAResource
     @Override
     public void rollback(Xid xid) throws XAException
     {
-        LOG.log(System.Logger.Level.TRACE,() -> String.format("trying to rollback, xid: %s ( %s )", PrettyPrinter.casualStringify(xid), xid));
+        LOG.log(DEBUG,() -> String.format("trying to rollback, xid: %s ( %s )", PrettyPrinter.casualStringify(xid), xid));
         Flag<XAFlags> flags = Flag.of(XAFlags.TMNOFLAGS);
         CasualTransactionResourceRollbackRequestMessage request =
                 CasualTransactionResourceRollbackRequestMessage.of(UUID.randomUUID(), xid, resourceManagerId, flags);
@@ -164,7 +166,7 @@ public class CasualXAResource implements XAResource
         CasualNWMessage<CasualTransactionResourceRollbackReplyMessage> replyEnvelope = replyEnvelopeFuture.join();
         CasualTransactionResourceRollbackReplyMessage replyMsg = replyEnvelope.getMessage();
         throwWhenTransactionErrorCode(replyMsg.getTransactionReturnCode());
-        LOG.log(System.Logger.Level.TRACE,() ->  String.format("rolled, xid: %s ( %s )", PrettyPrinter.casualStringify(xid), xid));
+        LOG.log(DEBUG,() ->  String.format("rolled, xid: %s ( %s )", PrettyPrinter.casualStringify(xid), xid));
     }
 
     @Override
@@ -177,12 +179,12 @@ public class CasualXAResource implements XAResource
     @Override
     public void start(Xid xid, int i) throws XAException
     {
-        LOG.log(System.Logger.Level.TRACE,()-> String.format("start, xid: %s (%s) flag: %d, %s ", PrettyPrinter.casualStringify(xid), xid, i, XAFlags.unmarshall(i)));
+        LOG.log(DEBUG,()-> String.format("start, xid: %s (%s) flag: %d, %s ", PrettyPrinter.casualStringify(xid), xid, i, XAFlags.unmarshall(i)));
         readOnly = false;
         if(!(XAFlags.TMJOIN.getValue() == i || XAFlags.TMRESUME.getValue() == i) &&
             CasualResourceManager.getInstance().isPending(domainId(), xid))
         {
-            LOG.log(System.Logger.Level.TRACE,()->"throwing XAException.XAER_DUPID");
+            LOG.log(DEBUG,()->"throwing XAException.XAER_DUPID");
             throw new XAException(XAException.XAER_DUPID);
         }
         associate(xid);
@@ -234,7 +236,7 @@ public class CasualXAResource implements XAResource
             case XA_OK, XA_RDONLY:
                 break;
             default:
-                LOG.log(System.Logger.Level.TRACE,()->"throwing XAException for XAReturnCode: " + transactionReturnCode);
+                LOG.log(DEBUG,()->"throwing XAException for XAReturnCode: " + transactionReturnCode);
                 throw new XAException( transactionReturnCode.getId());
         }
     }

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/ShutdownBarrier.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/ShutdownBarrier.java
@@ -8,6 +8,8 @@ package se.laz.casual.jca;
 
 import java.util.Objects;
 
+import static java.lang.System.Logger.Level.*;
+
 public class ShutdownBarrier
 {
     private static final System.Logger log = System.getLogger(ShutdownBarrier.class.getName());
@@ -44,7 +46,7 @@ public class ShutdownBarrier
             {
                 Thread.currentThread().interrupt();
                 // we are not allowed to throw here, so we log it
-                log.log(System.Logger.Level.WARNING,() -> "shutdown barrier thread interrupted during sleep");
+                log.log(WARNING,() -> "shutdown barrier thread interrupted during sleep",e);
             }
         }
     }

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/ShutdownBarrier.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/ShutdownBarrier.java
@@ -7,11 +7,10 @@
 package se.laz.casual.jca;
 
 import java.util.Objects;
-import java.util.logging.Logger;
 
 public class ShutdownBarrier
 {
-    private static final Logger log = Logger.getLogger(ShutdownBarrier.class.getName());
+    private static final System.Logger log = System.getLogger(ShutdownBarrier.class.getName());
     private final long sleepTime;
     private final Predicate predicate;
 
@@ -45,7 +44,7 @@ public class ShutdownBarrier
             {
                 Thread.currentThread().interrupt();
                 // we are not allowed to throw here, so we log it
-                log.warning(() -> "shutdown barrier thread interrupted during sleep");
+                log.log(System.Logger.Level.WARNING,() -> "shutdown barrier thread interrupted during sleep");
             }
         }
     }

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/conversation/ConversationConnectCaller.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/conversation/ConversationConnectCaller.java
@@ -27,6 +27,8 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
+import static java.lang.System.Logger.Level.*;
+
 public class ConversationConnectCaller implements CasualConversationApi
 {
     private static final System.Logger LOG = System.getLogger(ConversationConnectCaller.class.getName());
@@ -75,11 +77,11 @@ public class ConversationConnectCaller implements CasualConversationApi
         connectReplyFuture.whenComplete((v, e) ->{
             if(null != e)
             {
-                LOG.log(System.Logger.Level.TRACE,()->"conversation tpconnect failed for corrid: " + corrId + "\n serviceName" + serviceName);
+                LOG.log(DEBUG,()->"conversation tpconnect failed for corrid: " + corrId + "\n serviceName" + serviceName);
                 f.completeExceptionally(e);
                 return;
             }
-            LOG.log(System.Logger.Level.TRACE,()->"conversation tpconnect ok for corrid: " + corrId + "\n serviceName" + serviceName);
+            LOG.log(DEBUG,()->"conversation tpconnect ok for corrid: " + corrId + "\n serviceName" + serviceName);
             f.complete(v);
         });
         CasualNWMessage<ConnectReply> msg = f.join();

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/conversation/ConversationConnectCaller.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/conversation/ConversationConnectCaller.java
@@ -26,11 +26,10 @@ import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.logging.Logger;
 
 public class ConversationConnectCaller implements CasualConversationApi
 {
-    private static final Logger LOG = Logger.getLogger(ConversationConnectCaller.class.getName());
+    private static final System.Logger LOG = System.getLogger(ConversationConnectCaller.class.getName());
     private static final int RESULT_CODE_UNKNOWN = -1;
     private final CasualManagedConnection managedConnection;
 
@@ -76,11 +75,11 @@ public class ConversationConnectCaller implements CasualConversationApi
         connectReplyFuture.whenComplete((v, e) ->{
             if(null != e)
             {
-                LOG.finest(()->"conversation tpconnect failed for corrid: " + corrId + "\n serviceName" + serviceName);
+                LOG.log(System.Logger.Level.TRACE,()->"conversation tpconnect failed for corrid: " + corrId + "\n serviceName" + serviceName);
                 f.completeExceptionally(e);
                 return;
             }
-            LOG.finest(()->"conversation tpconnect ok for corrid: " + corrId + "\n serviceName" + serviceName);
+            LOG.log(System.Logger.Level.TRACE,()->"conversation tpconnect ok for corrid: " + corrId + "\n serviceName" + serviceName);
             f.complete(v);
         });
         CasualNWMessage<ConnectReply> msg = f.join();

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/discovery/CasualDiscoveryCaller.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/discovery/CasualDiscoveryCaller.java
@@ -24,12 +24,11 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.logging.Logger;
 
 public class CasualDiscoveryCaller implements CasualDiscoveryApi
 {
 
-    private static final Logger LOG = Logger.getLogger(CasualDiscoveryCaller.class.getName());
+    private static final System.Logger LOG = System.getLogger(CasualDiscoveryCaller.class.getName());
     private CasualManagedConnection connection;
 
     private CasualDiscoveryCaller(CasualManagedConnection connection)
@@ -46,7 +45,7 @@ public class CasualDiscoveryCaller implements CasualDiscoveryApi
     @Override
     public DiscoveryReturn discover(UUID corrid, List<String> serviceNames, List<String> queueNames)
     {
-        LOG.finest(() -> "issuing domain discovery, corrid: " + PrettyPrinter.casualStringify(corrid) + " service names: " + serviceNames + " queue names: " + queueNames);
+        LOG.log(System.Logger.Level.TRACE,() -> "issuing domain discovery, corrid: " + PrettyPrinter.casualStringify(corrid) + " service names: " + serviceNames + " queue names: " + queueNames);
 
         CasualDomainDiscoveryRequestMessage requestMsg = CasualDomainDiscoveryRequestMessage.createBuilder()
                                                                                             .setExecution(UUID.randomUUID())
@@ -59,7 +58,7 @@ public class CasualDiscoveryCaller implements CasualDiscoveryApi
         CompletableFuture<CasualNWMessage<CasualDomainDiscoveryReplyMessage>> replyMsgFuture = connection.getNetworkConnection().request(msg);
 
         CasualNWMessage<CasualDomainDiscoveryReplyMessage> replyMsg = replyMsgFuture.join();
-        LOG.finest(() -> "domain discovery ok for corrid: " + PrettyPrinter.casualStringify(corrid) + "reply -> service names: " + serviceNames + " queue names: " + queueNames);
+        LOG.log(System.Logger.Level.TRACE,() -> "domain discovery ok for corrid: " + PrettyPrinter.casualStringify(corrid) + "reply -> service names: " + serviceNames + " queue names: " + queueNames);
         return toDiscoveryReturn(replyMsg.getMessage());
     }
 

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/discovery/CasualDiscoveryCaller.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/discovery/CasualDiscoveryCaller.java
@@ -25,6 +25,8 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
+import static java.lang.System.Logger.Level.*;
+
 public class CasualDiscoveryCaller implements CasualDiscoveryApi
 {
 
@@ -45,7 +47,7 @@ public class CasualDiscoveryCaller implements CasualDiscoveryApi
     @Override
     public DiscoveryReturn discover(UUID corrid, List<String> serviceNames, List<String> queueNames)
     {
-        LOG.log(System.Logger.Level.TRACE,() -> "issuing domain discovery, corrid: " + PrettyPrinter.casualStringify(corrid) + " service names: " + serviceNames + " queue names: " + queueNames);
+        LOG.log(DEBUG,() -> "issuing domain discovery, corrid: " + PrettyPrinter.casualStringify(corrid) + " service names: " + serviceNames + " queue names: " + queueNames);
 
         CasualDomainDiscoveryRequestMessage requestMsg = CasualDomainDiscoveryRequestMessage.createBuilder()
                                                                                             .setExecution(UUID.randomUUID())
@@ -58,7 +60,7 @@ public class CasualDiscoveryCaller implements CasualDiscoveryApi
         CompletableFuture<CasualNWMessage<CasualDomainDiscoveryReplyMessage>> replyMsgFuture = connection.getNetworkConnection().request(msg);
 
         CasualNWMessage<CasualDomainDiscoveryReplyMessage> replyMsg = replyMsgFuture.join();
-        LOG.log(System.Logger.Level.TRACE,() -> "domain discovery ok for corrid: " + PrettyPrinter.casualStringify(corrid) + "reply -> service names: " + serviceNames + " queue names: " + queueNames);
+        LOG.log(DEBUG,() -> "domain discovery ok for corrid: " + PrettyPrinter.casualStringify(corrid) + "reply -> service names: " + serviceNames + " queue names: " + queueNames);
         return toDiscoveryReturn(replyMsg.getMessage());
     }
 

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/event/ConnectionEventHandler.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/event/ConnectionEventHandler.java
@@ -15,6 +15,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+import static java.lang.System.Logger.Level.*;
+
 public class ConnectionEventHandler
 {
     private static final System.Logger logger = System.getLogger(ConnectionEventHandler.class.getName());
@@ -33,7 +35,7 @@ public class ConnectionEventHandler
      */
     public void addConnectionEventListener(ConnectionEventListener listener)
     {
-        logger.log(System.Logger.Level.TRACE,"addConnectionEventListener()");
+        logger.log(DEBUG,"addConnectionEventListener()");
         Objects.requireNonNull( listener, "Listener is null" );
         listeners.add(listener);
     }
@@ -55,7 +57,7 @@ public class ConnectionEventHandler
      */
     public void removeConnectionEventListener(ConnectionEventListener listener)
     {
-        logger.log(System.Logger.Level.TRACE,"removeConnectionEventListener()");
+        logger.log(DEBUG,"removeConnectionEventListener()");
         Objects.requireNonNull( listener, "Listener is null" );
         listeners.remove(listener);
     }

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/event/ConnectionEventHandler.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/event/ConnectionEventHandler.java
@@ -14,11 +14,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.logging.Logger;
 
 public class ConnectionEventHandler
 {
-    private static final Logger logger = Logger.getLogger(ConnectionEventHandler.class.getName());
+    private static final System.Logger logger = System.getLogger(ConnectionEventHandler.class.getName());
 
     private final List<jakarta.resource.spi.ConnectionEventListener> listeners;
 
@@ -34,7 +33,7 @@ public class ConnectionEventHandler
      */
     public void addConnectionEventListener(ConnectionEventListener listener)
     {
-        logger.finest("addConnectionEventListener()");
+        logger.log(System.Logger.Level.TRACE,"addConnectionEventListener()");
         Objects.requireNonNull( listener, "Listener is null" );
         listeners.add(listener);
     }
@@ -56,7 +55,7 @@ public class ConnectionEventHandler
      */
     public void removeConnectionEventListener(ConnectionEventListener listener)
     {
-        logger.finest("removeConnectionEventListener()");
+        logger.log(System.Logger.Level.TRACE,"removeConnectionEventListener()");
         Objects.requireNonNull( listener, "Listener is null" );
         listeners.remove(listener);
     }

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/jmx/JMXStartup.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/jmx/JMXStartup.java
@@ -15,6 +15,8 @@ import javax.management.NotCompliantMBeanException;
 import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
 
+import static java.lang.System.Logger.Level.*;
+
 // yes it is intentional
 @SuppressWarnings("java:S6548")
 public class JMXStartup
@@ -40,7 +42,7 @@ public class JMXStartup
       }
       catch (MalformedObjectNameException | NotCompliantMBeanException | InstanceAlreadyExistsException | MBeanRegistrationException e)
       {
-         LOG.log(System.Logger.Level.WARNING,() -> "CasualMBean initiation failed, JMX entry will not exist: " + e);
+         LOG.log(WARNING,() -> "CasualMBean initiation failed, JMX entry will not exist: " + e,e);
       }
    }
 

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/jmx/JMXStartup.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/jmx/JMXStartup.java
@@ -14,13 +14,12 @@ import javax.management.MalformedObjectNameException;
 import javax.management.NotCompliantMBeanException;
 import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
-import java.util.logging.Logger;
 
 // yes it is intentional
 @SuppressWarnings("java:S6548")
 public class JMXStartup
 {
-   private static final Logger LOG = Logger.getLogger(JMXStartup.class.getName());
+   private static final System.Logger LOG = System.getLogger(JMXStartup.class.getName());
    private static final String NAME = "se.laz.casual.jca:type=Casual";
    private static final JMXStartup instance = new JMXStartup();
 
@@ -41,7 +40,7 @@ public class JMXStartup
       }
       catch (MalformedObjectNameException | NotCompliantMBeanException | InstanceAlreadyExistsException | MBeanRegistrationException e)
       {
-         LOG.warning(() -> "CasualMBean initiation failed, JMX entry will not exist: " + e);
+         LOG.log(System.Logger.Level.WARNING,() -> "CasualMBean initiation failed, JMX entry will not exist: " + e);
       }
    }
 

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/pool/NetworkConnectionPool.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/pool/NetworkConnectionPool.java
@@ -18,11 +18,10 @@ import se.laz.casual.network.outbound.NetworkListener;
 import java.net.InetSocketAddress;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Logger;
 
 public class NetworkConnectionPool implements ReferenceCountedNetworkCloseListener, NetworkListener
 {
-    private static final Logger LOG = Logger.getLogger(NetworkConnectionPool.class.getName());
+    private static final System.Logger LOG = System.getLogger(NetworkConnectionPool.class.getName());
     private final Address address;
     private final ConnectionContainer connections = ConnectionContainer.of();
     private final String poolName;
@@ -85,7 +84,7 @@ public class NetworkConnectionPool implements ReferenceCountedNetworkCloseListen
         synchronized (getOrCreateLock)
         {
             connections.removeConnection(networkConnection);
-            LOG.finest(() -> "removed: " + networkConnection + " from: " + this);
+            LOG.log(System.Logger.Level.TRACE,() -> "removed: " + networkConnection + " from: " + this);
         }
     }
 
@@ -129,7 +128,7 @@ public class NetworkConnectionPool implements ReferenceCountedNetworkCloseListen
         if (networkConnection instanceof NettyNetworkConnection impl)
         {
             impl.addListener(networkListener);
-            LOG.finest(() -> "created network connection: " + networkConnection);
+            LOG.log(System.Logger.Level.TRACE,() -> "created network connection: " + networkConnection);
             return ReferenceCountedNetworkConnection.of(impl, referenceCountedNetworkCloseListener);
         }
         throw new CasualResourceAdapterException("Wrong implementation for NetworkConnection, was expecting NettyNetworkConnection but got: " + networkConnection.getClass());

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/pool/NetworkConnectionPool.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/pool/NetworkConnectionPool.java
@@ -19,6 +19,8 @@ import java.net.InetSocketAddress;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static java.lang.System.Logger.Level.*;
+
 public class NetworkConnectionPool implements ReferenceCountedNetworkCloseListener, NetworkListener
 {
     private static final System.Logger LOG = System.getLogger(NetworkConnectionPool.class.getName());
@@ -84,7 +86,7 @@ public class NetworkConnectionPool implements ReferenceCountedNetworkCloseListen
         synchronized (getOrCreateLock)
         {
             connections.removeConnection(networkConnection);
-            LOG.log(System.Logger.Level.TRACE,() -> "removed: " + networkConnection + " from: " + this);
+            LOG.log(DEBUG,() -> "removed: " + networkConnection + " from: " + this);
         }
     }
 
@@ -128,7 +130,7 @@ public class NetworkConnectionPool implements ReferenceCountedNetworkCloseListen
         if (networkConnection instanceof NettyNetworkConnection impl)
         {
             impl.addListener(networkListener);
-            LOG.log(System.Logger.Level.TRACE,() -> "created network connection: " + networkConnection);
+            LOG.log(DEBUG,() -> "created network connection: " + networkConnection);
             return ReferenceCountedNetworkConnection.of(impl, referenceCountedNetworkCloseListener);
         }
         throw new CasualResourceAdapterException("Wrong implementation for NetworkConnection, was expecting NettyNetworkConnection but got: " + networkConnection.getClass());

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/pool/NetworkPoolHandler.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/pool/NetworkPoolHandler.java
@@ -15,6 +15,8 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static java.lang.System.Logger.Level.*;
+
 // yes it is intentional
 @SuppressWarnings("java:S6548")
 public class NetworkPoolHandler
@@ -36,8 +38,8 @@ public class NetworkPoolHandler
         }
         catch(CasualConnectionException e)
         {
-            log.log(System.Logger.Level.TRACE,() -> "connection failure for: " + address);
-            log.log(System.Logger.Level.TRACE,() -> "removing pool: " + poolName);
+            log.log(DEBUG,() -> "connection failure for: " + address);
+            log.log(DEBUG,() -> "removing pool: " + poolName);
             pools.remove(poolName);
             throw e;
         }

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/pool/NetworkPoolHandler.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/pool/NetworkPoolHandler.java
@@ -14,13 +14,12 @@ import se.laz.casual.network.outbound.NetworkListener;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Logger;
 
 // yes it is intentional
 @SuppressWarnings("java:S6548")
 public class NetworkPoolHandler
 {
-    private static final Logger log = Logger.getLogger(NetworkPoolHandler.class.getName());
+    private static final System.Logger log = System.getLogger(NetworkPoolHandler.class.getName());
     private static final NetworkPoolHandler instance = new NetworkPoolHandler();
     private final Map<String, NetworkConnectionPool> pools = new ConcurrentHashMap<>();
 
@@ -37,8 +36,8 @@ public class NetworkPoolHandler
         }
         catch(CasualConnectionException e)
         {
-            log.finest(() -> "connection failure for: " + address);
-            log.finest(() -> "removing pool: " + poolName);
+            log.log(System.Logger.Level.TRACE,() -> "connection failure for: " + address);
+            log.log(System.Logger.Level.TRACE,() -> "removing pool: " + poolName);
             pools.remove(poolName);
             throw e;
         }

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/pool/ReferenceCountedNetworkConnection.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/pool/ReferenceCountedNetworkConnection.java
@@ -20,6 +20,8 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static java.lang.System.Logger.Level.*;
+
 public class ReferenceCountedNetworkConnection implements NetworkConnection
 {
     private static final System.Logger log = System.getLogger(ReferenceCountedNetworkConnection.class.getName());
@@ -41,7 +43,7 @@ public class ReferenceCountedNetworkConnection implements NetworkConnection
 
     public int increment()
     {
-        log.log(System.Logger.Level.TRACE,() -> "increment current refcount: " + referenceCount.get());
+        log.log(DEBUG,() -> "increment current refcount: " + referenceCount.get());
         return referenceCount.incrementAndGet();
     }
 
@@ -83,10 +85,10 @@ public class ReferenceCountedNetworkConnection implements NetworkConnection
     @Override
     public void close()
     {
-        log.log(System.Logger.Level.TRACE,() -> "close current refcount: " + referenceCount.get());
+        log.log(DEBUG,() -> "close current refcount: " + referenceCount.get());
         if(referenceCount.decrementAndGet() == 0)
         {
-            log.log(System.Logger.Level.TRACE,() -> "closing network connection: " + networkConnection);
+            log.log(DEBUG,() -> "closing network connection: " + networkConnection);
             networkConnection.close();
             closeListener.closed(this);
         }

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/pool/ReferenceCountedNetworkConnection.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/pool/ReferenceCountedNetworkConnection.java
@@ -19,11 +19,10 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Logger;
 
 public class ReferenceCountedNetworkConnection implements NetworkConnection
 {
-    private static final Logger log = Logger.getLogger(ReferenceCountedNetworkConnection.class.getName());
+    private static final System.Logger log = System.getLogger(ReferenceCountedNetworkConnection.class.getName());
     private final AtomicInteger referenceCount = new AtomicInteger(1);
     private final NettyNetworkConnection networkConnection;
     private final ReferenceCountedNetworkCloseListener closeListener;
@@ -42,7 +41,7 @@ public class ReferenceCountedNetworkConnection implements NetworkConnection
 
     public int increment()
     {
-        log.finest(() -> "increment current refcount: " + referenceCount.get());
+        log.log(System.Logger.Level.TRACE,() -> "increment current refcount: " + referenceCount.get());
         return referenceCount.incrementAndGet();
     }
 
@@ -84,10 +83,10 @@ public class ReferenceCountedNetworkConnection implements NetworkConnection
     @Override
     public void close()
     {
-        log.finest(() -> "close current refcount: " + referenceCount.get());
+        log.log(System.Logger.Level.TRACE,() -> "close current refcount: " + referenceCount.get());
         if(referenceCount.decrementAndGet() == 0)
         {
-            log.finest(() -> "closing network connection: " + networkConnection);
+            log.log(System.Logger.Level.TRACE,() -> "closing network connection: " + networkConnection);
             networkConnection.close();
             closeListener.closed(this);
         }

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/service/CasualServiceCaller.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/service/CasualServiceCaller.java
@@ -44,6 +44,8 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
+import static java.lang.System.Logger.Level.*;
+
 public class CasualServiceCaller implements CasualServiceApi
 {
     private static final System.Logger LOG = System.getLogger(CasualServiceCaller.class.getName());
@@ -126,11 +128,11 @@ public class CasualServiceCaller implements CasualServiceApi
                 casualNWMessageCompletableFuture.whenComplete((v, e) -> {
                             if (null != e)
                             {
-                                LOG.log(System.Logger.Level.TRACE,() -> "service call request failed for corrid: " + PrettyPrinter.casualStringify(corrId) + SERVICE_NAME_LITERAL + serviceName);
+                                LOG.log(DEBUG,() -> "service call request failed for corrid: " + PrettyPrinter.casualStringify(corrId) + SERVICE_NAME_LITERAL + serviceName);
                                 f.completeExceptionally(e);
                                 return;
                             }
-                            LOG.log(System.Logger.Level.TRACE,() -> "service call request ok for corrid: " + PrettyPrinter.casualStringify(corrId) + SERVICE_NAME_LITERAL + serviceName);
+                            LOG.log(DEBUG,() -> "service call request ok for corrid: " + PrettyPrinter.casualStringify(corrId) + SERVICE_NAME_LITERAL + serviceName);
                     eventBuilder.withCode(v.getMessage().getError())
                             .end();
                             getEventPublisher().post(eventBuilder.build());
@@ -217,7 +219,7 @@ public class CasualServiceCaller implements CasualServiceApi
                 .setTimeout(timeout.toNanos())
                 .setXatmiFlags(flags).build();
         CasualNWMessage<CasualServiceCallRequestMessage> serviceRequestNetworkMessage = CasualNWMessageImpl.of(corrid, serviceRequestMessage);
-        LOG.log(System.Logger.Level.TRACE,() -> "issuing service call request, corrid: " + PrettyPrinter.casualStringify(corrid) + SERVICE_NAME_LITERAL + serviceName);
+        LOG.log(DEBUG,() -> "issuing service call request, corrid: " + PrettyPrinter.casualStringify(corrid) + SERVICE_NAME_LITERAL + serviceName);
 
         if(noReply)
         {
@@ -229,7 +231,7 @@ public class CasualServiceCaller implements CasualServiceApi
 
     private CasualNWMessage<CasualDomainDiscoveryReplyMessage> serviceDiscovery(UUID corrid, String serviceName)
     {
-        LOG.log(System.Logger.Level.TRACE,() -> "issuing domain discovery, corrid: " + PrettyPrinter.casualStringify(corrid) + SERVICE_NAME_LITERAL + serviceName);
+        LOG.log(DEBUG,() -> "issuing domain discovery, corrid: " + PrettyPrinter.casualStringify(corrid) + SERVICE_NAME_LITERAL + serviceName);
 
         CasualDomainDiscoveryRequestMessage requestMsg = CasualDomainDiscoveryRequestMessage.createBuilder()
                 .setExecution(UUID.randomUUID())
@@ -241,7 +243,7 @@ public class CasualServiceCaller implements CasualServiceApi
         CompletableFuture<CasualNWMessage<CasualDomainDiscoveryReplyMessage>> replyMsgFuture = connection.getNetworkConnection().request(msg);
 
         CasualNWMessage<CasualDomainDiscoveryReplyMessage> replyMsg = replyMsgFuture.join();
-        LOG.log(System.Logger.Level.TRACE,() -> "domain discovery ok for corrid: " + PrettyPrinter.casualStringify(corrid) + SERVICE_NAME_LITERAL + serviceName);
+        LOG.log(DEBUG,() -> "domain discovery ok for corrid: " + PrettyPrinter.casualStringify(corrid) + SERVICE_NAME_LITERAL + serviceName);
         return replyMsg;
     }
 

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/service/CasualServiceCaller.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/service/CasualServiceCaller.java
@@ -43,11 +43,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.logging.Logger;
 
 public class CasualServiceCaller implements CasualServiceApi
 {
-    private static final Logger LOG = Logger.getLogger(CasualServiceCaller.class.getName());
+    private static final System.Logger LOG = System.getLogger(CasualServiceCaller.class.getName());
     private static final String SERVICE_NAME_LITERAL = " serviceName: ";
     private ServiceCallEventPublisher  eventPublisher;
     private final CasualManagedConnection connection;
@@ -127,11 +126,11 @@ public class CasualServiceCaller implements CasualServiceApi
                 casualNWMessageCompletableFuture.whenComplete((v, e) -> {
                             if (null != e)
                             {
-                                LOG.finest(() -> "service call request failed for corrid: " + PrettyPrinter.casualStringify(corrId) + SERVICE_NAME_LITERAL + serviceName);
+                                LOG.log(System.Logger.Level.TRACE,() -> "service call request failed for corrid: " + PrettyPrinter.casualStringify(corrId) + SERVICE_NAME_LITERAL + serviceName);
                                 f.completeExceptionally(e);
                                 return;
                             }
-                            LOG.finest(() -> "service call request ok for corrid: " + PrettyPrinter.casualStringify(corrId) + SERVICE_NAME_LITERAL + serviceName);
+                            LOG.log(System.Logger.Level.TRACE,() -> "service call request ok for corrid: " + PrettyPrinter.casualStringify(corrId) + SERVICE_NAME_LITERAL + serviceName);
                     eventBuilder.withCode(v.getMessage().getError())
                             .end();
                             getEventPublisher().post(eventBuilder.build());
@@ -218,7 +217,7 @@ public class CasualServiceCaller implements CasualServiceApi
                 .setTimeout(timeout.toNanos())
                 .setXatmiFlags(flags).build();
         CasualNWMessage<CasualServiceCallRequestMessage> serviceRequestNetworkMessage = CasualNWMessageImpl.of(corrid, serviceRequestMessage);
-        LOG.finest(() -> "issuing service call request, corrid: " + PrettyPrinter.casualStringify(corrid) + SERVICE_NAME_LITERAL + serviceName);
+        LOG.log(System.Logger.Level.TRACE,() -> "issuing service call request, corrid: " + PrettyPrinter.casualStringify(corrid) + SERVICE_NAME_LITERAL + serviceName);
 
         if(noReply)
         {
@@ -230,7 +229,7 @@ public class CasualServiceCaller implements CasualServiceApi
 
     private CasualNWMessage<CasualDomainDiscoveryReplyMessage> serviceDiscovery(UUID corrid, String serviceName)
     {
-        LOG.finest(() -> "issuing domain discovery, corrid: " + PrettyPrinter.casualStringify(corrid) + SERVICE_NAME_LITERAL + serviceName);
+        LOG.log(System.Logger.Level.TRACE,() -> "issuing domain discovery, corrid: " + PrettyPrinter.casualStringify(corrid) + SERVICE_NAME_LITERAL + serviceName);
 
         CasualDomainDiscoveryRequestMessage requestMsg = CasualDomainDiscoveryRequestMessage.createBuilder()
                 .setExecution(UUID.randomUUID())
@@ -242,7 +241,7 @@ public class CasualServiceCaller implements CasualServiceApi
         CompletableFuture<CasualNWMessage<CasualDomainDiscoveryReplyMessage>> replyMsgFuture = connection.getNetworkConnection().request(msg);
 
         CasualNWMessage<CasualDomainDiscoveryReplyMessage> replyMsg = replyMsgFuture.join();
-        LOG.finest(() -> "domain discovery ok for corrid: " + PrettyPrinter.casualStringify(corrid) + SERVICE_NAME_LITERAL + serviceName);
+        LOG.log(System.Logger.Level.TRACE,() -> "domain discovery ok for corrid: " + PrettyPrinter.casualStringify(corrid) + SERVICE_NAME_LITERAL + serviceName);
         return replyMsg;
     }
 

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/work/Delayer.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/work/Delayer.java
@@ -11,6 +11,8 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.TimeUnit;
 
+import static java.lang.System.Logger.Level.*;
+
 public class Delayer
 {
     private static final System.Logger log = System.getLogger(Delayer.class.getName());
@@ -22,7 +24,7 @@ public class Delayer
     {
         try
         {
-            log.log(System.Logger.Level.TRACE,() -> "delaying current thread by " + seconds + " seconds");
+            log.log(DEBUG,() -> "delaying current thread by " + seconds + " seconds");
             Duration delay = Duration.ofSeconds(seconds);
             TimeUnit.SECONDS.sleep(delay.get(ChronoUnit.SECONDS));
         }

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/work/Delayer.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/work/Delayer.java
@@ -10,11 +10,10 @@ import se.laz.casual.jca.DelayFailedException;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 
 public class Delayer
 {
-    private static final Logger log = Logger.getLogger(Delayer.class.getName());
+    private static final System.Logger log = System.getLogger(Delayer.class.getName());
 
     private Delayer()
     {}
@@ -23,7 +22,7 @@ public class Delayer
     {
         try
         {
-            log.finest(() -> "delaying current thread by " + seconds + " seconds");
+            log.log(System.Logger.Level.TRACE,() -> "delaying current thread by " + seconds + " seconds");
             Duration delay = Duration.ofSeconds(seconds);
             TimeUnit.SECONDS.sleep(delay.get(ChronoUnit.SECONDS));
         }

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartInboundServerListener.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartInboundServerListener.java
@@ -10,6 +10,8 @@ import jakarta.resource.spi.work.WorkEvent;
 import jakarta.resource.spi.work.WorkListener;
 import java.util.function.Supplier;
 
+import static java.lang.System.Logger.Level.*;
+
 /**
  * Work Listener to handle completion of {@link jakarta.resource.spi.work.Work} item by
  * {@link jakarta.resource.spi.work.WorkManager} to log if anything goes wrong with starting the inbound server
@@ -29,25 +31,25 @@ public class StartInboundServerListener implements WorkListener
     @Override
     public void workAccepted(WorkEvent e)
     {
-        logWorkEvent( e, System.Logger.Level.TRACE, ()->"Casual inbound start, work accepted." );
+        logWorkEvent( e, DEBUG, ()->"Casual inbound start, work accepted." );
     }
 
     @Override
     public void workRejected(WorkEvent e)
     {
-        logWorkEvent( e, System.Logger.Level.WARNING, ()-> "Casual inbound start, work rejected, inbound will not be started!!!"  );
+        logWorkEvent( e, WARNING, ()-> "Casual inbound start, work rejected, inbound will not be started!!!"  );
     }
 
     @Override
     public void workStarted(WorkEvent e)
     {
-        logWorkEvent( e, System.Logger.Level.TRACE, ()-> "Casual inbound start, work started." );
+        logWorkEvent( e, DEBUG, ()-> "Casual inbound start, work started." );
     }
 
     @Override
     public void workCompleted(WorkEvent e)
     {
-        logWorkEvent( e, System.Logger.Level.TRACE, ()-> "Casual inbound start, work completed." );
+        logWorkEvent( e, DEBUG, ()-> "Casual inbound start, work completed." );
     }
 
     private void logWorkEvent( WorkEvent e, System.Logger.Level level, Supplier<String> supplier )
@@ -55,7 +57,7 @@ public class StartInboundServerListener implements WorkListener
         log.log( level, supplier );
         if( e.getException() != null )
         {
-            log.log(System.Logger.Level.ERROR, () -> "Casual inbound start WorkEvent contained an exception: ");
+            log.log(ERROR, () -> "Casual inbound start WorkEvent contained an exception: ");
         }
     }
 }

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartInboundServerListener.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartInboundServerListener.java
@@ -9,8 +9,6 @@ package se.laz.casual.jca.work;
 import jakarta.resource.spi.work.WorkEvent;
 import jakarta.resource.spi.work.WorkListener;
 import java.util.function.Supplier;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Work Listener to handle completion of {@link jakarta.resource.spi.work.Work} item by
@@ -18,7 +16,7 @@ import java.util.logging.Logger;
  */
 public class StartInboundServerListener implements WorkListener
 {
-    private static Logger log = Logger.getLogger( StartInboundServerListener.class.getName());
+    private static System.Logger log = System.getLogger( StartInboundServerListener.class.getName());
     private StartInboundServerListener()
     {
     }
@@ -31,33 +29,33 @@ public class StartInboundServerListener implements WorkListener
     @Override
     public void workAccepted(WorkEvent e)
     {
-        logWorkEvent( e, Level.FINEST, ()->"Casual inbound start, work accepted." );
+        logWorkEvent( e, System.Logger.Level.TRACE, ()->"Casual inbound start, work accepted." );
     }
 
     @Override
     public void workRejected(WorkEvent e)
     {
-        logWorkEvent( e, Level.WARNING, ()-> "Casual inbound start, work rejected, inbound will not be started!!!"  );
+        logWorkEvent( e, System.Logger.Level.WARNING, ()-> "Casual inbound start, work rejected, inbound will not be started!!!"  );
     }
 
     @Override
     public void workStarted(WorkEvent e)
     {
-        logWorkEvent( e, Level.FINEST, ()-> "Casual inbound start, work started." );
+        logWorkEvent( e, System.Logger.Level.TRACE, ()-> "Casual inbound start, work started." );
     }
 
     @Override
     public void workCompleted(WorkEvent e)
     {
-        logWorkEvent( e, Level.FINEST, ()-> "Casual inbound start, work completed." );
+        logWorkEvent( e, System.Logger.Level.TRACE, ()-> "Casual inbound start, work completed." );
     }
 
-    private void logWorkEvent( WorkEvent e, Level level, Supplier<String> supplier )
+    private void logWorkEvent( WorkEvent e, System.Logger.Level level, Supplier<String> supplier )
     {
         log.log( level, supplier );
         if( e.getException() != null )
         {
-            log.log(Level.SEVERE, e.getException(), () -> "Casual inbound start WorkEvent contained an exception: ");
+            log.log(System.Logger.Level.ERROR, () -> "Casual inbound start WorkEvent contained an exception: ");
         }
     }
 }

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartInboundServerWork.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartInboundServerWork.java
@@ -20,7 +20,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /**
@@ -28,7 +27,7 @@ import java.util.stream.Collectors;
  */
 public final class StartInboundServerWork<T> implements Work
 {
-    private static Logger log = Logger.getLogger( StartInboundServerWork.class.getName());
+    private static System.Logger log = System.getLogger( StartInboundServerWork.class.getName());
     private final List<String> startupServices;
     private final Consumer<T> consumer;
     private final Supplier<T> supplier;
@@ -95,20 +94,20 @@ public final class StartInboundServerWork<T> implements Work
                 throw new InboundStartupException( "Interrupted waiting for inbound startup services registration.", e );
             }
         }
-        log.info(() -> "All startup services registered.");
+        log.log(System.Logger.Level.INFO,() -> "All startup services registered.");
     }
 
     private void logInitialStartupServices(List<String> startupServices)
     {
-        log.info(() -> "Inbound startup mode: " + ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_INBOUND_STARTUP_MODE ) );
-        log.info(() -> "Waiting for " + startupServices.size() + " services to be registered before inbound starts.");
-        log.info(() -> "Initial services list: " + startupServices.stream()
+        log.log(System.Logger.Level.INFO,() -> "Inbound startup mode: " + ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_INBOUND_STARTUP_MODE ) );
+        log.log(System.Logger.Level.INFO,() -> "Waiting for " + startupServices.size() + " services to be registered before inbound starts.");
+        log.log(System.Logger.Level.INFO,() -> "Initial services list: " + startupServices.stream()
                                                                   .collect(Collectors.joining()));
     }
 
     private void logWaitingForStartupServices(Set<String> remaining)
     {
-        log.info(() -> "Waiting for registration of the following services: " + remaining.stream()
+        log.log(System.Logger.Level.INFO,() -> "Waiting for registration of the following services: " + remaining.stream()
                                                                                          .collect(Collectors.joining()));
     }
 
@@ -123,7 +122,7 @@ public final class StartInboundServerWork<T> implements Work
                 if( handler.isServiceAvailable( find ) )
                 {
                     notFound.remove( find );
-                    log.info( () -> "Startup service registered: " + find );
+                    log.log(System.Logger.Level.INFO, () -> "Startup service registered: " + find );
                 }
 
             }
@@ -145,17 +144,17 @@ public final class StartInboundServerWork<T> implements Work
         // Never seen on wildfly
         if(delay <= 0L)
         {
-            log.info(() -> "no inbound startup delay");
+            log.log(System.Logger.Level.INFO,() -> "no inbound startup delay");
             return;
         }
         Delayer.delay(delay);
-        log.info(() -> "inbound startup, delay of " + delay + " seconds - done");
+        log.log(System.Logger.Level.INFO,() -> "inbound startup, delay of " + delay + " seconds - done");
     }
 
     private void startInboundServer()
     {
         consumer.accept(supplier.get());
-        log.info(logMessage::get);
+        log.log(System.Logger.Level.INFO,logMessage::get);
     }
 
 }

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartInboundServerWork.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartInboundServerWork.java
@@ -22,6 +22,8 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static java.lang.System.Logger.Level.*;
+
 /**
  * Work instance for delaying start of inbound server until all startup services have been registered
  */
@@ -94,20 +96,20 @@ public final class StartInboundServerWork<T> implements Work
                 throw new InboundStartupException( "Interrupted waiting for inbound startup services registration.", e );
             }
         }
-        log.log(System.Logger.Level.INFO,() -> "All startup services registered.");
+        log.log(INFO,() -> "All startup services registered.");
     }
 
     private void logInitialStartupServices(List<String> startupServices)
     {
-        log.log(System.Logger.Level.INFO,() -> "Inbound startup mode: " + ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_INBOUND_STARTUP_MODE ) );
-        log.log(System.Logger.Level.INFO,() -> "Waiting for " + startupServices.size() + " services to be registered before inbound starts.");
-        log.log(System.Logger.Level.INFO,() -> "Initial services list: " + startupServices.stream()
+        log.log(INFO,() -> "Inbound startup mode: " + ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_INBOUND_STARTUP_MODE ) );
+        log.log(INFO,() -> "Waiting for " + startupServices.size() + " services to be registered before inbound starts.");
+        log.log(INFO,() -> "Initial services list: " + startupServices.stream()
                                                                   .collect(Collectors.joining()));
     }
 
     private void logWaitingForStartupServices(Set<String> remaining)
     {
-        log.log(System.Logger.Level.INFO,() -> "Waiting for registration of the following services: " + remaining.stream()
+        log.log(INFO,() -> "Waiting for registration of the following services: " + remaining.stream()
                                                                                          .collect(Collectors.joining()));
     }
 
@@ -122,7 +124,7 @@ public final class StartInboundServerWork<T> implements Work
                 if( handler.isServiceAvailable( find ) )
                 {
                     notFound.remove( find );
-                    log.log(System.Logger.Level.INFO, () -> "Startup service registered: " + find );
+                    log.log(INFO, () -> "Startup service registered: " + find );
                 }
 
             }
@@ -144,17 +146,17 @@ public final class StartInboundServerWork<T> implements Work
         // Never seen on wildfly
         if(delay <= 0L)
         {
-            log.log(System.Logger.Level.INFO,() -> "no inbound startup delay");
+            log.log(INFO,() -> "no inbound startup delay");
             return;
         }
         Delayer.delay(delay);
-        log.log(System.Logger.Level.INFO,() -> "inbound startup, delay of " + delay + " seconds - done");
+        log.log(INFO,() -> "inbound startup, delay of " + delay + " seconds - done");
     }
 
     private void startInboundServer()
     {
         consumer.accept(supplier.get());
-        log.log(System.Logger.Level.INFO,logMessage::get);
+        log.log(INFO,logMessage::get);
     }
 
 }

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartReverseInboundServerListener.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartReverseInboundServerListener.java
@@ -8,7 +8,6 @@ package se.laz.casual.jca.work;
 
 import jakarta.resource.spi.work.WorkEvent;
 import jakarta.resource.spi.work.WorkListener;
-import java.util.logging.Logger;
 
 /**
  * Work Listener to handle completion of {@link jakarta.resource.spi.work.Work} item by
@@ -16,7 +15,7 @@ import java.util.logging.Logger;
  */
 public class StartReverseInboundServerListener implements WorkListener
 {
-    private static Logger log = Logger.getLogger( StartReverseInboundServerListener.class.getName());
+    private static System.Logger log = System.getLogger( StartReverseInboundServerListener.class.getName());
     private StartReverseInboundServerListener()
     {
     }
@@ -35,7 +34,7 @@ public class StartReverseInboundServerListener implements WorkListener
     @Override
     public void workRejected(WorkEvent e)
     {
-        log.warning(() -> "reverse inbound workRejected, reverse inbound will not be started!!!");
+        log.log(System.Logger.Level.WARNING,() -> "reverse inbound workRejected, reverse inbound will not be started!!!");
     }
 
     @Override
@@ -49,8 +48,8 @@ public class StartReverseInboundServerListener implements WorkListener
     {
         if(null != e.getException())
         {
-            log.warning(() -> "reverse inbound, workCompleted with exception: " + e.getException());
-            log.warning(() -> "cause: " + e.getException().getCause());
+            log.log(System.Logger.Level.WARNING,() -> "reverse inbound, workCompleted with exception: " + e.getException());
+            log.log(System.Logger.Level.WARNING,() -> "cause: " + e.getException().getCause());
         }
     }
 }

--- a/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartReverseInboundServerListener.java
+++ b/casual/casual-jca/src/main/java/se/laz/casual/jca/work/StartReverseInboundServerListener.java
@@ -8,6 +8,7 @@ package se.laz.casual.jca.work;
 
 import jakarta.resource.spi.work.WorkEvent;
 import jakarta.resource.spi.work.WorkListener;
+import static java.lang.System.Logger.Level.*;
 
 /**
  * Work Listener to handle completion of {@link jakarta.resource.spi.work.Work} item by
@@ -34,7 +35,7 @@ public class StartReverseInboundServerListener implements WorkListener
     @Override
     public void workRejected(WorkEvent e)
     {
-        log.log(System.Logger.Level.WARNING,() -> "reverse inbound workRejected, reverse inbound will not be started!!!");
+        log.log(WARNING,() -> "reverse inbound workRejected, reverse inbound will not be started!!!",e.getException());
     }
 
     @Override
@@ -48,8 +49,8 @@ public class StartReverseInboundServerListener implements WorkListener
     {
         if(null != e.getException())
         {
-            log.log(System.Logger.Level.WARNING,() -> "reverse inbound, workCompleted with exception: " + e.getException());
-            log.log(System.Logger.Level.WARNING,() -> "cause: " + e.getException().getCause());
+            log.log(WARNING,() -> "reverse inbound, workCompleted with exception: " + e.getException(),e.getException());
+            log.log(WARNING,() -> "cause: " + e.getException().getCause(),e.getException());
         }
     }
 }

--- a/casual/casual-network/src/main/java/se/laz/casual/network/EventLoopFactory.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/EventLoopFactory.java
@@ -14,11 +14,10 @@ import se.laz.casual.network.outbound.JEEConcurrencyFactory;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Logger;
 
 public final class EventLoopFactory
 {
-    private static final Logger LOG = Logger.getLogger(EventLoopFactory.class.getName());
+    private static final System.Logger LOG = System.getLogger(EventLoopFactory.class.getName());
     private static final Map<EventLoopClient, EventLoopGroup> INSTANCES;
     static
     {
@@ -46,13 +45,13 @@ public final class EventLoopFactory
 
     private static EventLoopGroup getUnmanagedEventLoopGroup(boolean useEpoll, int numberOfThreads)
     {
-        LOG.info(() -> "event loop group not using any ManagedExecutorService, running unmanaged");
+        LOG.log(System.Logger.Level.INFO,() -> "event loop group not using any ManagedExecutorService, running unmanaged");
         if(useEpoll)
         {
-            LOG.info(() -> "using EpollEventLoopGroup");
+            LOG.log(System.Logger.Level.INFO,() -> "using EpollEventLoopGroup");
             return new EpollEventLoopGroup(numberOfThreads);
         }
-        LOG.info(() -> "using NioEventLoopGroup");
+        LOG.log(System.Logger.Level.INFO,() -> "using NioEventLoopGroup");
         return new NioEventLoopGroup(numberOfThreads);
     }
 
@@ -60,10 +59,10 @@ public final class EventLoopFactory
     {
         if (useEpoll)
         {
-            LOG.info(() -> "using EpollEventLoopGroup");
+            LOG.log(System.Logger.Level.INFO,() -> "using EpollEventLoopGroup");
             return new EpollEventLoopGroup(numberOfThreads, JEEConcurrencyFactory.getManagedExecutorService());
         }
-        LOG.info(() -> "using NioEventLoopGroup");
+        LOG.log(System.Logger.Level.INFO,() -> "using NioEventLoopGroup");
         return new NioEventLoopGroup(numberOfThreads, JEEConcurrencyFactory.getManagedExecutorService());
     }
 

--- a/casual/casual-network/src/main/java/se/laz/casual/network/EventLoopFactory.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/EventLoopFactory.java
@@ -15,6 +15,8 @@ import se.laz.casual.network.outbound.JEEConcurrencyFactory;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static java.lang.System.Logger.Level.*;
+
 public final class EventLoopFactory
 {
     private static final System.Logger LOG = System.getLogger(EventLoopFactory.class.getName());
@@ -45,13 +47,13 @@ public final class EventLoopFactory
 
     private static EventLoopGroup getUnmanagedEventLoopGroup(boolean useEpoll, int numberOfThreads)
     {
-        LOG.log(System.Logger.Level.INFO,() -> "event loop group not using any ManagedExecutorService, running unmanaged");
+        LOG.log(INFO,() -> "event loop group not using any ManagedExecutorService, running unmanaged");
         if(useEpoll)
         {
-            LOG.log(System.Logger.Level.INFO,() -> "using EpollEventLoopGroup");
+            LOG.log(INFO,() -> "using EpollEventLoopGroup");
             return new EpollEventLoopGroup(numberOfThreads);
         }
-        LOG.log(System.Logger.Level.INFO,() -> "using NioEventLoopGroup");
+        LOG.log(INFO,() -> "using NioEventLoopGroup");
         return new NioEventLoopGroup(numberOfThreads);
     }
 
@@ -59,10 +61,10 @@ public final class EventLoopFactory
     {
         if (useEpoll)
         {
-            LOG.log(System.Logger.Level.INFO,() -> "using EpollEventLoopGroup");
+            LOG.log(INFO,() -> "using EpollEventLoopGroup");
             return new EpollEventLoopGroup(numberOfThreads, JEEConcurrencyFactory.getManagedExecutorService());
         }
-        LOG.log(System.Logger.Level.INFO,() -> "using NioEventLoopGroup");
+        LOG.log(INFO,() -> "using NioEventLoopGroup");
         return new NioEventLoopGroup(numberOfThreads, JEEConcurrencyFactory.getManagedExecutorService());
     }
 

--- a/casual/casual-network/src/main/java/se/laz/casual/network/InboundMessageSender.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/InboundMessageSender.java
@@ -16,18 +16,17 @@ import se.laz.casual.network.protocol.messages.domain.DomainDiscoveryTopologyUpd
 
 import java.util.Objects;
 import java.util.UUID;
-import java.util.logging.Logger;
 
 public class InboundMessageSender
 {
-    private static final Logger log = Logger.getLogger(InboundMessageSender.class.getName());
+    private static final System.Logger log = System.getLogger(InboundMessageSender.class.getName());
     private InboundMessageSender()
     {}
     public static void sendDomainDisconnect(Channel channel)
     {
         Objects.requireNonNull(channel,"channel can not be null" );
         channel.writeAndFlush(createDomainDisconnectMessage());
-        log.finest(() -> "domain disconnect request sent to " + channel);
+        log.log(System.Logger.Level.TRACE,() -> "domain disconnect request sent to " + channel);
     }
 
     public static void sendDomainDiscoveryImplicitUpdate(Channel channel, UUID executionId)
@@ -35,7 +34,7 @@ public class InboundMessageSender
         Objects.requireNonNull(channel,"channel can not be null" );
         Objects.requireNonNull(executionId,"executionId can not be null" );
         channel.writeAndFlush(createDomainTopologyUpdateMessage(executionId));
-        log.finest(() -> "sent domain discovery topology update message to " + channel + " with executionId " + executionId);
+        log.log(System.Logger.Level.TRACE,() -> "sent domain discovery topology update message to " + channel + " with executionId " + executionId);
     }
 
     private static CasualNWMessage<DomainDisconnectRequestMessage> createDomainDisconnectMessage()

--- a/casual/casual-network/src/main/java/se/laz/casual/network/InboundMessageSender.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/InboundMessageSender.java
@@ -17,6 +17,8 @@ import se.laz.casual.network.protocol.messages.domain.DomainDiscoveryTopologyUpd
 import java.util.Objects;
 import java.util.UUID;
 
+import static java.lang.System.Logger.Level.*;
+
 public class InboundMessageSender
 {
     private static final System.Logger log = System.getLogger(InboundMessageSender.class.getName());
@@ -26,7 +28,7 @@ public class InboundMessageSender
     {
         Objects.requireNonNull(channel,"channel can not be null" );
         channel.writeAndFlush(createDomainDisconnectMessage());
-        log.log(System.Logger.Level.TRACE,() -> "domain disconnect request sent to " + channel);
+        log.log(DEBUG,() -> "domain disconnect request sent to " + channel);
     }
 
     public static void sendDomainDiscoveryImplicitUpdate(Channel channel, UUID executionId)
@@ -34,7 +36,7 @@ public class InboundMessageSender
         Objects.requireNonNull(channel,"channel can not be null" );
         Objects.requireNonNull(executionId,"executionId can not be null" );
         channel.writeAndFlush(createDomainTopologyUpdateMessage(executionId));
-        log.log(System.Logger.Level.TRACE,() -> "sent domain discovery topology update message to " + channel + " with executionId " + executionId);
+        log.log(DEBUG,() -> "sent domain discovery topology update message to " + channel + " with executionId " + executionId);
     }
 
     private static CasualNWMessage<DomainDisconnectRequestMessage> createDomainDisconnectMessage()

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/CasualMessageHandler.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/CasualMessageHandler.java
@@ -26,6 +26,8 @@ import se.laz.casual.network.protocol.messages.transaction.CasualTransactionReso
 
 import java.util.Objects;
 
+import static java.lang.System.Logger.Level.*;
+
 @ChannelHandler.Sharable
 public final class CasualMessageHandler extends SimpleChannelInboundHandler<CasualNWMessage<?>>
 {
@@ -58,7 +60,7 @@ public final class CasualMessageHandler extends SimpleChannelInboundHandler<Casu
     {
         MessageEndpoint endpoint = factory.createEndpoint(null);
         CasualMessageListener listener = (CasualMessageListener) endpoint;
-        log.log(System.Logger.Level.TRACE,() -> "inbound msg: " + message);
+        log.log(DEBUG,() -> "inbound msg: " + message);
         switch ( message.getType() )
         {
             case COMMIT_REQUEST:
@@ -83,7 +85,7 @@ public final class CasualMessageHandler extends SimpleChannelInboundHandler<Casu
                 listener.domainDiscoveryRequest((CasualNWMessage<CasualDomainDiscoveryRequestMessage>)message, ctx.channel());
                 break;
             default:
-                log.log(System.Logger.Level.WARNING,"Message type not supported: " + message.getType());
+                log.log(WARNING,"Message type not supported: " + message.getType());
         }
     }
 

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/CasualMessageHandler.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/CasualMessageHandler.java
@@ -25,12 +25,11 @@ import se.laz.casual.network.protocol.messages.transaction.CasualTransactionReso
 import se.laz.casual.network.protocol.messages.transaction.CasualTransactionResourceRollbackRequestMessage;
 
 import java.util.Objects;
-import java.util.logging.Logger;
 
 @ChannelHandler.Sharable
 public final class CasualMessageHandler extends SimpleChannelInboundHandler<CasualNWMessage<?>>
 {
-    private static Logger log = Logger.getLogger(CasualMessageHandler.class.getName());
+    private static System.Logger log = System.getLogger(CasualMessageHandler.class.getName());
     private final MessageEndpointFactory factory;
     private final XATerminator xaTerminator;
     private final WorkManager workManager;
@@ -59,7 +58,7 @@ public final class CasualMessageHandler extends SimpleChannelInboundHandler<Casu
     {
         MessageEndpoint endpoint = factory.createEndpoint(null);
         CasualMessageListener listener = (CasualMessageListener) endpoint;
-        log.finest(() -> "inbound msg: " + message);
+        log.log(System.Logger.Level.TRACE,() -> "inbound msg: " + message);
         switch ( message.getType() )
         {
             case COMMIT_REQUEST:
@@ -84,7 +83,7 @@ public final class CasualMessageHandler extends SimpleChannelInboundHandler<Casu
                 listener.domainDiscoveryRequest((CasualNWMessage<CasualDomainDiscoveryRequestMessage>)message, ctx.channel());
                 break;
             default:
-                log.warning("Message type not supported: " + message.getType());
+                log.log(System.Logger.Level.WARNING,"Message type not supported: " + message.getType());
         }
     }
 

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/CasualServer.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/CasualServer.java
@@ -24,6 +24,8 @@ import se.laz.casual.network.LogLevelProvider;
 
 import java.net.InetSocketAddress;
 
+import static java.lang.System.Logger.Level.*;
+
 /**
  * Inbound casual server
  */
@@ -61,7 +63,7 @@ public final class CasualServer
                     if(enableLogHandler)
                     {
                         ch.pipeline().addFirst(LOG_HANDLER_NAME, new LoggingHandler(LogLevelProvider.INBOUND_LOGGING_LEVEL));
-                        log.log(System.Logger.Level.INFO,() -> "inbound network log handler enabled, using netty logging level: " + LogLevelProvider.INBOUND_LOGGING_LEVEL);
+                        log.log(INFO,() -> "inbound network log handler enabled, using netty logging level: " + LogLevelProvider.INBOUND_LOGGING_LEVEL);
                     }
                 }
             }).childOption(ChannelOption.SO_KEEPALIVE, true);
@@ -79,10 +81,10 @@ public final class CasualServer
 
     public void close()
     {
-        log.log(System.Logger.Level.INFO,() -> "closing server");
+        log.log(INFO,() -> "closing server");
         channel.close().syncUninterruptibly();
         channel.eventLoop().shutdownGracefully().syncUninterruptibly();
-        log.log(System.Logger.Level.INFO,() -> "server closed");
+        log.log(INFO,() -> "server closed");
     }
 
 }

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/CasualServer.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/CasualServer.java
@@ -23,14 +23,13 @@ import se.laz.casual.network.CasualNWMessageEncoder;
 import se.laz.casual.network.LogLevelProvider;
 
 import java.net.InetSocketAddress;
-import java.util.logging.Logger;
 
 /**
  * Inbound casual server
  */
 public final class CasualServer
 {
-    private static final Logger log = Logger.getLogger(CasualServer.class.getName());
+    private static final System.Logger log = System.getLogger(CasualServer.class.getName());
     private static final String LOG_HANDLER_NAME = "logHandler";
     private final Channel channel;
 
@@ -62,7 +61,7 @@ public final class CasualServer
                     if(enableLogHandler)
                     {
                         ch.pipeline().addFirst(LOG_HANDLER_NAME, new LoggingHandler(LogLevelProvider.INBOUND_LOGGING_LEVEL));
-                        log.info(() -> "inbound network log handler enabled, using netty logging level: " + LogLevelProvider.INBOUND_LOGGING_LEVEL);
+                        log.log(System.Logger.Level.INFO,() -> "inbound network log handler enabled, using netty logging level: " + LogLevelProvider.INBOUND_LOGGING_LEVEL);
                     }
                 }
             }).childOption(ChannelOption.SO_KEEPALIVE, true);
@@ -80,10 +79,10 @@ public final class CasualServer
 
     public void close()
     {
-        log.info(() -> "closing server");
+        log.log(System.Logger.Level.INFO,() -> "closing server");
         channel.close().syncUninterruptibly();
         channel.eventLoop().shutdownGracefully().syncUninterruptibly();
-        log.info(() -> "server closed");
+        log.log(System.Logger.Level.INFO,() -> "server closed");
     }
 
 }

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/ExceptionHandler.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/ExceptionHandler.java
@@ -15,6 +15,8 @@ import se.laz.casual.network.InboundTopologyUpdateContext;
 
 import java.util.Objects;
 
+import static java.lang.System.Logger.Level.*;
+
 @ChannelHandler.Sharable
 public final class ExceptionHandler extends ChannelInboundHandlerAdapter
 {
@@ -35,7 +37,7 @@ public final class ExceptionHandler extends ChannelInboundHandlerAdapter
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)
     {
-        log.log(System.Logger.Level.WARNING,() -> "casual inbound exception caught: " + cause + " closing channel");
+        log.log(WARNING,() -> "casual inbound exception caught: " + cause + " closing channel",cause);
         InboundDeactivatedContext.remove(ctx.channel());
         InboundTopologyUpdateContext.remove(ctx.channel());
         inboundTransactionRegistry.remove(ctx.channel().id());

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/ExceptionHandler.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/ExceptionHandler.java
@@ -14,12 +14,11 @@ import se.laz.casual.network.InboundDeactivatedContext;
 import se.laz.casual.network.InboundTopologyUpdateContext;
 
 import java.util.Objects;
-import java.util.logging.Logger;
 
 @ChannelHandler.Sharable
 public final class ExceptionHandler extends ChannelInboundHandlerAdapter
 {
-    private static final Logger log = Logger.getLogger(ExceptionHandler.class.getName());
+    private static final System.Logger log = System.getLogger(ExceptionHandler.class.getName());
     private final CasualInboundTransactionRegistry inboundTransactionRegistry;
 
     public ExceptionHandler(CasualInboundTransactionRegistry inboundTransactionRegistry)
@@ -36,7 +35,7 @@ public final class ExceptionHandler extends ChannelInboundHandlerAdapter
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)
     {
-        log.warning(() -> "casual inbound exception caught: " + cause + " closing channel");
+        log.log(System.Logger.Level.WARNING,() -> "casual inbound exception caught: " + cause + " closing channel");
         InboundDeactivatedContext.remove(ctx.channel());
         InboundTopologyUpdateContext.remove(ctx.channel());
         inboundTransactionRegistry.remove(ctx.channel().id());

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundExceptionHandler.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundExceptionHandler.java
@@ -13,11 +13,10 @@ import se.laz.casual.network.InboundDeactivatedContext;
 import se.laz.casual.network.InboundTopologyUpdateContext;
 
 import java.util.Objects;
-import java.util.logging.Logger;
 
 public final class ReverseInboundExceptionHandler extends ChannelInboundHandlerAdapter
 {
-    private static final Logger log = Logger.getLogger(ReverseInboundExceptionHandler.class.getName());
+    private static final System.Logger log = System.getLogger(ReverseInboundExceptionHandler.class.getName());
     private final CasualInboundTransactionRegistry inboundTransactionRegistry;
 
     private ReverseInboundExceptionHandler(CasualInboundTransactionRegistry inboundTransactionRegistry)
@@ -34,7 +33,7 @@ public final class ReverseInboundExceptionHandler extends ChannelInboundHandlerA
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)
     {
-        log.warning(() -> "casual reverse inbound exception caught: " + cause + " closing channel");
+        log.log(System.Logger.Level.WARNING,() -> "casual reverse inbound exception caught: " + cause + " closing channel");
         InboundDeactivatedContext.remove(ctx.channel());
         InboundTopologyUpdateContext.remove(ctx.channel());
         inboundTransactionRegistry.remove(ctx.channel().id());

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundExceptionHandler.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundExceptionHandler.java
@@ -14,6 +14,8 @@ import se.laz.casual.network.InboundTopologyUpdateContext;
 
 import java.util.Objects;
 
+import static java.lang.System.Logger.Level.*;
+
 public final class ReverseInboundExceptionHandler extends ChannelInboundHandlerAdapter
 {
     private static final System.Logger log = System.getLogger(ReverseInboundExceptionHandler.class.getName());
@@ -33,7 +35,7 @@ public final class ReverseInboundExceptionHandler extends ChannelInboundHandlerA
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)
     {
-        log.log(System.Logger.Level.WARNING,() -> "casual reverse inbound exception caught: " + cause + " closing channel");
+        log.log(WARNING,() -> "casual reverse inbound exception caught: " + cause + " closing channel",cause);
         InboundDeactivatedContext.remove(ctx.channel());
         InboundTopologyUpdateContext.remove(ctx.channel());
         inboundTransactionRegistry.remove(ctx.channel().id());

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundMessageHandler.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundMessageHandler.java
@@ -27,6 +27,8 @@ import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static java.lang.System.Logger.Level.*;
+
 public final class ReverseInboundMessageHandler extends SimpleChannelInboundHandler<CasualNWMessage<?>>
 {
     private static System.Logger log = System.getLogger(ReverseInboundMessageHandler.class.getName());
@@ -59,7 +61,7 @@ public final class ReverseInboundMessageHandler extends SimpleChannelInboundHand
     {
         MessageEndpoint endpoint = factory.createEndpoint(null);
         CasualMessageListener listener = (CasualMessageListener) endpoint;
-        log.log(System.Logger.Level.TRACE,() -> "reverse inbound msg: " + message);
+        log.log(DEBUG,() -> "reverse inbound msg: " + message);
         switch ( message.getType() )
         {
             case COMMIT_REQUEST:
@@ -84,7 +86,7 @@ public final class ReverseInboundMessageHandler extends SimpleChannelInboundHand
                 listener.domainDiscoveryRequest((CasualNWMessage<CasualDomainDiscoveryRequestMessage>)message, ctx.channel());
                 break;
             default:
-                log.log(System.Logger.Level.WARNING,"Message type not supported: " + message.getType());
+                log.log(WARNING,"Message type not supported: " + message.getType());
         }
     }
 

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundMessageHandler.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundMessageHandler.java
@@ -26,11 +26,10 @@ import se.laz.casual.network.protocol.messages.transaction.CasualTransactionReso
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.logging.Logger;
 
 public final class ReverseInboundMessageHandler extends SimpleChannelInboundHandler<CasualNWMessage<?>>
 {
-    private static Logger log = Logger.getLogger(ReverseInboundMessageHandler.class.getName());
+    private static System.Logger log = System.getLogger(ReverseInboundMessageHandler.class.getName());
     private static final ExecutorService executor = Executors.newCachedThreadPool();
     private final MessageEndpointFactory factory;
     private final XATerminator xaTerminator;
@@ -60,7 +59,7 @@ public final class ReverseInboundMessageHandler extends SimpleChannelInboundHand
     {
         MessageEndpoint endpoint = factory.createEndpoint(null);
         CasualMessageListener listener = (CasualMessageListener) endpoint;
-        log.finest(() -> "reverse inbound msg: " + message);
+        log.log(System.Logger.Level.TRACE,() -> "reverse inbound msg: " + message);
         switch ( message.getType() )
         {
             case COMMIT_REQUEST:
@@ -85,7 +84,7 @@ public final class ReverseInboundMessageHandler extends SimpleChannelInboundHand
                 listener.domainDiscoveryRequest((CasualNWMessage<CasualDomainDiscoveryRequestMessage>)message, ctx.channel());
                 break;
             default:
-                log.warning("Message type not supported: " + message.getType());
+                log.log(System.Logger.Level.WARNING,"Message type not supported: " + message.getType());
         }
     }
 

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundServerImpl.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundServerImpl.java
@@ -29,6 +29,8 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
+import static java.lang.System.Logger.Level.*;
+
 /**
  * Inbound "server" that connects and then acts exactly like {@link  se.laz.casual.network.inbound.CasualServer}
  * In fact it is in actuality a client but after connect it behaves as if the connection was initiated from the other side.
@@ -57,7 +59,7 @@ public class ReverseInboundServerImpl implements ReverseInboundServer
         Channel ch = init(reverseInboundConnectionInformation.getAddress(), messageHandler, ReverseInboundExceptionHandler.of(reverseInboundConnectionInformation.getInboundTransactionRegistry()), reverseInboundConnectionInformation.isLogHandlerEnabled(), reverseInboundConnectionInformation.getChannelClass());
         ReverseInboundServerImpl server = new ReverseInboundServerImpl(ch, reverseInboundConnectionInformation.getAddress(), workManagerSupplier);
         ch.closeFuture().addListener(f -> server.onClose(reverseInboundConnectionInformation, eventListener));
-        LOG.log(System.Logger.Level.INFO,() -> "reverse inbound connected to: " + server.getAddress());
+        LOG.log(INFO,() -> "reverse inbound connected to: " + server.getAddress());
         return server;
     }
 
@@ -88,11 +90,11 @@ public class ReverseInboundServerImpl implements ReverseInboundServer
                         if(enableLogHandler)
                         {
                             ch.pipeline().addFirst(LOG_HANDLER_NAME, new LoggingHandler(LogLevelProvider.REVERSE_LOGGING_LEVEL));
-                            LOG.log(System.Logger.Level.INFO,() -> "reverse inbound log handler enabled, using netty logging level: " + LogLevelProvider.REVERSE_LOGGING_LEVEL);
+                            LOG.log(INFO,() -> "reverse inbound log handler enabled, using netty logging level: " + LogLevelProvider.REVERSE_LOGGING_LEVEL);
                         }
                     }
                 });
-        LOG.log(System.Logger.Level.INFO,() -> "reverse inbound about to connect to: " + address);
+        LOG.log(INFO,() -> "reverse inbound about to connect to: " + address);
         return b.connect(address).syncUninterruptibly().channel();
     }
 

--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundServerImpl.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/ReverseInboundServerImpl.java
@@ -28,7 +28,6 @@ import java.net.InetSocketAddress;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
-import java.util.logging.Logger;
 
 /**
  * Inbound "server" that connects and then acts exactly like {@link  se.laz.casual.network.inbound.CasualServer}
@@ -37,7 +36,7 @@ import java.util.logging.Logger;
  */
 public class ReverseInboundServerImpl implements ReverseInboundServer
 {
-    private static final Logger LOG = Logger.getLogger(ReverseInboundServerImpl.class.getName());
+    private static final System.Logger LOG = System.getLogger(ReverseInboundServerImpl.class.getName());
     private static final String LOG_HANDLER_NAME = "logHandler";
     private final Channel channel;
     private final InetSocketAddress address;
@@ -58,7 +57,7 @@ public class ReverseInboundServerImpl implements ReverseInboundServer
         Channel ch = init(reverseInboundConnectionInformation.getAddress(), messageHandler, ReverseInboundExceptionHandler.of(reverseInboundConnectionInformation.getInboundTransactionRegistry()), reverseInboundConnectionInformation.isLogHandlerEnabled(), reverseInboundConnectionInformation.getChannelClass());
         ReverseInboundServerImpl server = new ReverseInboundServerImpl(ch, reverseInboundConnectionInformation.getAddress(), workManagerSupplier);
         ch.closeFuture().addListener(f -> server.onClose(reverseInboundConnectionInformation, eventListener));
-        LOG.info(() -> "reverse inbound connected to: " + server.getAddress());
+        LOG.log(System.Logger.Level.INFO,() -> "reverse inbound connected to: " + server.getAddress());
         return server;
     }
 
@@ -89,11 +88,11 @@ public class ReverseInboundServerImpl implements ReverseInboundServer
                         if(enableLogHandler)
                         {
                             ch.pipeline().addFirst(LOG_HANDLER_NAME, new LoggingHandler(LogLevelProvider.REVERSE_LOGGING_LEVEL));
-                            LOG.info(() -> "reverse inbound log handler enabled, using netty logging level: " + LogLevelProvider.REVERSE_LOGGING_LEVEL);
+                            LOG.log(System.Logger.Level.INFO,() -> "reverse inbound log handler enabled, using netty logging level: " + LogLevelProvider.REVERSE_LOGGING_LEVEL);
                         }
                     }
                 });
-        LOG.info(() -> "reverse inbound about to connect to: " + address);
+        LOG.log(System.Logger.Level.INFO,() -> "reverse inbound about to connect to: " + address);
         return b.connect(address).syncUninterruptibly().channel();
     }
 

--- a/casual/casual-network/src/main/java/se/laz/casual/network/outbound/CasualMessageHandler.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/outbound/CasualMessageHandler.java
@@ -12,11 +12,10 @@ import se.laz.casual.api.network.protocol.messages.CasualNWMessage;
 import se.laz.casual.api.network.protocol.messages.CasualNWMessageType;
 
 import java.util.Objects;
-import java.util.logging.Logger;
 
 public class CasualMessageHandler extends SimpleChannelInboundHandler<CasualNWMessage<?>>
 {
-    private static final Logger LOG = Logger.getLogger(CasualMessageHandler.class.getName());
+    private static final System.Logger LOG = System.getLogger(CasualMessageHandler.class.getName());
     private final Correlator correlator;
 
     private CasualOutboundMessageListener messageListener;
@@ -41,7 +40,7 @@ public class CasualMessageHandler extends SimpleChannelInboundHandler<CasualNWMe
     @Override
     protected void channelRead0(final ChannelHandlerContext ctx, final CasualNWMessage<?> msg)
     {
-        LOG.finest(() -> String.format("reply: %s", LogTool.asLogEntry(msg)));
+        LOG.log(System.Logger.Level.TRACE,() -> String.format("reply: %s", LogTool.asLogEntry(msg)));
         if(isConversationalMessage(msg.getType()))
         {
             // pass along the pipeline to the next handler

--- a/casual/casual-network/src/main/java/se/laz/casual/network/outbound/CasualMessageHandler.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/outbound/CasualMessageHandler.java
@@ -13,6 +13,8 @@ import se.laz.casual.api.network.protocol.messages.CasualNWMessageType;
 
 import java.util.Objects;
 
+import static java.lang.System.Logger.Level.*;
+
 public class CasualMessageHandler extends SimpleChannelInboundHandler<CasualNWMessage<?>>
 {
     private static final System.Logger LOG = System.getLogger(CasualMessageHandler.class.getName());
@@ -40,7 +42,7 @@ public class CasualMessageHandler extends SimpleChannelInboundHandler<CasualNWMe
     @Override
     protected void channelRead0(final ChannelHandlerContext ctx, final CasualNWMessage<?> msg)
     {
-        LOG.log(System.Logger.Level.TRACE,() -> String.format("reply: %s", LogTool.asLogEntry(msg)));
+        LOG.log(DEBUG,() -> String.format("reply: %s", LogTool.asLogEntry(msg)));
         if(isConversationalMessage(msg.getType()))
         {
             // pass along the pipeline to the next handler

--- a/casual/casual-network/src/main/java/se/laz/casual/network/outbound/CorrelatorImpl.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/outbound/CorrelatorImpl.java
@@ -15,11 +15,10 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Logger;
 
 public final class CorrelatorImpl implements Correlator
 {
-    private static final Logger log = Logger.getLogger(CorrelatorImpl.class.getName());
+    private static final System.Logger log = System.getLogger(CorrelatorImpl.class.getName());
     private final Map<UUID, CompletableFuture<?>> requests = new ConcurrentHashMap<>();
     private CorrelatorImpl()
     {}
@@ -41,7 +40,7 @@ public final class CorrelatorImpl implements Correlator
         if(null == f)
         {
             // log failure, this is an inconsistency that should not occur
-            log.warning(() -> "Can not find a future for correlation id: " + msg.getCorrelationId() + " this should NEVER happen!");
+            log.log(System.Logger.Level.WARNING,() -> "Can not find a future for correlation id: " + msg.getCorrelationId() + " this should NEVER happen!");
             return;
         }
         if(!f.isCancelled())

--- a/casual/casual-network/src/main/java/se/laz/casual/network/outbound/CorrelatorImpl.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/outbound/CorrelatorImpl.java
@@ -16,6 +16,8 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static java.lang.System.Logger.Level.*;
+
 public final class CorrelatorImpl implements Correlator
 {
     private static final System.Logger log = System.getLogger(CorrelatorImpl.class.getName());
@@ -40,7 +42,7 @@ public final class CorrelatorImpl implements Correlator
         if(null == f)
         {
             // log failure, this is an inconsistency that should not occur
-            log.log(System.Logger.Level.WARNING,() -> "Can not find a future for correlation id: " + msg.getCorrelationId() + " this should NEVER happen!");
+            log.log(WARNING,() -> "Can not find a future for correlation id: " + msg.getCorrelationId() + " this should NEVER happen!");
             return;
         }
         if(!f.isCancelled())

--- a/casual/casual-network/src/main/java/se/laz/casual/network/outbound/DomainDisconnectHandler.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/outbound/DomainDisconnectHandler.java
@@ -15,6 +15,8 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
+import static java.lang.System.Logger.Level.*;
+
 public class DomainDisconnectHandler
 {
     private static final System.Logger LOG = System.getLogger(DomainDisconnectHandler.class.getName());
@@ -65,7 +67,7 @@ public class DomainDisconnectHandler
             ChannelFuture cf = channel.writeAndFlush(CasualNWMessageImpl.of(domainDisconnectReplyInfo.getCorrid(), replyMessage));
             cf.addListener(v -> {
                 if(!v.isSuccess()){
-                    LOG.log(System.Logger.Level.INFO,
+                    LOG.log(INFO,
                             () -> "failed sending domain disconnect reply to domain: " + domainId + " , this means that casual sent domain disconnect and then went away before we could send domain disconnect reply - this is ok");
                 }
             });
@@ -74,7 +76,7 @@ public class DomainDisconnectHandler
         {
             // if we did not manage to send the domain disconnect message it is due to the connection being gone
             // which is fine
-            LOG.log(System.Logger.Level.INFO,
+            LOG.log(INFO,
                     () -> "could not send domain disconnect reply to domain: " + domainId + " , this means that casual sent domain disconnect and then went away before we could send domain disconnect reply - this is ok" );
         }
     }

--- a/casual/casual-network/src/main/java/se/laz/casual/network/outbound/DomainDisconnectHandler.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/outbound/DomainDisconnectHandler.java
@@ -14,12 +14,10 @@ import se.laz.casual.network.protocol.messages.domain.DomainDisconnectReplyMessa
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class DomainDisconnectHandler
 {
-    private static final Logger LOG = Logger.getLogger(DomainDisconnectHandler.class.getName());
+    private static final System.Logger LOG = System.getLogger(DomainDisconnectHandler.class.getName());
     private final AtomicBoolean domainDisconnected = new AtomicBoolean(false);
     private final Channel channel;
     private final DomainId domainId;
@@ -67,7 +65,7 @@ public class DomainDisconnectHandler
             ChannelFuture cf = channel.writeAndFlush(CasualNWMessageImpl.of(domainDisconnectReplyInfo.getCorrid(), replyMessage));
             cf.addListener(v -> {
                 if(!v.isSuccess()){
-                    LOG.log(Level.INFO, v.cause(),
+                    LOG.log(System.Logger.Level.INFO,
                             () -> "failed sending domain disconnect reply to domain: " + domainId + " , this means that casual sent domain disconnect and then went away before we could send domain disconnect reply - this is ok");
                 }
             });
@@ -76,7 +74,7 @@ public class DomainDisconnectHandler
         {
             // if we did not manage to send the domain disconnect message it is due to the connection being gone
             // which is fine
-            LOG.log(Level.INFO, e,
+            LOG.log(System.Logger.Level.INFO,
                     () -> "could not send domain disconnect reply to domain: " + domainId + " , this means that casual sent domain disconnect and then went away before we could send domain disconnect reply - this is ok" );
         }
     }

--- a/casual/casual-network/src/main/java/se/laz/casual/network/outbound/JEEConcurrencyFactory.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/outbound/JEEConcurrencyFactory.java
@@ -14,11 +14,10 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.logging.Logger;
 
 public class JEEConcurrencyFactory
 {
-    private static final Logger LOG = Logger.getLogger(JEEConcurrencyFactory.class.getName());
+    private static final System.Logger LOG = System.getLogger(JEEConcurrencyFactory.class.getName());
     // An indirect, via java:comp, JNDI lookup can only be done from an application within a J2EE container (Web module, EJB module, or application client module).
     // Hence, we need to issue direct JNDI lookup since that is not true for us - yet, due to the packaging of casual-jca
 
@@ -59,14 +58,14 @@ public class JEEConcurrencyFactory
         String name = ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_OUTBOUND_MANAGED_EXECUTOR_SERVICE_NAME );
         try
         {
-            LOG.info(() -> "using ManagedExecutorService: " + name);
+            LOG.log(System.Logger.Level.INFO,() -> "using ManagedExecutorService: " + name);
             return InitialContext.doLookup(name);
         }
         catch (NamingException e)
         {
             try
             {
-                LOG.warning(() -> "failed using ManagedExecutorService: " + name + " will try with: " + DEFAULT_MANAGED_EXECUTOR_SERVICE_NAME_JBOSS_DIRECT);
+                LOG.log(System.Logger.Level.WARNING,() -> "failed using ManagedExecutorService: " + name + " will try with: " + DEFAULT_MANAGED_EXECUTOR_SERVICE_NAME_JBOSS_DIRECT);
                 return InitialContext.doLookup(DEFAULT_MANAGED_EXECUTOR_SERVICE_NAME_JBOSS_DIRECT);
             }
             catch (NamingException ee)
@@ -96,7 +95,7 @@ public class JEEConcurrencyFactory
         }
         catch (NamingException e)
         {
-            LOG.info("Failed lookup for " + DEFAULT_MANAGED_SCHEDULED_EXECUTOR_SERVICE_NAME_JBOSS_DIRECT + ", will retry indirect jndi name (may exist in this context on some non-standard application servers)");
+            LOG.log(System.Logger.Level.INFO,"Failed lookup for " + DEFAULT_MANAGED_SCHEDULED_EXECUTOR_SERVICE_NAME_JBOSS_DIRECT + ", will retry indirect jndi name (may exist in this context on some non-standard application servers)");
             try
             {
                 // Second try non-standard use of indirect jndi name defined in JSR-236
@@ -104,7 +103,7 @@ public class JEEConcurrencyFactory
             }
             catch (NamingException ex)
             {
-                LOG.info("Failed lookup for " + DEFAULT_MANAGED_SCHEDULED_EXECUTOR_SERVICE_NAME_INDIRECT + ", will use scheduled executor from java.util.concurrent.Executors");
+                LOG.log(System.Logger.Level.INFO,"Failed lookup for " + DEFAULT_MANAGED_SCHEDULED_EXECUTOR_SERVICE_NAME_INDIRECT + ", will use scheduled executor from java.util.concurrent.Executors");
                 // If all else fails, use java.util.concurrent variant as scheduler
                 return getSharedJavaUtilScheduledExecutor();
             }

--- a/casual/casual-network/src/main/java/se/laz/casual/network/outbound/JEEConcurrencyFactory.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/outbound/JEEConcurrencyFactory.java
@@ -15,6 +15,8 @@ import javax.naming.NamingException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
+import static java.lang.System.Logger.Level.*;
+
 public class JEEConcurrencyFactory
 {
     private static final System.Logger LOG = System.getLogger(JEEConcurrencyFactory.class.getName());
@@ -58,14 +60,14 @@ public class JEEConcurrencyFactory
         String name = ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_OUTBOUND_MANAGED_EXECUTOR_SERVICE_NAME );
         try
         {
-            LOG.log(System.Logger.Level.INFO,() -> "using ManagedExecutorService: " + name);
+            LOG.log(INFO,() -> "using ManagedExecutorService: " + name);
             return InitialContext.doLookup(name);
         }
         catch (NamingException e)
         {
             try
             {
-                LOG.log(System.Logger.Level.WARNING,() -> "failed using ManagedExecutorService: " + name + " will try with: " + DEFAULT_MANAGED_EXECUTOR_SERVICE_NAME_JBOSS_DIRECT);
+                LOG.log(WARNING,() -> "failed using ManagedExecutorService: " + name + " will try with: " + DEFAULT_MANAGED_EXECUTOR_SERVICE_NAME_JBOSS_DIRECT,e);
                 return InitialContext.doLookup(DEFAULT_MANAGED_EXECUTOR_SERVICE_NAME_JBOSS_DIRECT);
             }
             catch (NamingException ee)
@@ -95,7 +97,7 @@ public class JEEConcurrencyFactory
         }
         catch (NamingException e)
         {
-            LOG.log(System.Logger.Level.INFO,"Failed lookup for " + DEFAULT_MANAGED_SCHEDULED_EXECUTOR_SERVICE_NAME_JBOSS_DIRECT + ", will retry indirect jndi name (may exist in this context on some non-standard application servers)");
+            LOG.log(INFO,"Failed lookup for " + DEFAULT_MANAGED_SCHEDULED_EXECUTOR_SERVICE_NAME_JBOSS_DIRECT + ", will retry indirect jndi name (may exist in this context on some non-standard application servers)");
             try
             {
                 // Second try non-standard use of indirect jndi name defined in JSR-236
@@ -103,7 +105,7 @@ public class JEEConcurrencyFactory
             }
             catch (NamingException ex)
             {
-                LOG.log(System.Logger.Level.INFO,"Failed lookup for " + DEFAULT_MANAGED_SCHEDULED_EXECUTOR_SERVICE_NAME_INDIRECT + ", will use scheduled executor from java.util.concurrent.Executors");
+                LOG.log(INFO,"Failed lookup for " + DEFAULT_MANAGED_SCHEDULED_EXECUTOR_SERVICE_NAME_INDIRECT + ", will use scheduled executor from java.util.concurrent.Executors");
                 // If all else fails, use java.util.concurrent variant as scheduler
                 return getSharedJavaUtilScheduledExecutor();
             }

--- a/casual/casual-network/src/main/java/se/laz/casual/network/outbound/NettyNetworkConnection.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/outbound/NettyNetworkConnection.java
@@ -47,6 +47,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
+import static java.lang.System.Logger.Level.*;
+
 public class NettyNetworkConnection implements NetworkConnection, ConversationClose, CasualOutboundMessageListener
 {
     private static final System.Logger LOG = System.getLogger(NettyNetworkConnection.class.getName());
@@ -92,7 +94,7 @@ public class NettyNetworkConnection implements NetworkConnection, ConversationCl
         CasualMessageHandler messageHandler = CasualMessageHandler.of(correlator);
         Channel ch = init(ci.getAddress(), workerGroup, ci.getChannelClass(), messageHandler, conversationMessageHandler, ExceptionHandler.of(correlator, onNetworkError), ci.isLogHandlerEnabled());
         NettyNetworkConnection networkConnection = new NettyNetworkConnection(ci, correlator, ch, conversationMessageStorage, JEEConcurrencyFactory::getManagedExecutorService, errorInformer);
-        LOG.log(System.Logger.Level.TRACE,() -> networkConnection + " connected to: " + new InetSocketAddress(ci.getAddress().getHostName(), ci.getAddress().getPort()));
+        LOG.log(DEBUG,() -> networkConnection + " connected to: " + new InetSocketAddress(ci.getAddress().getHostName(), ci.getAddress().getPort()));
         ch.closeFuture().addListener(f -> handleClose(networkConnection, errorInformer));
         DomainId id = networkConnection.throwIfProtocolVersionNotSupportedByEIS(ci.getDomainId(), ci.getDomainName());
         networkConnection.setDomainId(id);
@@ -133,11 +135,11 @@ public class NettyNetworkConnection implements NetworkConnection, ConversationCl
                     if(enableLogHandler)
                     {
                         ch.pipeline().addFirst(LOG_HANDLER_NAME, new LoggingHandler(LogLevelProvider.OUTBOUND_LOGGING_LEVEL));
-                        LOG.log(System.Logger.Level.INFO,() -> "outbound network log handler enabled, using netty logging level: " + LogLevelProvider.OUTBOUND_LOGGING_LEVEL);
+                        LOG.log(INFO,() -> "outbound network log handler enabled, using netty logging level: " + LogLevelProvider.OUTBOUND_LOGGING_LEVEL);
                     }
                 }
             });
-        LOG.log(System.Logger.Level.TRACE,() -> "about to connect to: " + address);
+        LOG.log(DEBUG,() -> "about to connect to: " + address);
         return b.connect(address).syncUninterruptibly().channel();
     }
 
@@ -179,10 +181,10 @@ public class NettyNetworkConnection implements NetworkConnection, ConversationCl
     {
         issueRequest(message, true).ifPresent(casualNWMessageCompletableFuture -> casualNWMessageCompletableFuture.whenComplete((v, e) -> {
             if (null != e) {
-                LOG.log(System.Logger.Level.WARNING,"requestNoReply: " + message + " error: " + e);
+                LOG.log(WARNING,"requestNoReply: " + message + " error: " + e,e);
                 return;
             }
-            LOG.log(System.Logger.Level.WARNING,"requestNoReply: " + message + " got reply: " + v);
+            LOG.log(WARNING,"requestNoReply: " + message + " got reply: " + v);
         }));
     }
 
@@ -222,7 +224,7 @@ public class NettyNetworkConnection implements NetworkConnection, ConversationCl
     public void close()
     {
         connected.set(false);
-        LOG.log(System.Logger.Level.TRACE,() -> this + " network connection close called by appserver, closing");
+        LOG.log(DEBUG,() -> this + " network connection close called by appserver, closing");
         channel.close();
     }
 
@@ -233,7 +235,7 @@ public class NettyNetworkConnection implements NetworkConnection, ConversationCl
             // new service calls are not ok when domain has been disconnected
             throw new DomainDisconnectedException("Domain: " + domainId + " has disconnected, no service or queue calls allowed");
         }
-        LOG.log(System.Logger.Level.TRACE,() -> String.format("request: %s", LogTool.asLogEntry(message)) + "\n using " + this);
+        LOG.log(DEBUG,() -> String.format("request: %s", LogTool.asLogEntry(message)) + "\n using " + this);
     }
 
     private <T extends CasualNetworkTransmittable, X extends CasualNetworkTransmittable> Optional<CompletableFuture<CasualNWMessage<T>>> issueRequest(CasualNWMessage<X> message, boolean noReply)
@@ -242,7 +244,7 @@ public class NettyNetworkConnection implements NetworkConnection, ConversationCl
         CompletableFuture<CasualNWMessage<T>> f = new CompletableFuture<>();
         if(!channel.isActive())
         {
-            LOG.log(System.Logger.Level.TRACE,"channel not active, connection gone");
+            LOG.log(DEBUG,"channel not active, connection gone");
             f.completeExceptionally(new CasualConnectionException("can not write msg: " + message + " connection is gone"));
             return noReply ? Optional.empty() : Optional.of(f);
         }
@@ -256,7 +258,7 @@ public class NettyNetworkConnection implements NetworkConnection, ConversationCl
             if(!v.isSuccess()){
                 List<UUID> l = new ArrayList<>();
                 l.add(message.getCorrelationId());
-                LOG.log(System.Logger.Level.TRACE,() -> String.format("failed request: %s", LogTool.asLogEntry(message)));
+                LOG.log(DEBUG,() -> String.format("failed request: %s", LogTool.asLogEntry(message)));
                 // This since all outstanding requests may already have been completed exceptionally
                 // when no reply - nobody is listening Dave
                 if(!f.isCompletedExceptionally() && !noReply) {
@@ -331,18 +333,18 @@ public class NettyNetworkConnection implements NetworkConnection, ConversationCl
                                                                                             .withProtocols(ProtocolVersion.supportedVersionNumbers())
                                                                                             .build();
         CasualNWMessage<CasualDomainConnectRequestMessage> nwMessage = CasualNWMessageImpl.of(UUID.randomUUID(), requestMessage);
-        LOG.log(System.Logger.Level.TRACE,() -> "about to send handshake: " + this);
+        LOG.log(DEBUG,() -> "about to send handshake: " + this);
         CompletableFuture<CasualNWMessage<CasualDomainConnectReplyMessage>> replyEnvelopeFuture = request(nwMessage);
-        LOG.log(System.Logger.Level.TRACE,() -> "handshake sent: " + this);
+        LOG.log(DEBUG,() -> "handshake sent: " + this);
         CasualNWMessage<CasualDomainConnectReplyMessage> replyEnvelope = replyEnvelopeFuture.join();
-        LOG.log(System.Logger.Level.TRACE,() -> "received handshake reply: " + this);
+        LOG.log(DEBUG,() -> "received handshake reply: " + this);
         long actualProtocolVersion = ProtocolVersion.supportedVersionNumbers()
                                                               .stream()
                                                               .filter(version -> version == replyEnvelope.getMessage().getProtocolVersion())
                                                               .findFirst()
                                                               .orElseThrow(() -> new CasualConnectionException("wanted one of protocol versions " + ProtocolVersion.supportedVersionNumbers() + " but it is not supported by casual.\n Casual suggested protocol version " + replyEnvelope.getMessage().getProtocolVersion()));
         setProtocolVersion(ProtocolVersion.unmarshall(actualProtocolVersion));
-        LOG.log(System.Logger.Level.INFO,() -> "using protocol version: " + protocolVersion + " asked for: " + ProtocolVersion.supportedVersions());
+        LOG.log(INFO,() -> "using protocol version: " + protocolVersion + " asked for: " + ProtocolVersion.supportedVersions());
         return DomainId.of(replyEnvelope.getMessage().getDomainId());
     }
 
@@ -408,7 +410,7 @@ public class NettyNetworkConnection implements NetworkConnection, ConversationCl
     @Override
     public <T extends CasualNetworkTransmittable> void handleMessage(CasualNWMessage<T> message)
     {
-        LOG.log(System.Logger.Level.TRACE,() -> "message: " + LogTool.asLogEntry(message));
+        LOG.log(DEBUG,() -> "message: " + LogTool.asLogEntry(message));
         final T msg = message.getMessage();
         if(msg instanceof DomainDisconnectRequestMessage requestMessage)
         {
@@ -421,7 +423,7 @@ public class NettyNetworkConnection implements NetworkConnection, ConversationCl
         }
         else
         {
-            LOG.log(System.Logger.Level.WARNING,() -> "message type: " + message.getType() + " not handled!");
+            LOG.log(WARNING,() -> "message type: " + message.getType() + " not handled!");
         }
 
     }

--- a/casual/casual-network/src/main/java/se/laz/casual/network/outbound/NettyNetworkConnection.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/outbound/NettyNetworkConnection.java
@@ -46,11 +46,10 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
-import java.util.logging.Logger;
 
 public class NettyNetworkConnection implements NetworkConnection, ConversationClose, CasualOutboundMessageListener
 {
-    private static final Logger LOG = Logger.getLogger(NettyNetworkConnection.class.getName());
+    private static final System.Logger LOG = System.getLogger(NettyNetworkConnection.class.getName());
     private static final String LOG_HANDLER_NAME = "logHandler";
     private final BaseConnectionInformation ci;
     private final Correlator correlator;
@@ -93,7 +92,7 @@ public class NettyNetworkConnection implements NetworkConnection, ConversationCl
         CasualMessageHandler messageHandler = CasualMessageHandler.of(correlator);
         Channel ch = init(ci.getAddress(), workerGroup, ci.getChannelClass(), messageHandler, conversationMessageHandler, ExceptionHandler.of(correlator, onNetworkError), ci.isLogHandlerEnabled());
         NettyNetworkConnection networkConnection = new NettyNetworkConnection(ci, correlator, ch, conversationMessageStorage, JEEConcurrencyFactory::getManagedExecutorService, errorInformer);
-        LOG.finest(() -> networkConnection + " connected to: " + new InetSocketAddress(ci.getAddress().getHostName(), ci.getAddress().getPort()));
+        LOG.log(System.Logger.Level.TRACE,() -> networkConnection + " connected to: " + new InetSocketAddress(ci.getAddress().getHostName(), ci.getAddress().getPort()));
         ch.closeFuture().addListener(f -> handleClose(networkConnection, errorInformer));
         DomainId id = networkConnection.throwIfProtocolVersionNotSupportedByEIS(ci.getDomainId(), ci.getDomainName());
         networkConnection.setDomainId(id);
@@ -134,11 +133,11 @@ public class NettyNetworkConnection implements NetworkConnection, ConversationCl
                     if(enableLogHandler)
                     {
                         ch.pipeline().addFirst(LOG_HANDLER_NAME, new LoggingHandler(LogLevelProvider.OUTBOUND_LOGGING_LEVEL));
-                        LOG.info(() -> "outbound network log handler enabled, using netty logging level: " + LogLevelProvider.OUTBOUND_LOGGING_LEVEL);
+                        LOG.log(System.Logger.Level.INFO,() -> "outbound network log handler enabled, using netty logging level: " + LogLevelProvider.OUTBOUND_LOGGING_LEVEL);
                     }
                 }
             });
-        LOG.finest(() -> "about to connect to: " + address);
+        LOG.log(System.Logger.Level.TRACE,() -> "about to connect to: " + address);
         return b.connect(address).syncUninterruptibly().channel();
     }
 
@@ -180,10 +179,10 @@ public class NettyNetworkConnection implements NetworkConnection, ConversationCl
     {
         issueRequest(message, true).ifPresent(casualNWMessageCompletableFuture -> casualNWMessageCompletableFuture.whenComplete((v, e) -> {
             if (null != e) {
-                LOG.warning("requestNoReply: " + message + " error: " + e);
+                LOG.log(System.Logger.Level.WARNING,"requestNoReply: " + message + " error: " + e);
                 return;
             }
-            LOG.warning("requestNoReply: " + message + " got reply: " + v);
+            LOG.log(System.Logger.Level.WARNING,"requestNoReply: " + message + " got reply: " + v);
         }));
     }
 
@@ -223,7 +222,7 @@ public class NettyNetworkConnection implements NetworkConnection, ConversationCl
     public void close()
     {
         connected.set(false);
-        LOG.finest(() -> this + " network connection close called by appserver, closing");
+        LOG.log(System.Logger.Level.TRACE,() -> this + " network connection close called by appserver, closing");
         channel.close();
     }
 
@@ -234,7 +233,7 @@ public class NettyNetworkConnection implements NetworkConnection, ConversationCl
             // new service calls are not ok when domain has been disconnected
             throw new DomainDisconnectedException("Domain: " + domainId + " has disconnected, no service or queue calls allowed");
         }
-        LOG.finest(() -> String.format("request: %s", LogTool.asLogEntry(message)) + "\n using " + this);
+        LOG.log(System.Logger.Level.TRACE,() -> String.format("request: %s", LogTool.asLogEntry(message)) + "\n using " + this);
     }
 
     private <T extends CasualNetworkTransmittable, X extends CasualNetworkTransmittable> Optional<CompletableFuture<CasualNWMessage<T>>> issueRequest(CasualNWMessage<X> message, boolean noReply)
@@ -243,7 +242,7 @@ public class NettyNetworkConnection implements NetworkConnection, ConversationCl
         CompletableFuture<CasualNWMessage<T>> f = new CompletableFuture<>();
         if(!channel.isActive())
         {
-            LOG.finest("channel not active, connection gone");
+            LOG.log(System.Logger.Level.TRACE,"channel not active, connection gone");
             f.completeExceptionally(new CasualConnectionException("can not write msg: " + message + " connection is gone"));
             return noReply ? Optional.empty() : Optional.of(f);
         }
@@ -257,7 +256,7 @@ public class NettyNetworkConnection implements NetworkConnection, ConversationCl
             if(!v.isSuccess()){
                 List<UUID> l = new ArrayList<>();
                 l.add(message.getCorrelationId());
-                LOG.finest(() -> String.format("failed request: %s", LogTool.asLogEntry(message)));
+                LOG.log(System.Logger.Level.TRACE,() -> String.format("failed request: %s", LogTool.asLogEntry(message)));
                 // This since all outstanding requests may already have been completed exceptionally
                 // when no reply - nobody is listening Dave
                 if(!f.isCompletedExceptionally() && !noReply) {
@@ -332,18 +331,18 @@ public class NettyNetworkConnection implements NetworkConnection, ConversationCl
                                                                                             .withProtocols(ProtocolVersion.supportedVersionNumbers())
                                                                                             .build();
         CasualNWMessage<CasualDomainConnectRequestMessage> nwMessage = CasualNWMessageImpl.of(UUID.randomUUID(), requestMessage);
-        LOG.finest(() -> "about to send handshake: " + this);
+        LOG.log(System.Logger.Level.TRACE,() -> "about to send handshake: " + this);
         CompletableFuture<CasualNWMessage<CasualDomainConnectReplyMessage>> replyEnvelopeFuture = request(nwMessage);
-        LOG.finest(() -> "handshake sent: " + this);
+        LOG.log(System.Logger.Level.TRACE,() -> "handshake sent: " + this);
         CasualNWMessage<CasualDomainConnectReplyMessage> replyEnvelope = replyEnvelopeFuture.join();
-        LOG.finest(() -> "received handshake reply: " + this);
+        LOG.log(System.Logger.Level.TRACE,() -> "received handshake reply: " + this);
         long actualProtocolVersion = ProtocolVersion.supportedVersionNumbers()
                                                               .stream()
                                                               .filter(version -> version == replyEnvelope.getMessage().getProtocolVersion())
                                                               .findFirst()
                                                               .orElseThrow(() -> new CasualConnectionException("wanted one of protocol versions " + ProtocolVersion.supportedVersionNumbers() + " but it is not supported by casual.\n Casual suggested protocol version " + replyEnvelope.getMessage().getProtocolVersion()));
         setProtocolVersion(ProtocolVersion.unmarshall(actualProtocolVersion));
-        LOG.info(() -> "using protocol version: " + protocolVersion + " asked for: " + ProtocolVersion.supportedVersions());
+        LOG.log(System.Logger.Level.INFO,() -> "using protocol version: " + protocolVersion + " asked for: " + ProtocolVersion.supportedVersions());
         return DomainId.of(replyEnvelope.getMessage().getDomainId());
     }
 
@@ -409,7 +408,7 @@ public class NettyNetworkConnection implements NetworkConnection, ConversationCl
     @Override
     public <T extends CasualNetworkTransmittable> void handleMessage(CasualNWMessage<T> message)
     {
-        LOG.finest(() -> "message: " + LogTool.asLogEntry(message));
+        LOG.log(System.Logger.Level.TRACE,() -> "message: " + LogTool.asLogEntry(message));
         final T msg = message.getMessage();
         if(msg instanceof DomainDisconnectRequestMessage requestMessage)
         {
@@ -422,7 +421,7 @@ public class NettyNetworkConnection implements NetworkConnection, ConversationCl
         }
         else
         {
-            LOG.warning(() -> "message type: " + message.getType() + " not handled!");
+            LOG.log(System.Logger.Level.WARNING,() -> "message type: " + message.getType() + " not handled!");
         }
 
     }

--- a/casual/casual-network/src/main/java/se/laz/casual/network/outbound/NetworkErrorHandler.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/outbound/NetworkErrorHandler.java
@@ -8,11 +8,10 @@ package se.laz.casual.network.outbound;
 
 import io.netty.channel.Channel;
 
-import java.util.logging.Logger;
 
 public final class NetworkErrorHandler
 {
-    private static final Logger LOG = Logger.getLogger(NetworkErrorHandler.class.getName());
+    private static final System.Logger LOG = System.getLogger(NetworkErrorHandler.class.getName());
     private NetworkErrorHandler()
     {}
 
@@ -20,7 +19,7 @@ public final class NetworkErrorHandler
     {
         if(!channel.isActive())
         {
-            LOG.finest("network connection gone, informing listeners");
+            LOG.log(System.Logger.Level.TRACE,"network connection gone, informing listeners");
             errorInformer.inform();
         }
     }

--- a/casual/casual-network/src/main/java/se/laz/casual/network/outbound/NetworkErrorHandler.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/outbound/NetworkErrorHandler.java
@@ -7,7 +7,7 @@
 package se.laz.casual.network.outbound;
 
 import io.netty.channel.Channel;
-
+import static java.lang.System.Logger.Level.*;
 
 public final class NetworkErrorHandler
 {
@@ -19,7 +19,7 @@ public final class NetworkErrorHandler
     {
         if(!channel.isActive())
         {
-            LOG.log(System.Logger.Level.TRACE,"network connection gone, informing listeners");
+            LOG.log(DEBUG,"network connection gone, informing listeners");
             errorInformer.inform();
         }
     }

--- a/casual/casual-service-discovery-extension/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/CasualServiceDiscovery.java
+++ b/casual/casual-service-discovery-extension/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/CasualServiceDiscovery.java
@@ -22,8 +22,6 @@ import jakarta.inject.Named;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import java.lang.reflect.Method;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * CDI extension for discovering services to export to
@@ -31,18 +29,18 @@ import java.util.logging.Logger;
  */
 public class CasualServiceDiscovery implements Extension
 {
-    private static final Logger LOG = Logger.getLogger(CasualServiceDiscovery.class.getName());
+    private static final System.Logger LOG = System.getLogger(CasualServiceDiscovery.class.getName());
 
     private static final CasualServiceRegistry serviceRegistry = CasualServiceRegistry.getInstance();
 
     public void beforeBeanDiscovery(@Observes BeforeBeanDiscovery beforeBeanDiscovery)
     {
-        LOG.info(()->"Initializing service Discovery");
+        LOG.log(System.Logger.Level.INFO,()->"Initializing service Discovery");
     }
 
     public <T> void processAnnotatedType(@Observes @WithAnnotations({CasualService.class}) ProcessAnnotatedType<T> processAnnotatedType )
     {
-        LOG.info("processAnnotatedType() start.");
+        LOG.log(System.Logger.Level.INFO,"processAnnotatedType() start.");
 
         AnnotatedType<T> type = processAnnotatedType.getAnnotatedType();
 
@@ -63,7 +61,7 @@ public class CasualServiceDiscovery implements Extension
         }
         catch( NamingException e )
         {
-            LOG.log(Level.FINEST, e, ()-> "Error retrieving app name." );
+            LOG.log(System.Logger.Level.TRACE, ()-> "Error retrieving app name." );
         }
 
         try
@@ -72,7 +70,7 @@ public class CasualServiceDiscovery implements Extension
         }
         catch( NamingException e )
         {
-            LOG.log(Level.FINEST, e, ()-> "Error retrieving module name." );
+            LOG.log(System.Logger.Level.TRACE, ()-> "Error retrieving module name." );
         }
 
         CasualServiceMetaData.CasualServiceMetaDataBuilder b = CasualServiceMetaData.newBuilder()
@@ -93,13 +91,13 @@ public class CasualServiceDiscovery implements Extension
                 serviceRegistry.register(b.build());
             }
         }
-        LOG.info(()->"processAnnotatedType() end.");
+        LOG.log(System.Logger.Level.INFO,()->"processAnnotatedType() end.");
     }
 
     public void afterBeanDiscovery(@Observes AfterBeanDiscovery abd)
     {
-        LOG.info(()->"Services found: " + serviceRegistry.serviceMetaDataSize() );
-        LOG.info(()->"Service Discovery Done");
+        LOG.log(System.Logger.Level.INFO,()->"Services found: " + serviceRegistry.serviceMetaDataSize() );
+        LOG.log(System.Logger.Level.INFO,()->"Service Discovery Done");
     }
 
 }

--- a/casual/casual-service-discovery-extension/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/CasualServiceDiscovery.java
+++ b/casual/casual-service-discovery-extension/src/main/java/se/laz/casual/jca/inbound/handler/service/casual/CasualServiceDiscovery.java
@@ -23,6 +23,8 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import java.lang.reflect.Method;
 
+import static java.lang.System.Logger.Level.*;
+
 /**
  * CDI extension for discovering services to export to
  * casual
@@ -35,12 +37,12 @@ public class CasualServiceDiscovery implements Extension
 
     public void beforeBeanDiscovery(@Observes BeforeBeanDiscovery beforeBeanDiscovery)
     {
-        LOG.log(System.Logger.Level.INFO,()->"Initializing service Discovery");
+        LOG.log(INFO,()->"Initializing service Discovery");
     }
 
     public <T> void processAnnotatedType(@Observes @WithAnnotations({CasualService.class}) ProcessAnnotatedType<T> processAnnotatedType )
     {
-        LOG.log(System.Logger.Level.INFO,"processAnnotatedType() start.");
+        LOG.log(INFO,"processAnnotatedType() start.");
 
         AnnotatedType<T> type = processAnnotatedType.getAnnotatedType();
 
@@ -61,7 +63,7 @@ public class CasualServiceDiscovery implements Extension
         }
         catch( NamingException e )
         {
-            LOG.log(System.Logger.Level.TRACE, ()-> "Error retrieving app name." );
+            LOG.log(DEBUG, ()-> "Error retrieving app name." );
         }
 
         try
@@ -70,7 +72,7 @@ public class CasualServiceDiscovery implements Extension
         }
         catch( NamingException e )
         {
-            LOG.log(System.Logger.Level.TRACE, ()-> "Error retrieving module name." );
+            LOG.log(DEBUG, ()-> "Error retrieving module name." );
         }
 
         CasualServiceMetaData.CasualServiceMetaDataBuilder b = CasualServiceMetaData.newBuilder()
@@ -91,13 +93,13 @@ public class CasualServiceDiscovery implements Extension
                 serviceRegistry.register(b.build());
             }
         }
-        LOG.log(System.Logger.Level.INFO,()->"processAnnotatedType() end.");
+        LOG.log(INFO,()->"processAnnotatedType() end.");
     }
 
     public void afterBeanDiscovery(@Observes AfterBeanDiscovery abd)
     {
-        LOG.log(System.Logger.Level.INFO,()->"Services found: " + serviceRegistry.serviceMetaDataSize() );
-        LOG.log(System.Logger.Level.INFO,()->"Service Discovery Done");
+        LOG.log(INFO,()->"Services found: " + serviceRegistry.serviceMetaDataSize() );
+        LOG.log(INFO,()->"Service Discovery Done");
     }
 
 }

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '3.3.7'
+version = '3.3.8'
 
 def netty_version = '4.1.121.Final'
 def gson_version = '2.11.0'


### PR DESCRIPTION
Replaced java.util.logging.Logger with System.Logger to allow for more flexible and future-proof logging. Behavior remains the same.
