### PR TITLE
docs: wildfly deployment

### DIFF
--- a/casual/casual-jca/build.gradle
+++ b/casual/casual-jca/build.gradle
@@ -20,13 +20,6 @@ configurations {
     resourceAdapterLib
 }
 
-/**
- * To ensure good developer UX, published poms include required transitive
- * dependencies, though these do not need to be packaged into the
- * RAR as they are expected to be provided or included on the classpath.
- * The following removes these transitive dependencies from the RAR.
- * In the case of netty it is instead included in the RAR lib folder.
- */
 configurations.resourceAdapter{
     exclude( group: 'io.netty' )
     exclude( group: 'com.google.code.gson' )

--- a/deployment-wildfly.md
+++ b/deployment-wildfly.md
@@ -1,18 +1,17 @@
 # Wildfly Deployment
 
 ## Wildfly version
-Note that these examples have been tested with wildfly `34.0.1.Final`.
+Note that these examples have been tested with wildfly `38.0.0.Final`.
 
 ## Casual Dependencies
 
 Create a new module, with an appropriate name e.g. `se.laz.casual`, via the jboss-cli:
 ```python
-module add --name=se.laz.casual \
-	--resources=/opt/jboss/wildfly/casual/casual-inbound-handler-api-${CASUAL_VERSION}.jar:/opt/jboss/wildfly/casual/casual-fielded-annotations-${CASUAL_VERSION}.jar:/opt/jboss/wildfly/casual/casual-service-discovery-extension-${CASUAL_VERSION}.jar:/opt/jboss/wildfly/casual/casual-api-${CASUAL_VERSION}.jar:/opt/jboss/wildfly/casual/casual-event-api-${CASUAL_VERSION}.jar:/opt/jboss/wildfly/casual/objenesis-3.4.jar \
-                --dependencies=javaee.api,sun.jdk"
+module add --name=se.laz.casual \	--resources=/opt/jboss/wildfly/casual/casual-inbound-handler-api-${CASUAL_VERSION}.jar:/opt/jboss/wildfly/casual/casual-fielded-annotations-${CASUAL_VERSION}.jar:/opt/jboss/wildfly/casual/casual-service-discovery-extension-${CASUAL_VERSION}.jar:/opt/jboss/wildfly/casual/casual-api-${CASUAL_VERSION}.jar:/opt/jboss/wildfly/casual/casual-event-api-${CASUAL_VERSION}.jar:/opt/jboss/wildfly/casual/gson-${GSON_VERSION}.jar \
+                --dependencies=javaee.api,sun.jdk
 ```
 
-Where ```CASUAL_VERSION``` is the casual-jca version, such as ```3.2.49```.
+Where ```CASUAL_VERSION``` is the casual-jca version, such as ```3.3.7```.
 
 
 To make this module available globally you can either update the standalone.xml:
@@ -27,6 +26,23 @@ Or you can add it via the jboss-cli:
 /subsystem=ee:list-add(name=global-modules, value={name=se.laz.casual})
 ```
 
+## Graceful shutdown
+
+To enable graceful shutdown, wildfly has to be configured via the cli such as:
+```python
+/subsystem=ejb3:write-attribute(name=enable-graceful-txn-shutdown, value=true)
+```
+If this is not set, wildfly will not wait for in flight transactions to finish.
+That also means that `casual-jca` can't handle that as well unless wildfly is configured correctly.
+
+## Note regarding casual-jca global module not exposing its gson dependencies anymore
+
+Starting with `casual-jca` version `3.2.49`, casual-jca does not expose its `gson` dependency anymore, thus does not pollute all
+other applications with its `gson` version.
+
+That means that your own application(s) need to package whatever `gson` they want to use ( or if you have your own global module,
+exposing a specific version of `gson`).
+
 ## Example Casual RA Configuration
 
 Please note that the id of the resource adapter **must** be `casual-jca`.
@@ -40,7 +56,7 @@ Added the following to the standalone.xml on your wildfly server:
     <resource-adapters>
         <resource-adapter id="casual-jca">
             <archive>
-            casual-jca-app-3.2.49.ear#casual-jca.rar
+            casual-jca-app-3.3.7.ear#casual-jca.rar
             </archive>
             <transaction-support>XATransaction</transaction-support>
             <connection-definitions>

--- a/deployment-wildfly.md
+++ b/deployment-wildfly.md
@@ -35,7 +35,7 @@ To enable graceful shutdown, wildfly has to be configured via the cli such as:
 /subsystem=ejb3:write-attribute(name=enable-graceful-txn-shutdown, value=true)
 ```
 If this is not set, wildfly will not wait for in flight transactions to finish.
-That also means that `casual-jca` can't handle that as well unless wildfly is configured correctly.
+Without this wildfly configuration casual-jca is not able to perform a graceful shutdown.
 
 ## Note regarding casual-jca global module not exposing its gson dependencies anymore
 

--- a/deployment-wildfly.md
+++ b/deployment-wildfly.md
@@ -7,7 +7,9 @@ Note that these examples have been tested with wildfly `38.0.0.Final`.
 
 Create a new module, with an appropriate name e.g. `se.laz.casual`, via the jboss-cli:
 ```python
-module add --name=se.laz.casual \	--resources=/opt/jboss/wildfly/casual/casual-inbound-handler-api-${CASUAL_VERSION}.jar:/opt/jboss/wildfly/casual/casual-fielded-annotations-${CASUAL_VERSION}.jar:/opt/jboss/wildfly/casual/casual-service-discovery-extension-${CASUAL_VERSION}.jar:/opt/jboss/wildfly/casual/casual-api-${CASUAL_VERSION}.jar:/opt/jboss/wildfly/casual/casual-event-api-${CASUAL_VERSION}.jar:/opt/jboss/wildfly/casual/gson-${GSON_VERSION}.jar \
+module add --name=se.laz.casual \	
+
+--resources=/opt/jboss/wildfly/casual/casual-inbound-handler-api-${CASUAL_VERSION}.jar:/opt/jboss/wildfly/casual/casual-fielded-annotations-${CASUAL_VERSION}.jar:/opt/jboss/wildfly/casual/casual-service-discovery-extension-${CASUAL_VERSION}.jar:/opt/jboss/wildfly/casual/casual-api-${CASUAL_VERSION}.jar:/opt/jboss/wildfly/casual/casual-event-api-${CASUAL_VERSION}.jar \
                 --dependencies=javaee.api,sun.jdk
 ```
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '3.3.7'
+version = '3.3.8'
 
 def netty_version = '4.1.121.Final'
 def gson_version = '2.11.0'


### PR DESCRIPTION
Updated wildfly deployment description with regards to gson no longer being wanted in the casual-jca global module as well that you need to enable wildfly graceful tx shutdown for graceful shutdown being able to function as wanted.