### PR TITLE
fix: Error handling for inbound

### DIFF
--- a/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/work/CasualServiceCallWork.java
+++ b/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/work/CasualServiceCallWork.java
@@ -26,6 +26,7 @@ import se.laz.casual.network.protocol.messages.service.CasualServiceCallReplyMes
 import se.laz.casual.network.protocol.messages.service.CasualServiceCallRequestMessage;
 
 import java.util.UUID;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static se.laz.casual.network.ProtocolVersion.VERSION_1_3;
@@ -72,7 +73,7 @@ public final class CasualServiceCallWork implements Work
     @Override
     public void release()
     {
-        /**
+        /*
          * Currently no way to stop a service lookup or call.
          * Transaction context with which this Work is started
          * is applied with timeout that lies outside this code.
@@ -133,6 +134,13 @@ public final class CasualServiceCallWork implements Work
             replyBuilder.setError( ErrorState.TPENOENT )
                         .setTransactionState( TransactionState.ROLLBACK_ONLY );
             log.warning( ()-> "ServiceHandler not available for: " + message.getServiceName() );
+        }
+        catch( Throwable t)
+        {
+            replyBuilder.setError( ErrorState.TPESYSTEM )
+                        .setTransactionState( TransactionState.ROLLBACK_ONLY );
+            // This shouldn't happen with a well-behaved service handler. If it does, the handler that threw might need fixing.
+            log.log( Level.SEVERE, "An exception was thrown while handing a service call", t );
         }
         finally
         {

--- a/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/work/CasualServiceCallWork.java
+++ b/casual/casual-inbound-api/src/main/java/se/laz/casual/jca/inflow/work/CasualServiceCallWork.java
@@ -45,6 +45,7 @@ public final class CasualServiceCallWork implements Work
     private CasualNWMessage<CasualServiceCallReplyMessage> response;
     private ServiceHandler handler = null;
     private final SpanId spanId;
+    private boolean workFailedUnexpectedly = false;
 
     public CasualServiceCallWork(UUID correlationId, CasualServiceCallRequestMessage message, boolean isTpNoReply, ProtocolVersion protocolVersion, SpanId spanId)
     {
@@ -104,6 +105,12 @@ public final class CasualServiceCallWork implements Work
         {
             log.warning( ()-> "ServiceHandler not available for: " + message.getServiceName() );
         }
+        catch( Throwable t)
+        {
+            workFailedUnexpectedly = true;
+            // This shouldn't happen with a well-behaved service handler. If it does, the handler that threw might need fixing.
+            log.log( Level.SEVERE, "An exception was thrown while handing a TPNOREPLY service call", t );
+        }
     }
 
     // try with resources to transport information to potential outbound thread
@@ -137,6 +144,7 @@ public final class CasualServiceCallWork implements Work
         }
         catch( Throwable t)
         {
+            workFailedUnexpectedly = true;
             replyBuilder.setError( ErrorState.TPESYSTEM )
                         .setTransactionState( TransactionState.ROLLBACK_ONLY );
             // This shouldn't happen with a well-behaved service handler. If it does, the handler that threw might need fixing.
@@ -173,4 +181,8 @@ public final class CasualServiceCallWork implements Work
         this.handler = handler;
     }
 
+    public boolean failedUnexpectedly()
+    {
+        return workFailedUnexpectedly;
+    }
 }

--- a/casual/casual-inbound-api/src/test/groovy/se/laz/casual/jca/inflow/work/CasualServiceCallWorkTest.groovy
+++ b/casual/casual-inbound-api/src/test/groovy/se/laz/casual/jca/inflow/work/CasualServiceCallWorkTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2025, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2026, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -252,5 +252,27 @@ class CasualServiceCallWorkTest extends Specification
         CasualNWMessage<CasualServiceCallReplyMessage> reply = instance.getResponse()
         then:
         reply.getMessage().getError() == ErrorState.TPENOENT
+    }
+
+    def "Call service where service handler throws an exception, returns result with TPESYSTEM status."()
+    {
+        given:
+        CasualServiceCallRequestMessage messageThrows = CasualServiceCallRequestMessage.createBuilder()
+                .setXid( XID.NULL_XID)
+                .setExecution(UUID.randomUUID())
+                .setServiceName( TestHandler.SERVICE_THROWS )
+                .setServiceBuffer( ServiceBuffer.of( "json",
+                        JsonBuffer.of(
+                                json )
+                                .getBytes() ) )
+                .setXatmiFlags( Flag.of())
+                .setProtocolVersion(ProtocolVersion.VERSION_1_2)
+                .build()
+        instance = new CasualServiceCallWork(correlationId, messageThrows, false, ProtocolVersion.VERSION_1_2, SpanId.of())
+        when:
+        instance.run()
+        CasualNWMessage<CasualServiceCallReplyMessage> reply = instance.getResponse()
+        then:
+        reply.getMessage().getError() == ErrorState.TPESYSTEM
     }
 }

--- a/casual/casual-inbound-api/src/test/groovy/se/laz/casual/jca/inflow/work/CasualServiceCallWorkTest.groovy
+++ b/casual/casual-inbound-api/src/test/groovy/se/laz/casual/jca/inflow/work/CasualServiceCallWorkTest.groovy
@@ -275,4 +275,28 @@ class CasualServiceCallWorkTest extends Specification
         then:
         reply.getMessage().getError() == ErrorState.TPESYSTEM
     }
+
+    def "Call service with TPNOREPLY where service handler throws an exception, return result with TPESYSTEM status."()
+    {
+        given:
+        CasualServiceCallRequestMessage messageThrows = CasualServiceCallRequestMessage.createBuilder()
+                .setXid( XID.NULL_XID)
+                .setExecution(UUID.randomUUID())
+                .setServiceName( TestHandler.SERVICE_THROWS )
+                .setServiceBuffer( ServiceBuffer.of( "json",
+                        JsonBuffer.of(
+                                json )
+                                .getBytes() ) )
+                .setXatmiFlags( Flag.of())
+                .setProtocolVersion(ProtocolVersion.VERSION_1_2)
+                .build()
+
+        instance = new CasualServiceCallWork(correlationId, messageThrows, true, ProtocolVersion.VERSION_1_2, SpanId.of())
+
+        when:
+        instance.run()
+
+        then:
+        noExceptionThrown()
+    }
 }

--- a/casual/casual-inbound-api/src/test/java/se/laz/casual/jca/inflow/handler/test/TestHandler.java
+++ b/casual/casual-inbound-api/src/test/java/se/laz/casual/jca/inflow/handler/test/TestHandler.java
@@ -11,29 +11,36 @@ import se.laz.casual.jca.inbound.handler.InboundRequest;
 import se.laz.casual.jca.inbound.handler.InboundResponse;
 import se.laz.casual.jca.inbound.handler.service.ServiceHandler;
 
+import java.util.List;
+
 public class TestHandler implements ServiceHandler
 {
     public static final String SERVICE_1 = "testService1";
+    public static final String SERVICE_THROWS = "testServiceThrows";
+
+    private static final List<String> HANDLED_SERVICES = List.of(SERVICE_1, SERVICE_THROWS);
+    private static final List<String> AVAILABLE_SERVICES = List.of(SERVICE_THROWS);
 
     @Override
     public boolean canHandleService(String serviceName)
     {
-        if( serviceName.equals( SERVICE_1 ) )
-        {
-            return true;
-        }
-        return false;
+        return HANDLED_SERVICES.contains(serviceName);
     }
 
     @Override
     public boolean isServiceAvailable(String serviceName)
     {
-        return false;
+        return AVAILABLE_SERVICES.contains(serviceName);
     }
 
     @Override
     public InboundResponse invokeService(InboundRequest request)
     {
+        if (SERVICE_THROWS.equals(request.getServiceName()))
+        {
+            throw new RuntimeException("this service throws");
+        }
+
         return null;
     }
 

--- a/casual/casual-inbound/src/main/java/se/laz/casual/jca/inflow/ServiceCallWorkListener.java
+++ b/casual/casual-inbound/src/main/java/se/laz/casual/jca/inflow/ServiceCallWorkListener.java
@@ -102,13 +102,14 @@ public class ServiceCallWorkListener implements WorkListener
     @Override
     public void workStarted(WorkEvent e)
     {
-        log.finest(() -> "Work started in %d ms with corrid %s".formatted(e.getStartDuration(), getCasualCorrelationId(getCasualServiceCallWork(e))));
+        log.finest(() -> "Work started in %d ms with corrid=%s".formatted(e.getStartDuration(), getCasualCorrelationId(getCasualServiceCallWork(e))));
         eventBuilder.start();
     }
 
     @Override
     public void workCompleted(WorkEvent e)
     {
+        log.finest(() -> "Work completed %s exception, corrid=%s".formatted(e.getException() == null ? "without" : "with", getCasualCorrelationId(getCasualServiceCallWork(e))));
         eventBuilder.end();
         if (e.getException() != null)
         {
@@ -158,7 +159,11 @@ public class ServiceCallWorkListener implements WorkListener
         }
         else
         {
-            eventBuilder.withCode(ErrorState.OK);
+            eventBuilder.withCode(
+                    work != null && !work.failedUnexpectedly()
+                    ? ErrorState.OK
+                    : ErrorState.TPESYSTEM
+            );
         }
         return eventBuilder.build();
     }

--- a/casual/casual-inbound/src/main/java/se/laz/casual/jca/inflow/ServiceCallWorkListener.java
+++ b/casual/casual-inbound/src/main/java/se/laz/casual/jca/inflow/ServiceCallWorkListener.java
@@ -8,8 +8,12 @@ package se.laz.casual.jca.inflow;
 
 import io.netty.channel.Channel;
 import jakarta.resource.spi.work.WorkEvent;
+import jakarta.resource.spi.work.WorkException;
 import jakarta.resource.spi.work.WorkListener;
+import se.laz.casual.api.buffer.type.ServiceBuffer;
 import se.laz.casual.api.flags.ErrorState;
+import se.laz.casual.api.flags.TransactionState;
+import se.laz.casual.api.network.protocol.messages.CasualNWMessage;
 import se.laz.casual.config.ConfigurationOptions;
 import se.laz.casual.config.ConfigurationService;
 import se.laz.casual.event.Order;
@@ -17,12 +21,16 @@ import se.laz.casual.event.ServiceCallEvent;
 import se.laz.casual.event.ServiceCallEventPublisher;
 import se.laz.casual.event.ServiceCallEventStoreFactory;
 import se.laz.casual.jca.SpanId;
+import se.laz.casual.jca.CasualResourceAdapterException;
 import se.laz.casual.jca.inflow.work.CasualServiceCallWork;
 import se.laz.casual.network.ProtocolVersion;
+import se.laz.casual.network.protocol.messages.CasualNWMessageImpl;
 import se.laz.casual.network.protocol.messages.service.CasualServiceCallReplyMessage;
 import se.laz.casual.network.protocol.messages.service.CasualServiceCallRequestMessage;
 
 import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import static se.laz.casual.network.ProtocolVersion.VERSION_1_3;
 
@@ -32,11 +40,14 @@ import static se.laz.casual.network.ProtocolVersion.VERSION_1_3;
  */
 public class ServiceCallWorkListener implements WorkListener
 {
+    private static final Logger log = Logger.getLogger(ServiceCallWorkListener.class.getName());
     private final Channel channel;
     private final boolean isTpNoReply;
     private final CasualServiceCallRequestMessage message;
     private final ProtocolVersion protocolVersion;
     private ServiceCallEventPublisher eventPublisher;
+    private boolean replySent = false;
+
     private final ServiceCallEvent.Builder eventBuilder;
     private final SpanId spanId;
 
@@ -58,18 +69,40 @@ public class ServiceCallWorkListener implements WorkListener
     @Override
     public void workAccepted(WorkEvent e)
     {
-        //No Op
+        log.finest(() -> "Accepted CasualServiceCallWork with corrid=%s".formatted(getCasualCorrelationId(getCasualServiceCallWork(e))));
     }
 
     @Override
     public void workRejected(WorkEvent e)
     {
-        // No Op
+        CasualServiceCallWork work = getCasualServiceCallWork(e);
+        if (log.isLoggable(Level.WARNING))
+        {
+            if (null != e.getException())
+            {
+                log.log(Level.WARNING,
+                        "CasualServiceCallWork rejected with errorCode=%s, corrid=%s".formatted(
+                                getDescriptiveWorkExceptionErrorCode(e.getException()),
+                                getCasualCorrelationId(work)),
+                        e.getException());
+            }
+            else
+            {
+                log.log(Level.WARNING,
+                        "CasualServiceCallWork rejected without an exception, this is not normal, corrid=%s".formatted(getCasualCorrelationId(work)));
+            }
+        }
+
+        if (!isTpNoReply)
+        {
+            sendReply(createEmptyErrorBuffer(work));
+        }
     }
 
     @Override
     public void workStarted(WorkEvent e)
     {
+        log.finest(() -> "Work started in %d ms with corrid %s".formatted(e.getStartDuration(), getCasualCorrelationId(getCasualServiceCallWork(e))));
         eventBuilder.start();
     }
 
@@ -77,12 +110,23 @@ public class ServiceCallWorkListener implements WorkListener
     public void workCompleted(WorkEvent e)
     {
         eventBuilder.end();
-        CasualServiceCallWork work = (CasualServiceCallWork) e.getWork();
+        if (e.getException() != null)
+        {
+            log.log(Level.SEVERE, "Inbound call failed with an exception, errorCode=%s".formatted(getDescriptiveWorkExceptionErrorCode(e.getException())), e.getException());
+        }
+        CasualServiceCallWork work = getCasualServiceCallWork(e);
         ServiceCallEvent event = createEvent(work);
         getEventPublisher().post(event);
         if(!isTpNoReply)
         {
-            channel.writeAndFlush(work.getResponse());
+            if(workContainsReply(work))
+            {
+                sendReply(work.getResponse());
+            }
+            else
+            {
+                sendReply(createEmptyErrorBuffer(work));
+            }
         }
     }
 
@@ -93,20 +137,24 @@ public class ServiceCallWorkListener implements WorkListener
                     .withParent(message.getParentName())
                     .withService(message.getServiceName())
                     .withOrder(Order.SEQUENTIAL);
-        if(protocolVersion.isGreaterThanOrEqualTo( VERSION_1_3 ) )
+        if(protocolVersion.isGreaterThanOrEqualTo( VERSION_1_3 ))
         {
             eventBuilder.withParentSpanId(message.getParentSpan().asHex())
                         .withSpanId(spanId.asHex());
-            if(!isTpNoReply)
+            if(!isTpNoReply && workContainsReply(work))
             {
                 CasualServiceCallReplyMessage reply = work.getResponse().getMessage();
+
                 eventBuilder.withUserCode(reply.getUserDefinedCode());
             }
         }
         if(!isTpNoReply)
         {
-            CasualServiceCallReplyMessage reply = work.getResponse().getMessage();
-            eventBuilder.withCode(reply.getError());
+            eventBuilder.withCode(
+                    workContainsReply(work)
+                    ? work.getResponse().getMessage().getError()
+                    : ErrorState.TPESYSTEM
+            );
         }
         else
         {
@@ -128,6 +176,73 @@ public class ServiceCallWorkListener implements WorkListener
     void setEventPublisher(ServiceCallEventPublisher eventPublisher)
     {
         this.eventPublisher = eventPublisher;
+    }
+
+    private boolean workContainsReply(CasualServiceCallWork work)
+    {
+        return work.getResponse() != null && work.getResponse().getMessage() != null;
+    }
+
+    private CasualServiceCallWork getCasualServiceCallWork(WorkEvent e)
+    {
+        return (CasualServiceCallWork) e.getWork();
+    }
+
+    private String getDescriptiveWorkExceptionErrorCode(WorkException e)
+    {
+        return e.getErrorCode() == null
+                ? "null"
+                : switch (e.getErrorCode())
+        {
+            case WorkException.INTERNAL -> "INTERNAL(-1)";
+            case WorkException.UNDEFINED -> "UNDEFINED(0)";
+            case WorkException.START_TIMED_OUT -> "START_TIMED_OUT(1)";
+            case WorkException.TX_CONCURRENT_WORK_DISALLOWED -> "TX_CONCURRENT_WORK_DISALLOWED(2)";
+            case WorkException.TX_RECREATE_FAILED -> "TX_RECREATE_FAILED(3)";
+            default -> "UNKNOWN(%s)".formatted(e.getErrorCode());
+        };
+    }
+
+    private UUID getCasualCorrelationId(CasualServiceCallWork work)
+    {
+        if (work.getCorrelationId() != null)
+        {
+            return work.getCorrelationId();
+        }
+        else
+        {
+            throw new CasualResourceAdapterException("Casual Work does not contain a correlation id, this should not happen.");
+        }
+    }
+
+    private CasualNWMessage<?> createEmptyErrorBuffer(CasualServiceCallWork work)
+    {
+        CasualServiceCallReplyMessage.Builder replyMessageBuilder = new CasualServiceCallReplyMessage.Builder()
+                .setProtocolVersion(protocolVersion)
+                .setExecution(work.getMessage().getExecution())
+                .setError(ErrorState.TPESYSTEM)
+                .setTransactionState(TransactionState.ROLLBACK_ONLY)
+                .setServiceBuffer(ServiceBuffer.nullBuffer());
+
+        if (protocolVersion.isLessThan( VERSION_1_3) )
+        {
+            replyMessageBuilder.setXid(work.getMessage().getXid());
+        }
+
+        return CasualNWMessageImpl.of(work.getCorrelationId(), replyMessageBuilder.build());
+    }
+
+    private void sendReply(CasualNWMessage<?> replyMessage)
+    {
+        if (!replySent)
+        {
+            channel.writeAndFlush(replyMessage);
+            replySent = true;
+        }
+        else
+        {
+            throw new RuntimeException("Response already sent to casual, there seems to be a logic error");
+        }
     }
 
 }

--- a/casual/casual-inbound/src/test/groovy/se/laz/casual/jca/inflow/ServiceCallWorkListenerTest.groovy
+++ b/casual/casual-inbound/src/test/groovy/se/laz/casual/jca/inflow/ServiceCallWorkListenerTest.groovy
@@ -8,6 +8,7 @@ package se.laz.casual.jca.inflow
 
 import io.netty.channel.Channel
 import io.netty.channel.embedded.EmbeddedChannel
+import jakarta.resource.spi.work.Work
 import jakarta.resource.spi.work.WorkCompletedException
 import jakarta.resource.spi.work.WorkEvent
 import jakarta.resource.spi.work.WorkException
@@ -143,6 +144,33 @@ class ServiceCallWorkListenerTest extends Specification
       }
       0 * channel.writeAndFlush(_ as CasualServiceCallReplyMessage)
    }
