### PR TITLE
feat: changes for quarkus

### DIFF
--- a/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/AutoReconnect.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/inbound/reverse/AutoReconnect.java
@@ -1,17 +1,18 @@
 /*
- * Copyright (c) 2022, The casual project. All rights reserved.
+ * Copyright (c) 2022 - 2026, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
 
 package se.laz.casual.network.inbound.reverse;
 
+import jakarta.resource.spi.work.WorkManager;
 import se.laz.casual.api.util.work.RepeatUntilSuccessTaskWork;
+import se.laz.casual.jca.RuntimeInformation;
 import se.laz.casual.network.outbound.JEEConcurrencyFactory;
 import se.laz.casual.network.reverse.inbound.ReverseInboundListener;
 import se.laz.casual.network.reverse.inbound.ReverseInboundServer;
 
-import jakarta.resource.spi.work.WorkManager;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -22,7 +23,10 @@ public class AutoReconnect
    public AutoReconnect(RepeatUntilSuccessTaskWork<ReverseInboundServer> task)
    {
       this.task = task;
-      task.start();
+      if(!RuntimeInformation.isDomainBeingShutdown())
+      {
+          task.start();
+      }
    }
 
    public static AutoReconnect of(ReverseInboundConnectionInformation reverseInboundConnectionInformation,

--- a/casual/casual-network/src/main/java/se/laz/casual/network/outbound/JEEConcurrencyFactory.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/outbound/JEEConcurrencyFactory.java
@@ -1,17 +1,17 @@
 /*
- * Copyright (c) 2024, The casual project. All rights reserved.
+ * Copyright (c) 2024 - 2026, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
 package se.laz.casual.network.outbound;
 
-import jakarta.enterprise.concurrent.ManagedExecutorService;
 import se.laz.casual.config.ConfigurationOptions;
 import se.laz.casual.config.ConfigurationService;
 import se.laz.casual.jca.CasualResourceAdapterException;
 
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.logging.Logger;
@@ -40,6 +40,8 @@ public class JEEConcurrencyFactory
 
     /** Fallback ScheduledExecutorService that is used when nothing is found through jndi */
     private static ScheduledExecutorService sharedScheduledExecutor;
+    /** Fallback ExecutorService that is used when nothing is found through jndi */
+    private static ExecutorService sharedExecutorService;
 
     private JEEConcurrencyFactory()
     {}
@@ -47,14 +49,17 @@ public class JEEConcurrencyFactory
     /**
      * Gets default managed executor service - on jboss
      * On wls it will throw CasualResourceAdapterException unless a direct JNDI-name is configured
+     *
+     * If configured to run unmanaged, we use the shared executor service
+     * This is needed for conversation handling
      * @return an ExecutorService
      */
-    public static ManagedExecutorService getManagedExecutorService()
+    public static ExecutorService getManagedExecutorService()
     {
         boolean unmanaged = ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_OUTBOUND_UNMANAGED );
         if(unmanaged)
         {
-            return null;
+            return getSharedExecutorService();
         }
         String name = ConfigurationService.getConfiguration( ConfigurationOptions.CASUAL_OUTBOUND_MANAGED_EXECUTOR_SERVICE_NAME );
         try
@@ -74,6 +79,15 @@ public class JEEConcurrencyFactory
                 throw new CasualResourceAdapterException("failed lookup for: " + name + "\n outbound will not function!", e);
             }
         }
+    }
+
+    private static ExecutorService getSharedExecutorService()
+    {
+        if(null == sharedExecutorService)
+        {
+            sharedExecutorService = Executors.newCachedThreadPool();
+        }
+        return sharedExecutorService;
     }
 
     /**

--- a/casual/casual-network/src/main/java/se/laz/casual/network/outbound/NettyNetworkConnection.java
+++ b/casual/casual-network/src/main/java/se/laz/casual/network/outbound/NettyNetworkConnection.java
@@ -14,7 +14,6 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.logging.LoggingHandler;
-import jakarta.enterprise.concurrent.ManagedExecutorService;
 import se.laz.casual.api.conversation.ConversationClose;
 import se.laz.casual.api.network.protocol.messages.CasualNWMessage;
 import se.laz.casual.api.network.protocol.messages.CasualNWMessageType;
@@ -45,6 +44,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.logging.Logger;
@@ -58,7 +58,7 @@ public class NettyNetworkConnection implements NetworkConnection, ConversationCl
     private final ConversationMessageStorage conversationMessageStorage;
     private final Channel channel;
     private final AtomicBoolean connected = new AtomicBoolean(true);
-    private final Supplier<ManagedExecutorService> managedExecutorService;
+    private final Supplier<ExecutorService> executorServiceSupplier;
     private final ErrorInformer errorInformer;
     private DomainId domainId;
     private ProtocolVersion protocolVersion;
@@ -69,14 +69,14 @@ public class NettyNetworkConnection implements NetworkConnection, ConversationCl
                                    Correlator correlator,
                                    Channel channel,
                                    ConversationMessageStorage conversationMessageStorage,
-                                   Supplier<ManagedExecutorService> managedExecutorService,
+                                   Supplier<ExecutorService> executorServiceSupplier,
                                    ErrorInformer errorInformer)
     {
         this.ci = ci;
         this.correlator = correlator;
         this.channel = channel;
         this.conversationMessageStorage = conversationMessageStorage;
-        this.managedExecutorService = managedExecutorService;
+        this.executorServiceSupplier = executorServiceSupplier;
         this.errorInformer = errorInformer;
     }
 
@@ -218,7 +218,7 @@ public class NettyNetworkConnection implements NetworkConnection, ConversationCl
         maybeMessage.ifPresent(future::complete);
         if(!future.isDone())
         {
-            managedExecutorService.get().execute(() -> future.complete(conversationMessageStorage.takeFirst(corrid)));
+            executorServiceSupplier.get().execute(() -> future.complete(conversationMessageStorage.takeFirst(corrid)));
         }
         return future;
     }

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '3.4.0'
+version = '3.4.1'
 
 def netty_version = '4.1.121.Final'
 def gson_version = '2.11.0'


### PR DESCRIPTION
Changes needed when running outside of a JEE application server:
* no ManagedExecutorService used by interface type
* for conversation, fallback to non managed executor service

We also make sure that we do not try to start any new reverse inbound connections
if the domain is going down.
