### PR TITLE
build: allow local publish without signing

### DIFF
--- a/publish.gradle
+++ b/publish.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2025, The casual project. All rights reserved.
+ * Copyright (c) 2017 - 2026, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -79,6 +79,7 @@ publishing {
 
 
 signing {
+    required { project.hasProperty("signing.keyId") }
     sign publishing.publications.mavenJava
 }
 javadoc {

--- a/scripts/utilities.py
+++ b/scripts/utilities.py
@@ -41,12 +41,12 @@ def clean_message(msg):
 
 
 def validate_format(msg):
-    pattern = r"^(feat|fix|docs|style|refactor|test|chore)(\(.+\))?: .+"
+    pattern = r"^(feat|fix|build|ci|perf|docs|style|refactor|test|chore)(\(.+\))?: .+"
     if not re.match(pattern, msg):
         print(f"Error: PR title '{msg}' does not follow conventional commit format.")
         print("Format: <type>[optional scope]: <description>")
         print("Example: feat: add new feature")
-        print("Allowed types: feat, fix, docs, style, refactor, test, chore")
+        print("Allowed types: feat, fix, docs, style, refactor, test, chore, build, ci, perf")
         return False
     else:
         print(f"PR title '{msg}' is valid.")

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '3.4.5'
+version = '3.4.6'
 
 def netty_version = '4.1.121.Final'
 def gson_version = '2.11.0'


### PR DESCRIPTION
Fixes https://github.com/casualcore/casual-java/issues/207

Fix to allow `publishToMavenLocal` gradle task to run if you do not have casual gpg key setting configured.