+
+    def "TPNOREPLY, WorkCompleted correct ErrorState is reported in ServiceCallEvent"(Boolean failedUnexpectedly, ErrorState expectedErrorState)
+    {
+        setup:
+        CasualServiceCallWork work = new CasualServiceCallWork(UUID.randomUUID(), request, true, ProtocolVersion.VERSION_1_2, SpanId.of())
+        work.workFailedUnexpectedly = failedUnexpectedly
+        WorkEvent event = new WorkEvent(this, WorkEvent.WORK_COMPLETED, work, null)
+        instance = new ServiceCallWorkListener(channel, request, true, SpanId.of(), ProtocolVersion.VERSION_1_2)
+        instance.setEventPublisher(serviceCallEventPublisher)
+        String receivedErrorCode = null;
+
+        when:
+        instance.workStarted(Mock(WorkEvent))
+        instance.workCompleted(event)
+
+        then:
+        1 * serviceCallEventPublisher.post(_ as ServiceCallEvent) >> { ServiceCallEvent serviceCallEvent ->
+            receivedErrorCode = serviceCallEvent.getCode()
+        }
+
+        receivedErrorCode == expectedErrorState.name()
+
+        where:
+        failedUnexpectedly | expectedErrorState
+        false              | ErrorState.OK
+        true               | ErrorState.TPESYSTEM
+    }
 
     Xid createXid()
     {

--- a/casual/casual-inbound/src/test/groovy/se/laz/casual/jca/inflow/ServiceCallWorkListenerTest.groovy
+++ b/casual/casual-inbound/src/test/groovy/se/laz/casual/jca/inflow/ServiceCallWorkListenerTest.groovy
@@ -1,13 +1,16 @@
 /*
- * Copyright (c) 2017 - 2025, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2026, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
 
 package se.laz.casual.jca.inflow
 
+import io.netty.channel.Channel
 import io.netty.channel.embedded.EmbeddedChannel
+import jakarta.resource.spi.work.WorkCompletedException
 import jakarta.resource.spi.work.WorkEvent
+import jakarta.resource.spi.work.WorkException
 import se.laz.casual.api.buffer.CasualBuffer
 import se.laz.casual.api.buffer.type.JsonBuffer
 import se.laz.casual.api.buffer.type.ServiceBuffer
@@ -146,5 +149,119 @@ class ServiceCallWorkListenerTest extends Specification
         String gid = Integer.toString( ThreadLocalRandom.current().nextInt() )
         String b = Integer.toString( ThreadLocalRandom.current().nextInt() )
         return XID.of(gid.getBytes(StandardCharsets.UTF_8), b.getBytes(StandardCharsets.UTF_8), 0)
+    }
+
+    def "WorkCompleted with abnormal error, WorkEvent returns with an Exception and no reply"(ProtocolVersion protocolVersion)
+    {
+        given:
+        def channel = Mock(Channel)
+        def request = createRequestMessage(protocolVersion)
+
+        def event = new WorkEvent(this, WorkEvent.WORK_COMPLETED, new CasualServiceCallWork(UUID.randomUUID(), request, false, protocolVersion, SpanId.of()), new WorkCompletedException("work failed unexpectedly", WorkException.INTERNAL))
+        def workWithNullResponse = new CasualServiceCallWork(UUID.randomUUID(), request, false, protocolVersion, SpanId.of())
+        def listener = new ServiceCallWorkListener(channel, request, SpanId.of(), protocolVersion)
+        listener.setEventPublisher(serviceCallEventPublisher)
+        CasualNWMessage written = null
+        String receivedErrorCode = null
+
+        when:
+        listener.workStarted(event)
+        listener.workCompleted(event)
+
+        then:
+        1 * channel.writeAndFlush(_) >> { args ->
+            def msg = args[0]
+            if (msg instanceof CasualNWMessage)
+            {
+                written = (CasualNWMessage) msg
+            }
+            return null
+        }
+        1 * serviceCallEventPublisher.post(_) >> { args ->
+            ServiceCallEvent callEvent = (ServiceCallEvent) args[0]
+            receivedErrorCode = callEvent.getCode()
+        }
+        noExceptionThrown()
+        written != null
+        written.getMessage() instanceof CasualServiceCallReplyMessage
+        ErrorState.TPESYSTEM.name() == receivedErrorCode
+        workWithNullResponse.getResponse() == null
+
+        where:
+        protocolVersion | _
+        ProtocolVersion.VERSION_1_0 | _
+        ProtocolVersion.VERSION_1_1 | _
+        ProtocolVersion.VERSION_1_2 | _
+        ProtocolVersion.VERSION_1_3 | _
+        ProtocolVersion.VERSION_1_4 | _
+    }
+
+    def "WorkCompleted with normal casual error, WorkEvent returns without exception and with reply"(ProtocolVersion protocolVersion)
+    {
+        given:
+        def channel = Mock(Channel)
+        def request = createRequestMessage(protocolVersion)
+        def replyBuilder = CasualServiceCallReplyMessage.createBuilder()
+                .setExecution(request.getExecution())
+                .setProtocolVersion(protocolVersion)
+                .setServiceBuffer(null)
+                .setError(ErrorState.TPESVCERR)
+        if (protocolVersion.isLessThan(ProtocolVersion.VERSION_1_3))
+        {
+            replyBuilder.setXid(request.getXid())
+        }
+        def reply = replyBuilder.build()
+
+        def workWithResponse = new CasualServiceCallWork(UUID.randomUUID(), request, false, protocolVersion, SpanId.of())
+        workWithResponse.response = CasualNWMessageImpl.of(work.getCorrelationId(), reply)
+        def event = new WorkEvent(this, WorkEvent.WORK_COMPLETED, workWithResponse, new WorkCompletedException("work failed unexpectedly", WorkException.INTERNAL))
+        def listener = new ServiceCallWorkListener(channel, request, SpanId.of(), protocolVersion)
+        listener.setEventPublisher(serviceCallEventPublisher)
+        CasualNWMessage written = null
+        String receivedErrorCode = null
+
+        when:
+        listener.workStarted(event)
+        listener.workCompleted(event)
+
+        then:
+        workWithResponse.getResponse() != null
+        1 * channel.writeAndFlush(_) >> { args ->
+            def msg = args[0]
+            if (msg instanceof CasualNWMessage)
+            {
+                written = (CasualNWMessage) msg
+            }
+            return null
+        }
+        1 * serviceCallEventPublisher.post(_) >> { args ->
+            ServiceCallEvent callEvent = (ServiceCallEvent) args[0]
+            receivedErrorCode = callEvent.getCode()
+        }
+        noExceptionThrown()
+        written != null
+        written.getMessage() instanceof CasualServiceCallReplyMessage
+        ErrorState.TPESVCERR.name() == receivedErrorCode
+        workWithResponse.getResponse() != null
+
+        where:
+        protocolVersion | _
+        ProtocolVersion.VERSION_1_0 | _
+        ProtocolVersion.VERSION_1_1 | _
+        ProtocolVersion.VERSION_1_2 | _
+        ProtocolVersion.VERSION_1_3 | _
+        ProtocolVersion.VERSION_1_4 | _
+    }
+
+    private static CasualServiceCallRequestMessage createRequestMessage(ProtocolVersion protocolVersion)
+    {
+        return CasualServiceCallRequestMessage.createBuilder()
+                .setXid(XID.NULL_XID)
+                .setExecution(UUID.randomUUID())
+                .setParentName("some-parent")
+                .setServiceName("some-service")
+                .setParentSpan(SpanId.of())
+                .setProtocolVersion(protocolVersion)
+                .build()
     }
 }

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '3.4.2'
+version = '3.4.3'
 
 def netty_version = '4.1.121.Final'
 def gson_version = '2.11.0'


### PR DESCRIPTION
Fixes several possible inbound-issues where exceptions are thrown:
- Service handler throws, make sure a correct error code is set ensuring that some error response is sent to casual.
- CasualServiceCallWork::issueCall throws outside of try, now JCA work listener handles thrown exception.

Both fixes add better error handling and ensure the callee casual domain does not hang waiting for a reply (at least until a timeout is reached).

Refs: #96 #101